### PR TITLE
don't index workspace edges when deleting elements off of graph

### DIFF
--- a/core/plugins/model-vertexium/src/main/java/org/visallo/vertexium/model/workspace/VertexiumWorkspaceRepository.java
+++ b/core/plugins/model-vertexium/src/main/java/org/visallo/vertexium/model/workspace/VertexiumWorkspaceRepository.java
@@ -391,6 +391,7 @@ public class VertexiumWorkspaceRepository extends WorkspaceRepository {
                 WorkspaceProperties.WORKSPACE_TO_ENTITY_GRAPH_LAYOUT_JSON.removeProperty(m, VISIBILITY.getVisibility());
                 WorkspaceProperties.WORKSPACE_TO_ENTITY_GRAPH_POSITION_X.removeProperty(m, VISIBILITY.getVisibility());
                 WorkspaceProperties.WORKSPACE_TO_ENTITY_GRAPH_POSITION_Y.removeProperty(m, VISIBILITY.getVisibility());
+                m.setIndexHint(IndexHint.DO_NOT_INDEX);
                 m.save(authorizations);
             }
         }


### PR DESCRIPTION
- [x] @sfeng88 @rygim @jharwig 
- [x] @srfarley @joeferner @mwizeman 
- [x] @EvanOxfeld @joeybrk372 @dsingley

When we update entities we're not indexing the workspace edges, however when we delete entities we don't specify to not index the workspace edges which causes a 500 Error in `/update`.