### PR TITLE
Fix property info popover not tearing down after deleting a comment on an edge

### DIFF
--- a/web/war/src/main/webapp/js/comments/comments.js
+++ b/web/war/src/main/webapp/js/comments/comments.js
@@ -296,7 +296,7 @@ define([
             this.dataRequest(this.type, 'deleteProperty',
                 this.attr.data.id, data.property
             ).then(function() {
-                $(event.target).popover('hide');
+                self.hidePropertyInfo($(event.target));
             });
         };
 


### PR DESCRIPTION
- [x] @sfeng88 @rygim @jharwig 
- [x] @srfarley @joeferner @mwizeman 
- [x] @EvanOxfeld @joeybrk372 @dsingley