### PR TITLE
Renamed ontology key in config from 'sample' to 'default'

### DIFF
--- a/config/x-visallo.properties
+++ b/config/x-visallo.properties
@@ -1,7 +1,7 @@
 
 repository.ontology=org.visallo.vertexium.model.ontology.InMemoryOntologyRepository
-repository.ontology.owl.sample.iri=http://visallo.org/sample
-repository.ontology.owl.sample.file=${VISALLO_DIR}/config/ontology-sample/sample.owl
+repository.ontology.owl.default.iri=http://visallo.org/sample
+repository.ontology.owl.default.file=${VISALLO_DIR}/config/ontology-sample/sample.owl
 
 cachingHttp.cacheDir=${VISALLO_DIR}/datastore/httpCache
 

--- a/docs/getting-started/ontology.md
+++ b/docs/getting-started/ontology.md
@@ -11,8 +11,8 @@ For an example see the [dev ontology](https://github.com/v5analytics/visallo/tre
 Add the following to your [configuration](configuration.md).
 
 ```
-repository.ontology.owl.sample.iri=http://visallo.org/sample
-repository.ontology.owl.sample.dir=$VISALLO_DIR/config/ontology-sample
+repository.ontology.owl.default.iri=http://visallo.org/sample
+repository.ontology.owl.default.dir=$VISALLO_DIR/config/ontology-sample
 ```
 
 ## Visallo OWL Extensions


### PR DESCRIPTION
- [ ] @sfeng88 @rygim @jharwig 
- [x] @joeferner @mwizeman 
- [x] @EvanOxfeld @joeybrk372 @dsingley

Since there's no way to negate a previously defined property, this makes it easier for projects to override the sample ontology (like with a `y-visallo.properties` file) when using the default set of Visallo configuration files as the base.
