### PR TITLE
Move getSimpleOrmContext from User to UserRepository

### DIFF
--- a/core/core/src/main/java/org/visallo/core/model/artifactThumbnails/ArtifactThumbnailRepository.java
+++ b/core/core/src/main/java/org/visallo/core/model/artifactThumbnails/ArtifactThumbnailRepository.java
@@ -2,14 +2,15 @@ package org.visallo.core.model.artifactThumbnails;
 
 import com.google.inject.Inject;
 import com.v5analytics.simpleorm.SimpleOrmSession;
+import org.vertexium.Vertex;
 import org.visallo.core.exception.VisalloResourceNotFoundException;
 import org.visallo.core.model.ontology.OntologyRepository;
 import org.visallo.core.model.properties.types.BooleanVisalloProperty;
 import org.visallo.core.model.properties.types.IntegerVisalloProperty;
+import org.visallo.core.model.user.UserRepository;
 import org.visallo.core.user.User;
 import org.visallo.core.util.VisalloLogger;
 import org.visallo.core.util.VisalloLoggerFactory;
-import org.vertexium.Vertex;
 
 import javax.imageio.ImageIO;
 import java.awt.*;
@@ -27,15 +28,18 @@ public class ArtifactThumbnailRepository {
     public static int PREVIEW_FRAME_WIDTH = 360;
     public static int PREVIEW_FRAME_HEIGHT = 240;
     private final SimpleOrmSession simpleOrmSession;
+    private final UserRepository userRepository;
     private BooleanVisalloProperty yAxisFlippedProperty;
     private IntegerVisalloProperty clockwiseRotationProperty;
 
     @Inject
     public ArtifactThumbnailRepository(
             SimpleOrmSession simpleOrmSession,
+            UserRepository userRepository,
             final OntologyRepository ontologyRepository
     ) {
         this.simpleOrmSession = simpleOrmSession;
+        this.userRepository = userRepository;
 
         String yAxisFlippedPropertyIri = ontologyRepository.getPropertyIRIByIntent("media.yAxisFlipped");
         if (yAxisFlippedPropertyIri != null) {
@@ -50,7 +54,7 @@ public class ArtifactThumbnailRepository {
 
     public ArtifactThumbnail getThumbnail(String artifactVertexId, String thumbnailType, int width, int height, User user) {
         String id = ArtifactThumbnail.createId(artifactVertexId, thumbnailType, width, height);
-        return simpleOrmSession.findById(ArtifactThumbnail.class, id, user.getSimpleOrmContext());
+        return simpleOrmSession.findById(ArtifactThumbnail.class, id, userRepository.getSimpleOrmContext(user));
     }
 
     public byte[] getThumbnailData(String artifactVertexId, String thumbnailType, int width, int height, User user) {
@@ -63,7 +67,7 @@ public class ArtifactThumbnailRepository {
 
     public ArtifactThumbnail createThumbnail(Vertex artifactVertex, String propertyKey, String thumbnailType, InputStream in, int[] boundaryDims, User user) throws IOException {
         ArtifactThumbnail thumbnail = generateThumbnail(artifactVertex, propertyKey, thumbnailType, in, boundaryDims);
-        simpleOrmSession.save(thumbnail, VISIBILITY_STRING, user.getSimpleOrmContext());
+        simpleOrmSession.save(thumbnail, VISIBILITY_STRING, userRepository.getSimpleOrmContext(user));
         return thumbnail;
     }
 

--- a/core/core/src/main/java/org/visallo/core/model/user/UserRepository.java
+++ b/core/core/src/main/java/org/visallo/core/model/user/UserRepository.java
@@ -273,6 +273,11 @@ public abstract class UserRepository {
         }
     }
 
+    public SimpleOrmContext getSimpleOrmContext(User user) {
+        String[] authorizations = getAuthorizations(user).getAuthorizations();
+        return getSimpleOrmContext(authorizations);
+    }
+
     public SimpleOrmContext getSimpleOrmContext(org.vertexium.Authorizations authorizations, String... additionalAuthorizations) {
         ArrayList<String> auths = new ArrayList<>();
 

--- a/core/core/src/main/java/org/visallo/core/user/ProxyUser.java
+++ b/core/core/src/main/java/org/visallo/core/user/ProxyUser.java
@@ -1,6 +1,5 @@
 package org.visallo.core.user;
 
-import com.v5analytics.simpleorm.SimpleOrmContext;
 import org.json.JSONObject;
 import org.visallo.core.model.user.UserRepository;
 import org.visallo.web.clientapi.model.UserStatus;
@@ -33,15 +32,6 @@ public class ProxyUser implements User {
     public User getProxiedUser() {
         ensureUser();
         return proxiedUser;
-    }
-
-    @Override
-    public SimpleOrmContext getSimpleOrmContext() {
-        ensureUser();
-        if (proxiedUser == null) {
-            return null;
-        }
-        return proxiedUser.getSimpleOrmContext();
     }
 
     @Override

--- a/core/core/src/main/java/org/visallo/core/user/SystemUser.java
+++ b/core/core/src/main/java/org/visallo/core/user/SystemUser.java
@@ -22,11 +22,6 @@ public class SystemUser implements User {
     }
 
     @Override
-    public SimpleOrmContext getSimpleOrmContext() {
-        return simpleOrmContext;
-    }
-
-    @Override
     public String getUserId() {
         return USER_ID;
     }

--- a/core/core/src/main/java/org/visallo/core/user/User.java
+++ b/core/core/src/main/java/org/visallo/core/user/User.java
@@ -13,8 +13,6 @@ import java.util.Set;
 public interface User extends Serializable {
     long serialVersionUID = 2L;
 
-    SimpleOrmContext getSimpleOrmContext();
-
     String getUserId();
 
     String getUsername();

--- a/core/core/src/main/java/org/visallo/core/util/ModelUtil.java
+++ b/core/core/src/main/java/org/visallo/core/util/ModelUtil.java
@@ -5,6 +5,7 @@ import com.v5analytics.simpleorm.SimpleOrmSession;
 import org.vertexium.Graph;
 import org.visallo.core.exception.VisalloException;
 import org.visallo.core.model.user.AuthorizationRepository;
+import org.visallo.core.model.user.UserRepository;
 import org.visallo.core.model.workQueue.WorkQueueRepository;
 import org.visallo.core.user.User;
 
@@ -14,11 +15,12 @@ public class ModelUtil {
     public static void drop(
             Graph graph,
             SimpleOrmSession simpleOrmSession,
+            UserRepository userRepository,
             WorkQueueRepository workQueueRepository,
             AuthorizationRepository authorizationRepository,
             User user
     ) {
-        ModelUtil.clearTables(simpleOrmSession, user);
+        ModelUtil.clearTables(userRepository, simpleOrmSession, user);
         workQueueRepository.format();
         // TODO provide a way to delete the graph and it's search index
         // graph.delete(getUser());
@@ -33,31 +35,16 @@ public class ModelUtil {
         graph.drop();
     }
 
-    public static void deleteTables(SimpleOrmSession simpleOrmSession, User user) {
-        LOGGER.warn("BEGIN deleting tables");
-        String tablePrefix = simpleOrmSession.getTablePrefix();
-        if (Strings.isNullOrEmpty(tablePrefix)) {
-            throw new VisalloException("Unable to format without a SimpleOrmSession table prefix");
-        }
-        for (String table : simpleOrmSession.getTableList(user.getSimpleOrmContext())) {
-            if (table.startsWith(tablePrefix)) {
-                LOGGER.warn("deleting table: %s", table);
-                simpleOrmSession.deleteTable(table, user.getSimpleOrmContext());
-            }
-        }
-        LOGGER.warn("END deleting tables");
-    }
-
-    public static void clearTables(SimpleOrmSession simpleOrmSession, User user) {
+    public static void clearTables(UserRepository userRepository, SimpleOrmSession simpleOrmSession, User user) {
         LOGGER.warn("BEGIN clearing tables");
         String tablePrefix = simpleOrmSession.getTablePrefix();
         if (Strings.isNullOrEmpty(tablePrefix)) {
             throw new VisalloException("Unable to format without a SimpleOrmSession table prefix");
         }
-        for (String table : simpleOrmSession.getTableList(user.getSimpleOrmContext())) {
+        for (String table : simpleOrmSession.getTableList(userRepository.getSimpleOrmContext(user))) {
             if (table.startsWith(tablePrefix)) {
                 LOGGER.warn("clearing table: %s", table);
-                simpleOrmSession.clearTable(table, user.getSimpleOrmContext());
+                simpleOrmSession.clearTable(table, userRepository.getSimpleOrmContext(user));
             }
         }
         LOGGER.warn("END clearing tables");

--- a/core/plugins/model-vertexium-inmemory/src/main/java/org/visallo/vertexium/model/user/InMemoryUser.java
+++ b/core/plugins/model-vertexium-inmemory/src/main/java/org/visallo/vertexium/model/user/InMemoryUser.java
@@ -1,7 +1,6 @@
 package org.visallo.vertexium.model.user;
 
 import com.google.common.collect.ImmutableMap;
-import com.v5analytics.simpleorm.SimpleOrmContext;
 import org.json.JSONObject;
 import org.visallo.core.user.User;
 import org.visallo.web.clientapi.model.UserStatus;
@@ -46,11 +45,6 @@ public class InMemoryUser implements User {
         Collections.addAll(this.authorizations, authorizations);
         this.currentWorkspaceId = currentWorkspaceId;
         this.preferences = new JSONObject();
-    }
-
-    @Override
-    public SimpleOrmContext getSimpleOrmContext() {
-        throw new RuntimeException("not implemented");
     }
 
     @Override

--- a/core/plugins/model-vertexium-inmemory/src/main/java/org/visallo/vertexium/model/user/InMemoryUserRepository.java
+++ b/core/plugins/model-vertexium-inmemory/src/main/java/org/visallo/vertexium/model/user/InMemoryUserRepository.java
@@ -13,6 +13,8 @@ import org.visallo.core.model.notification.UserNotificationRepository;
 import org.visallo.core.model.user.UserRepository;
 import org.visallo.core.model.user.UserSessionCounterRepository;
 import org.visallo.core.model.workQueue.WorkQueueRepository;
+import org.visallo.core.security.VisalloVisibility;
+import org.visallo.core.user.ProxyUser;
 import org.visallo.core.user.SystemUser;
 import org.visallo.core.user.User;
 import org.visallo.web.clientapi.model.UserStatus;
@@ -128,7 +130,14 @@ public class InMemoryUserRepository extends UserRepository {
     @Override
     public Authorizations getAuthorizations(User user, String... additionalAuthorizations) {
         List<String> auths = new ArrayList<>();
-        Collections.addAll(auths, ((InMemoryUser) user).getAuthorizations());
+        if (user instanceof SystemUser) {
+            auths.add(VisalloVisibility.SUPER_USER_VISIBILITY_STRING);
+        } else if (user instanceof ProxyUser) {
+            ProxyUser proxyUser = (ProxyUser) user;
+            Collections.addAll(auths, ((InMemoryUser) proxyUser.getProxiedUser()).getAuthorizations());
+        } else {
+            Collections.addAll(auths, ((InMemoryUser) user).getAuthorizations());
+        }
         Collections.addAll(auths, additionalAuthorizations);
         return this.graph.createAuthorizations(auths.toArray(new String[auths.size()]));
     }

--- a/core/plugins/model-vertexium/src/main/java/org/visallo/vertexium/model/user/VertexiumUser.java
+++ b/core/plugins/model-vertexium/src/main/java/org/visallo/vertexium/model/user/VertexiumUser.java
@@ -19,7 +19,6 @@ import java.util.Set;
 
 public class VertexiumUser implements User, Serializable {
     private static final long serialVersionUID = 6688073934273514248L;
-    private SimpleOrmContext simpleOrmContext;
     private String userId;
     private Map<String, Object> properties = new HashMap<>();
 
@@ -33,12 +32,6 @@ public class VertexiumUser implements User, Serializable {
         for (Property property : userVertex.getProperties()) {
             this.properties.put(property.getName(), property.getValue());
         }
-        this.simpleOrmContext = simpleOrmContext;
-    }
-
-    @Override
-    public SimpleOrmContext getSimpleOrmContext() {
-        return simpleOrmContext;
     }
 
     @Override

--- a/tools/format/src/main/java/org/visallo/tools/format/FormatVisallo.java
+++ b/tools/format/src/main/java/org/visallo/tools/format/FormatVisallo.java
@@ -16,7 +16,14 @@ public class FormatVisallo extends CommandLineTool {
 
     @Override
     protected int run() throws Exception {
-        ModelUtil.drop(getGraph(), getSimpleOrmSession(), getWorkQueueRepository(), authorizationRepository, getUser());
+        ModelUtil.drop(
+                getGraph(),
+                getSimpleOrmSession(),
+                getUserRepository(),
+                getWorkQueueRepository(),
+                authorizationRepository,
+                getUser()
+        );
         return 0;
     }
 


### PR DESCRIPTION
- [x] @sfeng88 @rygim @jharwig 
- [ ] @srfarley @rajanpardipuramv5 @joeferner
- [x] @EvanOxfeld @joeybrk372

This is to support serializing `User` which is not currently supported because `SimpleOrmContext` is not guaranteed to be serializable.