### PR TITLE
Upgrade to Vertexium 2.2.11

### DIFF
--- a/dev/jetty-server/pom.xml
+++ b/dev/jetty-server/pom.xml
@@ -34,6 +34,13 @@
             <version>${javax.servlet.api.version}</version>
             <scope>runtime</scope>
         </dependency>
+        <!-- Groovy is required when Visallo is configured to use in-process elasticsearch -->
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy</artifactId>
+            <version>${groovy.version}</version>
+            <scope>runtime</scope>
+        </dependency>
         <dependency>
             <groupId>org.visallo</groupId>
             <artifactId>visallo-web-auth-username-only</artifactId>

--- a/root/pom.xml
+++ b/root/pom.xml
@@ -74,9 +74,9 @@
         <log4j.version>1.2.17</log4j.version>
         <lucene.version>4.7.0</lucene.version>
         <metrics.version>3.0.2</metrics.version>
-        <vertexium.version>2.2.10</vertexium.version>
+        <vertexium.version>2.2.11</vertexium.version>
         <simple-orm.version>1.1.0</simple-orm.version>
-        <groovy.version>2.4.3</groovy.version>
+        <groovy.version>2.4.5</groovy.version>
         <zip4j.version>1.3.1</zip4j.version>
         <zookeeper.version>3.4.7</zookeeper.version>
         <jersey.version>1.19</jersey.version>


### PR DESCRIPTION
Groovy is new a required runtime dependency when Visallo is configured to use in-process Elasticsearch.

- [x] @jharwig @sfeng88 @rygim
- [x] @joeferner @mwizeman 
- [x] @EvanOxfeld @joeybrk372 @dsingley