### PR TITLE
Fix find path when limited by edge type(s) ignoring the type(s) filter

### DIFF
--- a/web/web-base/src/main/java/org/visallo/web/routes/vertex/VertexFindPath.java
+++ b/web/web-base/src/main/java/org/visallo/web/routes/vertex/VertexFindPath.java
@@ -36,7 +36,7 @@ public class VertexFindPath implements ParameterizedHandler {
             @Required(name = "outVertexId") String outVertexId,
             @Required(name = "inVertexId") String inVertexId,
             @Required(name = "hops") int hops,
-            @Optional(name = "labels[]") String[] labels,
+            @Optional(name = "edgeLabels[]") String[] edgeLabels,
             Authorizations authorizations,
             VisalloResponse response
     ) throws Exception {
@@ -50,7 +50,7 @@ public class VertexFindPath implements ParameterizedHandler {
             throw new VisalloResourceNotFoundException("Destination vertex not found");
         }
 
-        FindPathLongRunningProcessQueueItem findPathQueueItem = new FindPathLongRunningProcessQueueItem(outVertex.getId(), inVertex.getId(), labels, hops, workspaceId, authorizations);
+        FindPathLongRunningProcessQueueItem findPathQueueItem = new FindPathLongRunningProcessQueueItem(outVertex.getId(), inVertex.getId(), edgeLabels, hops, workspaceId, authorizations);
         String id = this.longRunningProcessRepository.enqueue(findPathQueueItem.toJson(), user, authorizations);
 
         return new ClientApiLongRunningProcessSubmitResponse(id);


### PR DESCRIPTION
Update mismatched argument name for edge types to find by

- [x] @sfeng88 @rygim @jharwig 
- [x] @srfarley @rajanpardipuramv5 @joeferner
- [x] @EvanOxfeld @joeybrk372

