### PR TITLE
Fix IE11 loading issue when trying to do feature detection of XmlHttp…

### DIFF
--- a/web/war/src/main/webapp/js/data/web-worker/util/ajax.js
+++ b/web/war/src/main/webapp/js/data/web-worker/util/ajax.js
@@ -77,9 +77,9 @@ define(['util/promise'], function(Promise) {
 
                 r.onload = function() {
                     finished = true;
-                    if (r.upload) {
+                    try {
                         r.upload.removeEventListener('progress', progressHandler);
-                    }
+                    } catch(e) {}
                     var text = r.status === 200 && r.responseText;
 
                     if (text) {
@@ -116,14 +116,15 @@ define(['util/promise'], function(Promise) {
                 };
                 r.onerror = function() {
                     finished = true;
-                    if (r.upload) {
+                    try {
                         r.upload.removeEventListener('progress', progressHandler);
-                    }
+                    } catch(e) {}
                     reject(new Error('Network Error'));
                 };
                 r.open(method, resolvedUrl, true);
 
-                if (r.upload) {
+                // using try/catch here because I could not get feature detection to work in IE11
+                try {
                     r.upload.addEventListener('progress', (progressHandler = function(event) {
                         if (event.lengthComputable) {
                             var complete = (event.loaded / event.total || 0);
@@ -132,7 +133,7 @@ define(['util/promise'], function(Promise) {
                             }
                         }
                     }), false);
-                }
+                } catch(e) {}
 
                 if (method === 'POST' && parameters) {
                     formData = params;


### PR DESCRIPTION
- [x] @sfeng88 @rygim @jharwig 
- [x] @srfarley @mwizeman 
- [x] @EvanOxfeld @joeybrk372 @dsingley

…Request upload feature.  IE11 does not like "if (xmlhttpreq.upload)" syntax

After making this change Visallo comes up and is somewhat usable in IE11