### PR TITLE
Enhanced "Possible Values" property search filter

### DIFF
--- a/core/messages/src/main/resources/MessageBundle.properties
+++ b/core/messages/src/main/resources/MessageBundle.properties
@@ -216,6 +216,7 @@ field.geolocation.form.radius.placeholder=km
 field.geolocation.button.radius.search=Search on Map...
 
 field.restrict_values.form.placeholder=Choose {0}...
+field.restrict_values_multi.form.placeholder=Add {0}...
 
 field.string.form.contains=Contains
 field.string.form.equals=Equals
@@ -556,6 +557,7 @@ search.filters.predicates.date.<=Before
 search.filters.predicates.date.>=After
 search.filters.predicates.range=Between
 search.filters.predicates.within=Within
+search.filters.predicates.in=Matches Any
 search.filters.predicates.has=Has {0}
 search.filters.predicates.hasNot=Does Not Have {0}
 

--- a/web/war/src/main/webapp/js/fields/restrictValues.js
+++ b/web/war/src/main/webapp/js/fields/restrictValues.js
@@ -22,11 +22,10 @@ define([
                     }
                 });
 
-            this.indexedByValue = _.indexBy(possibleValues, 'value');
-
             this.$node.html(template({
                 displayName: this.attr.property.displayName,
-                values: possibleValues
+                values: possibleValues,
+                placeholderKey: this.attr.placeholderKey || 'field.restrict_values.form.placeholder'
             }));
         });
 

--- a/web/war/src/main/webapp/js/fields/restrictValuesMulti.js
+++ b/web/war/src/main/webapp/js/fields/restrictValuesMulti.js
@@ -1,0 +1,106 @@
+define([
+    'flight/lib/component',
+    './restrictValues',
+    'util/vertex/formatters',
+    './withPropertyField',
+    'hbs!./restrictValuesMultiTpl'
+], function(defineComponent, RestrictValues, F, withPropertyField, template) {
+    'use strict';
+
+    return defineComponent(RestrictValuesMultiField, withPropertyField);
+
+    function RestrictValuesMultiField() {
+
+        function compare(v1, v2) {
+            return v1.toLowerCase().localeCompare(v2.toLowerCase());
+        }
+
+        this.defaultAttrs({
+            removeSelector: 'ul.values li .remove-value'
+        });
+
+        this.after('initialize', function() {
+            var self = this;
+
+            this.on('click', {
+                removeSelector: onRemoveItemClick
+            });
+
+            this.$node.html(template({}));
+
+            var $restrictValues = this.$node.find('.restrict-values');
+            RestrictValues.attachTo($restrictValues, {
+                property: this.attr.property,
+                value: '',
+                preventChangeHandler: true,
+                placeholderKey: 'field.restrict_values_multi.form.placeholder'
+            });
+            $restrictValues.on('change', onRestrictValueChange);
+
+            this.setValue(this.attr.value);
+
+            function onRestrictValueChange(event) {
+                var value = $(event.target).val();
+                if (self.addValue(value)) {
+                    $restrictValues.trigger('setValue', null);
+                    self.trigger('propertychange', {
+                        propertyId: self.attr.property.title,
+                        value: self.getValue(),
+                        metadata: _.isFunction(self.getMetadata) && self.getMetadata() || {},
+                        options: {}
+                    });
+                }
+            }
+
+            function onRemoveItemClick(event) {
+                var $item = $(event.target).parent();
+                var value = $item.data('value');
+                $item.remove();
+                self.removeValue(value);
+            }
+        });
+
+        this.addValue = function(value) {
+            if (this.values.indexOf(value) === -1) {
+                this.values.push(value);
+                return true;
+            } else {
+                return false;
+            }
+        };
+
+        this.removeValue = function(value) {
+            this.values.splice(this.values.indexOf(value), 1);
+            this.trigger('propertychange', {
+                propertyId: this.attr.property.title,
+                value: this.getValue(),
+                metadata: _.isFunction(this.getMetadata) && this.getMetadata() || {},
+                options: {}
+            });
+        };
+
+        this.setValue = function(values) {
+            var self = this;
+            this.values = [];
+            this.$node.find('ul.values').empty();
+
+            values.sort(compare).forEach(function(value) {
+                if (self.addValue(value)) {
+                    self.$node.find('ul.values')
+                        .append(
+                            '<li><div>' + F.vertex.propDisplay(self.attr.property.title, value) +
+                            '</div><button class="remove-value remove-icon">x</button></li>');
+                    self.$node.find('ul.values li').last().data('value', value);
+                }
+            });
+        };
+
+        this.getValue = function() {
+            return this.values.slice(0);
+        };
+
+        this.isValid = function(values) {
+            return values.length;
+        };
+    }
+});

--- a/web/war/src/main/webapp/js/fields/restrictValuesMultiTpl.hbs
+++ b/web/war/src/main/webapp/js/fields/restrictValuesMultiTpl.hbs
@@ -1,0 +1,4 @@
+<div class="restrict-values-multi">
+    <div class="restrict-values"></div>
+    <ul class="values"></ul>
+</div>

--- a/web/war/src/main/webapp/js/fields/restrictValuesTpl.hbs
+++ b/web/war/src/main/webapp/js/fields/restrictValuesTpl.hbs
@@ -1,5 +1,5 @@
 <select>
-  <option value="">{{ i18n 'field.restrict_values.form.placeholder' displayName }}</option>
+  <option value="">{{ i18n placeholderKey displayName }}</option>
   {{#each values}}
   <option value="{{ value }}">{{ display }}</option>
   {{/each}}

--- a/web/war/src/main/webapp/less/search/restrictValuesMulti.less
+++ b/web/war/src/main/webapp/less/search/restrictValuesMulti.less
@@ -1,0 +1,20 @@
+.restrict-values-multi {
+  .values {
+    margin: 0 0 0.5em 0;
+
+    li {
+      white-space: nowrap;
+      display: flex;
+      margin: 0;
+      padding: 0 0 0 10px;
+
+      div {
+        flex: 2;
+        text-overflow: ellipsis;
+        overflow: hidden;
+        color: #777;
+        font-size: 95%;
+      }
+    }
+  }
+}

--- a/web/war/src/main/webapp/less/visallo.less
+++ b/web/war/src/main/webapp/less/visallo.less
@@ -53,6 +53,7 @@
 @import "workspaces/userAccount";
 @import "workspaces/timeline";
 @import "search/sort";
+@import "search/restrictValuesMulti";
 @import "detail/layouts";
 
 html.fullscreenApp {

--- a/web/web-base/src/main/java/org/visallo/web/routes/vertex/ElementSearchBase.java
+++ b/web/web-base/src/main/java/org/visallo/web/routes/vertex/ElementSearchBase.java
@@ -387,6 +387,8 @@ public abstract class ElementSearchBase {
             graphQuery.has(propertyName);
         } else if ("hasNot".equals(predicateString)) {
             graphQuery.hasNot(propertyName);
+        } else if ("in".equals(predicateString)) {
+            graphQuery.has(propertyName, Contains.IN, JSONUtil.toList(obj.getJSONArray("values")));
         } else {
             PropertyType propertyDataType = PropertyType.convert(obj.optString("propertyDataType"));
             JSONArray values = obj.getJSONArray("values");


### PR DESCRIPTION
- [x] @sfeng88 @rygim @jharwig 
- [x] @joeferner @mwizeman 
- [x] @EvanOxfeld @joeybrk372 @dsingley

This changes the search filter for properties defined with "visallo:possibleValues" in the ontology such that more than one of the possible values can be selected in the UI. This executes an "IN" query in Vertexium.

![restrictvaluesmulti](https://cloud.githubusercontent.com/assets/528468/14259913/1fce5bb2-fa77-11e5-83ae-484560898b83.png)