### PR TITLE
Allow edge transformers and class extensions access to edge properties

### DIFF
--- a/web/war/src/main/webapp/js/data/withWorkspaces.js
+++ b/web/war/src/main/webapp/js/data/withWorkspaces.js
@@ -132,8 +132,12 @@ define(['util/undoManager'], function(UndoManager) {
         // Worker Handlers
 
         this.edgesLoaded = function(message) {
+            var self = this,
+                edgeIds = _.pluck(message.edges, 'edgeId');
+
             lastReloadedState.edges = message;
             this.trigger('edgesLoaded', message);
+            this.loadFullEdges(edgeIds);
         };
 
         this.workspaceUpdated = function(message) {
@@ -163,6 +167,20 @@ define(['util/undoManager'], function(UndoManager) {
             this.trigger('workspaceLoaded', workspace);
             this.trigger('selectObjects');
             this.fireApplicationReadyOnce();
+        };
+
+        this.loadFullEdges = function(edgeIds) {
+            var self = this;
+            return this.dataRequestPromise.then(function(dataRequest) {
+                if (edgeIds.length) {
+                    return dataRequest('edge', 'multiple', { edgeIds: edgeIds })
+                }
+                return null;
+            }).then(function(data) {
+                if (data) {
+                    self.trigger('edgesLoaded', data);
+                }
+            });
         };
 
         function undoManagerForWorkspace(workspaceId) {

--- a/web/war/src/main/webapp/js/workspaces/overlay.js
+++ b/web/war/src/main/webapp/js/workspaces/overlay.js
@@ -208,7 +208,7 @@ define([
         this.onDiffBadgeMouse = function(event) {
             this.trigger(
                 event.type === 'mouseenter' ? 'focusVertices' : 'defocusVertices',
-                { vertexIds: this.currentDiffIds || [] }
+                { elementIds: this.currentDiffIds || [] }
             );
         };
 


### PR DESCRIPTION
- [x] @sfeng88 @rygim @jharwig 
- [x] @srfarley @joeferner @mwizeman 
- [x] @EvanOxfeld @joeybrk372 @dsingley

Current the `org.visallo.graph.edge.[transformer | class]` extensions get workspace edge json, which doesn't include properties. This PR converts those workspace edges into full json edges after initial load.