### PR TITLE
remove unused and incorrect Lucene version from pom

### DIFF
--- a/root/pom.xml
+++ b/root/pom.xml
@@ -72,7 +72,6 @@
         <json.version>20131018</json.version>
         <lesscss.version>1.3.3</lesscss.version>
         <log4j.version>1.2.17</log4j.version>
-        <lucene.version>4.7.0</lucene.version>
         <metrics.version>3.0.2</metrics.version>
         <vertexium.version>2.2.11</vertexium.version>
         <simple-orm.version>1.1.0</simple-orm.version>


### PR DESCRIPTION
- [x] @sfeng88 @rygim @jharwig 
- [x] @srfarley @mwizeman 
- [ ] @EvanOxfeld @joeybrk372 @dsingley

This version appears to not be used and it isn't in line with Elasticsearch anyway so should be removed.