### PR TITLE
Change GraphPropertyWorkerTestBase to be more realistic and use visallo visibility when running the GPW under test

### DIFF
--- a/graph-property-worker/graph-property-worker-plugin-test/src/main/java/org/visallo/test/GraphPropertyWorkerTestBase.java
+++ b/graph-property-worker/graph-property-worker-plugin-test/src/main/java/org/visallo/test/GraphPropertyWorkerTestBase.java
@@ -22,6 +22,7 @@ import org.visallo.core.model.WorkQueueNames;
 import org.visallo.core.model.workQueue.Priority;
 import org.visallo.core.model.workQueue.WorkQueueRepository;
 import org.visallo.core.security.DirectVisibilityTranslator;
+import org.visallo.core.security.VisalloVisibility;
 import org.visallo.core.security.VisibilityTranslator;
 import org.visallo.core.user.User;
 import org.visallo.model.queue.inmemory.InMemoryWorkQueueRepository;
@@ -88,7 +89,7 @@ public abstract class GraphPropertyWorkerTestBase {
                 user = getUser();
             }
             if (authorizations == null) {
-                authorizations = getGraphAuthorizations();
+                authorizations = getGraphAuthorizations(VisalloVisibility.SUPER_USER_VISIBILITY_STRING);
             }
             graphPropertyWorkerPrepareData = new GraphPropertyWorkerPrepareData(configuration, termMentionFilters, user, authorizations, injector);
         }


### PR DESCRIPTION
- [x] @sfeng88 @rygim @jharwig 
- [x] @srfarley @rajanpardipuramv5 @joeferner
- [x] @EvanOxfeld @joeybrk372
