### PR TITLE
Show source-mapped files in bluebird stacks

### DIFF
--- a/core/core/src/main/resources/org/visallo/core/formula/loader.js
+++ b/core/core/src/main/resources/org/visallo/core/formula/loader.js
@@ -10,6 +10,7 @@ console = {
     warn: consoleWarn,
     error: consoleError
 };
+window.addEventListener = function() { };
 
 require.config({
     baseUrl: '',

--- a/web/war/src/main/webapp/js/util/promise.js
+++ b/web/war/src/main/webapp/js/util/promise.js
@@ -46,6 +46,7 @@ define([
     addProgress();
     addTimeout();
     addRequire();
+    registerUnhandledRejection();
 
     self.Promise = Promise;
     return Promise;
@@ -115,6 +116,15 @@ define([
                 });
             };
         } else console.warn('Native implementation of require');
+    }
+
+    function registerUnhandledRejection() {
+        self.addEventListener('unhandledrejection', function(e) {
+            // See Promise.onPossiblyUnhandledRejection for parameter documentation
+            e.preventDefault();
+            // Causes better stack traces (source map support) over console.log
+            throw e.detail.reason;
+        });
     }
 
 });


### PR DESCRIPTION
- [ ] @sfeng88 @rygim @jharwig 
- [x] @srfarley @rajanpardipuramv5 @joeferner
- [x] @EvanOxfeld @joeybrk372 

@srfarley wasn't getting source-mapped files in stack traces (produced from promises), this fixes it.
