### PR TITLE
Runtime closure-compile

### DIFF
--- a/core/core/src/main/java/org/visallo/core/config/Configuration.java
+++ b/core/core/src/main/java/org/visallo/core/config/Configuration.java
@@ -63,6 +63,8 @@ public class Configuration {
     public static final String MAPZEN_TILE_API_KEY = "mapzen.tile.api.key";
     public static final String DEV_MODE = "devMode";
     public static final boolean DEV_MODE_DEFAULT = false;
+    public static final String PLUGIN_DEV_MODE = "pluginDevMode";
+    public static final boolean PLUGIN_DEV_MODE_DEFAULT = false;
     public static final String DEFAULT_SEARCH_RESULT_COUNT = "search.defaultSearchCount";
     public static final String LOCK_REPOSITORY_PATH_PREFIX = "lockRepository.pathPrefix";
     public static final String DEFAULT_LOCK_REPOSITORY_PATH_PREFIX = "/visallo/locks";

--- a/root/pom.xml
+++ b/root/pom.xml
@@ -58,6 +58,7 @@
         <elasticsearch.version>1.4.4</elasticsearch.version>
         <evo.inflector.version>1.0.1</evo.inflector.version>
         <guice.version>3.0</guice.version>
+        <visallo.closure.compiler.version>1.0.0</visallo.closure.compiler.version>
         <hadoop.version>2.6.0-cdh5.4.2</hadoop.version>
         <twill.version>0.4.0-incubating</twill.version>
         <hadoop-test.version>2.6.0-mr1-cdh5.4.2</hadoop-test.version>
@@ -502,6 +503,11 @@
                 <groupId>com.asual.lesscss</groupId>
                 <artifactId>lesscss-engine</artifactId>
                 <version>${lesscss.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.visallo</groupId>
+                <artifactId>visallo-closure-compiler</artifactId>
+                <version>${visallo.closure.compiler.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.json</groupId>

--- a/web/web-base/pom.xml
+++ b/web/web-base/pom.xml
@@ -36,6 +36,10 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.visallo</groupId>
+            <artifactId>visallo-closure-compiler</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
             <scope>provided</scope>

--- a/web/web-base/src/main/java/org/visallo/web/JavascriptResourceHandler.java
+++ b/web/web-base/src/main/java/org/visallo/web/JavascriptResourceHandler.java
@@ -1,0 +1,227 @@
+package org.visallo.web;
+
+
+import com.v5analytics.webster.HandlerChain;
+import com.v5analytics.webster.RequestResponseHandler;
+import org.apache.commons.io.IOUtils;
+import org.visallo.core.exception.VisalloException;
+import org.visallo.core.util.VisalloLogger;
+import org.visallo.core.util.VisalloLoggerFactory;
+import org.visallo.web.closurecompiler.com.google.javascript.jscomp.*;
+import org.visallo.web.closurecompiler.com.google.javascript.jscomp.Compiler;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.net.URL;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
+import java.util.logging.Level;
+
+
+public class JavascriptResourceHandler implements RequestResponseHandler {
+
+    private static final int EXECUTOR_CONCURRENT = 3;
+    private static final long EXECUTOR_IDLE_THREAD_RELEASE_SECONDS = 5;
+    private static final ThreadPoolExecutor compilationExecutor = new ThreadPoolExecutor(
+            EXECUTOR_CONCURRENT,
+            EXECUTOR_CONCURRENT,
+            EXECUTOR_IDLE_THREAD_RELEASE_SECONDS,
+            TimeUnit.SECONDS,
+            new LinkedBlockingQueue());
+
+    static {
+        compilationExecutor.allowCoreThreadTimeOut(true);
+    }
+
+    private String jsResourceName;
+    private String jsResourcePath;
+    private boolean enableSourceMaps;
+    private Future<CachedCompilation> compilationTask;
+    private volatile CachedCompilation previousCompilation;
+
+    public JavascriptResourceHandler(final String jsResourceName, final String jsResourcePath, boolean enableSourceMaps) {
+        this.jsResourceName = jsResourceName;
+        this.jsResourcePath = jsResourcePath;
+        this.enableSourceMaps = enableSourceMaps;
+
+        compilationTask = compilationExecutor.submit(new Callable<CachedCompilation>() {
+            @Override
+            public CachedCompilation call() throws Exception {
+                return compileIfNecessary(null);
+            }
+        });
+    }
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, HandlerChain chain) throws Exception {
+        CachedCompilation cache = getCache();
+
+        if (request.getRequestURI().endsWith(".map")) {
+            write(response, "application/json", cache.getSourceMap());
+        } else if (request.getRequestURI().endsWith(".src")) {
+            write(response, "application/javascript", cache.getInput());
+        } else {
+            if (this.enableSourceMaps && cache.getSourceMap() != null) {
+                response.setHeader("X-SourceMap", request.getRequestURI() + ".map");
+            }
+            write(response, "application/javascript", cache.getOutput());
+        }
+    }
+
+    private CachedCompilation getCache() throws IOException, InterruptedException, ExecutionException {
+        CachedCompilation cache;
+
+        if (compilationTask == null) {
+            cache = compileIfNecessary(previousCompilation);
+        } else if (compilationTask.isDone()) {
+            previousCompilation = compilationTask.get();
+            compilationTask = null;
+            cache = compileIfNecessary(previousCompilation);
+        } else {
+            cache = compilationTask.get();
+        }
+
+        previousCompilation = cache;
+        return cache;
+    }
+
+    private void write(HttpServletResponse response, String contentType, String output) throws IOException {
+        if (output != null) {
+            try (PrintWriter outWriter = response.getWriter()) {
+                response.setContentType(contentType);
+                outWriter.println(output);
+            }
+        } else {
+            throw new VisalloException("Errors during minify: " + jsResourceName);
+        }
+    }
+
+
+    private CachedCompilation compileIfNecessary(CachedCompilation previousCompilation) throws IOException {
+        URL url = this.getClass().getResource(jsResourceName);
+        long lastModified = url.openConnection().getLastModified();
+
+        if (previousCompilation == null || previousCompilation.isNecessary(lastModified)) {
+            CachedCompilation newCache = new CachedCompilation();
+            newCache.setLastModified(lastModified);
+            try (InputStream input = this.getClass().getResourceAsStream(jsResourceName)) {
+                try (StringWriter writer = new StringWriter()) {
+                    IOUtils.copy(input, writer, StandardCharsets.UTF_8);
+                    String inputJavascript = writer.toString();
+                    newCache.setInput(inputJavascript);
+
+                    runClosureCompilation(newCache);
+                }
+            }
+            return newCache;
+        }
+
+        return previousCompilation;
+    }
+
+    private CachedCompilation runClosureCompilation(CachedCompilation cachedCompilation) throws IOException {
+        Compiler.setLoggingLevel(Level.INFO);
+        Compiler compiler = new Compiler(new JavascriptResourceHandlerErrorManager());
+
+        CompilerOptions compilerOptions = new CompilerOptions();
+        CompilationLevel.SIMPLE_OPTIMIZATIONS.setOptionsForCompilationLevel(compilerOptions);
+        WarningLevel.VERBOSE.setOptionsForWarningLevel(compilerOptions);
+        compilerOptions.setLanguageIn(CompilerOptions.LanguageMode.ECMASCRIPT6);
+        compilerOptions.setLanguageOut(CompilerOptions.LanguageMode.ECMASCRIPT5);
+        compilerOptions.setEnvironment(CompilerOptions.Environment.BROWSER);
+        compilerOptions.setSourceMapOutputPath("");
+        compilerOptions.setSourceMapFormat(SourceMap.Format.V3);
+        compilerOptions.setSourceMapDetailLevel(SourceMap.DetailLevel.ALL);
+
+        List<SourceFile> inputs = new ArrayList<SourceFile>();
+        inputs.add(SourceFile.fromCode(jsResourcePath + ".src", cachedCompilation.getInput()));
+
+        List<SourceFile> externs = AbstractCommandLineRunner.getBuiltinExterns(compilerOptions);
+        InputStream visalloExterns = JavascriptResourceHandler.class.getResourceAsStream("visallo-externs.js");
+        externs.add(SourceFile.fromInputStream("visallo-externs.js", visalloExterns, Charset.forName("UTF-8")));
+
+        Result result = compiler.compile(externs, inputs, compilerOptions);
+        if (result.success) {
+            cachedCompilation.setOutput(compiler.toSource());
+
+            if (enableSourceMaps) {
+                StringBuilder sb = new StringBuilder();
+                result.sourceMap.appendTo(sb, jsResourcePath);
+                cachedCompilation.setSourceMap(sb.toString());
+            }
+        }
+        return cachedCompilation;
+    }
+
+    private static class CachedCompilation {
+        private String sourceMap;
+        private String input;
+        private String output;
+        private Long lastModified;
+
+        public String getSourceMap() {
+            return sourceMap;
+        }
+
+        public void setSourceMap(String sourceMap) {
+            this.sourceMap = sourceMap;
+        }
+
+        public String getInput() {
+            return input;
+        }
+
+        public void setInput(String input) {
+            this.input = input;
+        }
+
+        public String getOutput() {
+            return output;
+        }
+
+        public void setOutput(String output) {
+            this.output = output;
+        }
+
+        public Long getLastModified() {
+            return lastModified;
+        }
+
+        public void setLastModified(Long lastModified) {
+            this.lastModified = lastModified;
+        }
+
+        public boolean isNecessary(long lastModified) {
+            return getLastModified() == null ||
+                   getLastModified() != lastModified ||
+                   getOutput() == null;
+        }
+    }
+
+    private static class JavascriptResourceHandlerErrorManager extends BasicErrorManager {
+        private static final VisalloLogger LOGGER = VisalloLoggerFactory.getLogger(JavascriptResourceHandlerErrorManager.class);
+
+        @Override
+        public void println(CheckLevel checkLevel, JSError jsError) {
+            if (checkLevel.equals(CheckLevel.ERROR)) {
+                LOGGER.error("%s:%s %s", jsError.sourceName, jsError.getLineNumber(), jsError.description);
+            }
+        }
+
+        @Override
+        protected void printSummary() {
+            if (this.getErrorCount() > 0) {
+                LOGGER.error("%d error(s)", this.getErrorCount());
+            }
+        }
+    }
+
+}
+

--- a/web/web-base/src/main/java/org/visallo/web/WebApp.java
+++ b/web/web-base/src/main/java/org/visallo/web/WebApp.java
@@ -113,7 +113,18 @@ public class WebApp extends App {
 
     private void register(String name, String type, String pathPrefix, Boolean includeInPage, List<String> resourceList) {
         String resourcePath = "/" + (pathPrefix + name).replaceAll("^/", "");
-        get(resourcePath, new StaticResourceHandler(this.getClass(), name, type));
+        if (type.equals("application/javascript")) {
+            boolean enableSourceMaps = isDevModeEnabled();
+            JavascriptResourceHandler handler = new JavascriptResourceHandler(name, resourcePath, enableSourceMaps);
+            get(resourcePath, handler);
+            if (enableSourceMaps) {
+                get(resourcePath + ".map", handler);
+                get(resourcePath + ".src", handler);
+            }
+        } else {
+            get(resourcePath, new StaticResourceHandler(this.getClass(), name, type));
+        }
+
         if (includeInPage) {
             resourceList.add(resourcePath);
         }

--- a/web/web-base/src/main/java/org/visallo/web/WebApp.java
+++ b/web/web-base/src/main/java/org/visallo/web/WebApp.java
@@ -38,6 +38,7 @@ public class WebApp extends App {
     private static final VisalloLogger LOGGER = VisalloLoggerFactory.getLogger(WebApp.class);
     private final Injector injector;
     private final boolean devMode;
+    private final boolean pluginDevMode;
 
     private final List<String> pluginsJsResourcesWebWorker = new ArrayList<>();
     private final List<String> pluginsJsResourcesBeforeAuth = new ArrayList<>();
@@ -76,6 +77,7 @@ public class WebApp extends App {
 
         Configuration config = injector.getInstance(Configuration.class);
         this.devMode = config.getBoolean(Configuration.DEV_MODE, Configuration.DEV_MODE_DEFAULT);
+        this.pluginDevMode = config.getBoolean(Configuration.PLUGIN_DEV_MODE, Configuration.PLUGIN_DEV_MODE_DEFAULT);
 
         if (!isDevModeEnabled()) {
             String pluginsCssRoute = "plugins.css";
@@ -113,7 +115,7 @@ public class WebApp extends App {
 
     private void register(String name, String type, String pathPrefix, Boolean includeInPage, List<String> resourceList) {
         String resourcePath = "/" + (pathPrefix + name).replaceAll("^/", "");
-        if (type.equals("application/javascript")) {
+        if (type.equals("application/javascript") && !pluginDevMode) {
             boolean enableSourceMaps = isDevModeEnabled();
             JavascriptResourceHandler handler = new JavascriptResourceHandler(name, resourcePath, enableSourceMaps);
             get(resourcePath, handler);

--- a/web/web-base/src/main/resources/org/visallo/web/visallo-externs.js
+++ b/web/web-base/src/main/resources/org/visallo/web/visallo-externs.js
@@ -1,0 +1,46 @@
+// Define Visallo Globals for closure-compiler used in JavascriptResourceHandler for plugin js
+
+// Underscore.js, and jQuery are implicit dependencies
+var _;
+var $;
+var jQuery;
+
+// Most 3rd party libraries check for these
+var exports;
+var module;
+
+var visalloData;
+
+/**
+ * @type {string}
+ * @const
+ */
+var TRANSITION_END;
+
+/**
+ * @type {string}
+ * @const
+ */
+var ANIMATION_END;
+
+/**
+ * @param {string} key
+ * @return {string}
+ */
+function i18n(key) {}
+
+/**
+ * @param {...?} varargs
+ * @return {?}
+ */
+function define(varargs) {}
+
+/**
+ * @param {Array<String>} dependencies
+ * @param {Function} callback
+ * @return {?}
+ */
+function require(dependencies, callback) {}
+
+
+function dispatchMain() {}


### PR DESCRIPTION
- [x] @sfeng88 @rygim @jharwig 
- [x] @srfarley @rajanpardipuramv5 @joeferner
- [x] @EvanOxfeld @joeybrk372


The previous compile-js PR was reverted since the closure-compiler packages guava inside the jar. This version of guava conflicted with accumulo expecting guava 14. This references a new repackaged closure-compiler that shades the guava (and other) dependencies.

* [x] Add WebConfiguration parameter to disable (on by default / not disabled)
* [x] Travis build and maven release of closure-compiler