### PR TITLE
Read formula files from classpath using specified charset

### DIFF
--- a/core/core/src/main/java/org/visallo/core/formula/RequireJsSupport.java
+++ b/core/core/src/main/java/org/visallo/core/formula/RequireJsSupport.java
@@ -11,6 +11,7 @@ import org.mozilla.javascript.ScriptableObject;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.Charset;
 
 public class RequireJsSupport extends ScriptableObject {
 
@@ -68,7 +69,7 @@ public class RequireJsSupport extends ScriptableObject {
         InputStream is = RequireJsSupport.class.getResourceAsStream(file);
         if (is != null) {
             try {
-                return IOUtils.toString(is);
+                return IOUtils.toString(is, Charset.forName("UTF-8"));
             } catch (IOException e) {
                 LOGGER.error("File not readable %s", file, e);
             }


### PR DESCRIPTION
Resolves #167 

- [x] @sfeng88 @rygim @jharwig 
- [x] @srfarley @rajanpardipuramv5 @joeferner
- [ ] @EvanOxfeld @joeybrk372

FormulaEvaluatorTests were failing when JVM charset was not UTF. The chrono.js dependency was throwing errors when loaded with non-UTF charset. Solution is to specify the charset when reading all JS files from class path.

No unit test as setting `System.setProperty("file.encoding", "Cp850")` pragmatically is not supported. Tested manually by adding `-Dfile.encoding=Cp850` when running tests.