### PR TITLE
Term Mention Fixes

### DIFF
--- a/web/war/src/main/webapp/js/detail/detectedObjects/detectedObjects.js
+++ b/web/war/src/main/webapp/js/detail/detectedObjects/detectedObjects.js
@@ -111,7 +111,8 @@ define([
                                 self.showForm({
                                     property: property,
                                     value: property.value,
-                                    title: F.vertex.title(vertex)
+                                    title: F.vertex.title(vertex),
+                                    unresolve: true
                                 },
                                     //$.extend({}, property.value, {
                                         //title: F.vertex.title(vertex),
@@ -162,7 +163,8 @@ define([
                     }, data.value),
                     restrictConcept: data.value.concept,
                     existing: Boolean(data.property && data.property.resolvedVertexId),
-                    detectedObject: true
+                    detectedObject: true,
+                    unresolve: data.unresolve || false
                 });
             })
         };

--- a/web/war/src/main/webapp/js/detail/dropdowns/propertyForm/propForm.js
+++ b/web/war/src/main/webapp/js/detail/dropdowns/propertyForm/propForm.js
@@ -504,6 +504,8 @@ define([
         };
 
         this.onSave = function(evt) {
+            var self = this;
+
             if (!this.valid) return;
 
             var vertexId = this.attr.data.id,
@@ -543,6 +545,7 @@ define([
                             metadata: this.currentMetadata
                         }, justification)
                 });
+                self.teardown();
             }
         };
     }

--- a/web/war/src/main/webapp/js/detail/dropdowns/termForm/termForm.js
+++ b/web/war/src/main/webapp/js/detail/dropdowns/termForm/termForm.js
@@ -330,7 +330,6 @@ define([
                 var mentionVertex = $(this.attr.mentionNode);
                 data = mentionVertex.data('info');
                 existingEntity = this.attr.existing ? mentionVertex.addClass('focused').hasClass('resolved') : false;
-                graphVertexId = data && data.resolvedToVertexId;
                 title = $.trim(data && data.title || '');
 
                 if (this.attr.selection && !existingEntity) {
@@ -344,7 +343,8 @@ define([
 
                 if (existingEntity && mentionVertex.hasClass('resolved')) {
                     objectSign = title;
-                    this.unresolve = true;
+                    this.unresolve = this.attr.unresolve;
+                    graphVertexId = this.unresolve && data && (data.resolvedToVertexId || data.resolvedVertexId);
                     this.termMentionId = data && data.id;
                 } else {
                     objectSign = this.attr.sign || mentionVertex.text();
@@ -353,8 +353,8 @@ define([
                 data = this.attr.dataInfo;
                 objectSign = data && data.title;
                 existingEntity = this.attr.existing;
-                graphVertexId = data && (data.resolvedToVertexId || data.resolvedVertexId);
-                this.unresolve = graphVertexId && graphVertexId !== '';
+                this.unresolve = this.attr.unresolve;
+                graphVertexId = this.unresolve && data && (data.resolvedToVertexId || data.resolvedVertexId);
             }
 
             vertex.html(dropdownTemplate({


### PR DESCRIPTION
- Fix resolve as new not creating a new entity(instead it was adding reference to first resolved term)
- Allow unresolve of published entity(consistent with detected objects)
- Resolve as property dropdown will now teardown after submission instead of being stuck loading
- Picking fullscreen option on resolved property/comment goes to the owning entity.

- [x] @sfeng88 @rygim @jharwig 
- [x] @srfarley @joeferner @mwizeman 
- [x] @EvanOxfeld @joeybrk372 @dsingley