### PR TITLE
Updated elasticsearch status for new API.

### DIFF
--- a/docker/dev/status.sh
+++ b/docker/dev/status.sh
@@ -41,7 +41,7 @@ function status_accumulo {
 
 function status_elasticsearch {
     _status_begin "Elasticsearch"
-    if [[ $(curl -XGET 'http://localhost:9200/_status' 2>&1) =~ "\"successful\":1" ]]; then
+    if [[ $(curl -XGET 'http://localhost:9200/_cluster/health?' 2>&1) =~ "\"green\"" ]]; then
         _status_good "Elasticsearch"
     else
         _status_fail "Elasticsearch"


### PR DESCRIPTION
The current status check for elasticsearch is out of date with the API and always returns a FAIL. This updates to the new API so the status check is accurate.