### PR TITLE
allow removing an item from the workspace if Visallo is readonly and …

### DIFF
--- a/web/war/src/main/webapp/js/data/withObjectSelection.js
+++ b/web/war/src/main/webapp/js/data/withObjectSelection.js
@@ -146,23 +146,21 @@ define([], function() {
         this.onDeleteSelected = function(event, data) {
             var self = this;
 
-            require(['util/privileges'], function(Privileges) {
-                if (!Privileges.canEDIT) {
-                    return;
-                }
+            if (!visalloData.currentWorkspaceEditable) {
+                return;
+            }
 
-                if (data && data.vertexId) {
+            if (data && data.vertexId) {
+                self.trigger('updateWorkspace', {
+                    entityDeletes: [data.vertexId]
+                });
+            } else if (selectedObjects) {
+                if (selectedObjects.vertices.length) {
                     self.trigger('updateWorkspace', {
-                        entityDeletes: [data.vertexId]
+                        entityDeletes: _.pluck(selectedObjects.vertices, 'id')
                     });
-                } else if (selectedObjects) {
-                    if (selectedObjects.vertices.length) {
-                        self.trigger('updateWorkspace', {
-                            entityDeletes: _.pluck(selectedObjects.vertices, 'id')
-                        });
-                    }
                 }
-            });
+            }
         };
 
         this.onSelectObjects = function(event, data) {


### PR DESCRIPTION
- [x] @sfeng88 @rygim @jharwig 
- [x] @srfarley @mwizeman 
- [x] @EvanOxfeld @joeybrk372 @dsingley

…you have edit access to the workspace

resolves #275 

The diff looks worse than it really is. Really just removed `require(['util/privileges'], function(Privileges) {` and changed `!Privileges.canEDIT` to `!visalloData.currentWorkspaceEditable` the rest is indent issues.