### PR TITLE
Fix race condition when multiple workspace/update with new vertices are in flight

### DIFF
--- a/web/war/src/main/webapp/js/data/web-worker/services/workspace.js
+++ b/web/war/src/main/webapp/js/data/web-worker/services/workspace.js
@@ -2,8 +2,8 @@
 define([
     '../util/ajax',
     '../util/store',
-    '../util/abort'
-], function(ajax, store, abortPrevious) {
+    '../util/queue'
+], function(ajax, store, queue) {
     'use strict';
 
     var api = {
@@ -209,7 +209,7 @@ define([
                     })
         },
 
-        save: abortPrevious(function(workspaceId, changes) {
+        save: queue(function(workspaceId, changes) {
             if (arguments.length === 1) {
                 changes = workspaceId;
                 workspaceId = publicData.currentWorkspaceId;
@@ -260,7 +260,7 @@ define([
                 data: JSON.stringify(allChanges)
             }).then(function() {
                 return { saved: true, workspace: store.updateWorkspace(workspaceId, allChanges) };
-            })
+            });
         }),
 
         vertices: function(workspaceId) {

--- a/web/war/src/main/webapp/js/data/web-worker/util/queue.js
+++ b/web/war/src/main/webapp/js/data/web-worker/util/queue.js
@@ -1,0 +1,32 @@
+
+define([], function() {
+    'use strict';
+    return function queue(func) {
+        var stack = [], promise;
+        return function() {
+            var args = Array.prototype.slice.call(arguments, 0),
+                thisPromise = function() {
+                    var p = func.apply(null, args);
+                    p.tap(function() {
+                        var index = _.findIndex(stack, p);
+                        if (index >= 0) {
+                            stack.splice(index, 1);
+                        }
+                        if (stack.length === 0) {
+                            promise = null;
+                        }
+                    })
+                    stack.push(p);
+                    return p;
+                };
+
+            if (promise && !promise.isCancelled()) {
+                promise = promise.then(thisPromise)
+            } else {
+                promise = thisPromise();
+            }
+
+            return promise;
+        }
+    };
+});

--- a/web/war/src/main/webapp/js/data/withWorkspaceVertexDrop.js
+++ b/web/war/src/main/webapp/js/data/withWorkspaceVertexDrop.js
@@ -104,7 +104,7 @@ define([], function() {
                                         });
                                         start = false;
                                     } else {
-                                        self.trigger('verticesHoveringEnded');
+                                        self.trigger('verticesHoveringEnded', { vertices: vertices });
                                     }
                                 }
                             });

--- a/web/war/src/main/webapp/js/data/withWorkspaces.js
+++ b/web/war/src/main/webapp/js/data/withWorkspaces.js
@@ -117,15 +117,17 @@ define(['util/undoManager'], function(UndoManager) {
                     .then(function(data) {
                         clearTimeout(buffer);
                         if (data.saved) {
-                            self.trigger('workspaceSaved', lastReloadedState.workspace);
+                            triggered = true;
                         }
                     })
-                    .finally(function() {
+                    .catch(function(e) {
+                        console.error(e);
+                    })
+                    .then(function() {
                         if (triggered) {
                             self.trigger('workspaceSaved', lastReloadedState.workspace);
                         }
                     })
-                    .done();
             });
         };
 

--- a/web/war/src/main/webapp/package.json
+++ b/web/war/src/main/webapp/package.json
@@ -5,7 +5,7 @@
   "repository": "git://github.com/v5analytics/visallo",
   "dependencies": {
     "atmosphere.js": "2.3.1",
-    "bluebird": "3.1.1",
+    "bluebird": "3.3.5",
     "bootstrap": "twbs/bootstrap.git#v2.3.2",
     "bootstrap-datepicker": "1.5.0",
     "bootstrap-timepicker": "0.5.1",


### PR DESCRIPTION
- [ ] @sfeng88 @rygim @jharwig 
- [x] @srfarley @joeferner @mwizeman 
- [x] @EvanOxfeld @joeybrk372 @dsingley

The previous requests were aborted and only the last add would win. Now they happen in a queue

To reproduce old issue that this PR fixes:
1. Turn on chrome network throttling with delay
2. Add vertex
3. Add another vertex within delay

Results: First vertex is grey and will never be actually added to graph (refresh fixes)