### PR TITLE
Upgrade simple orm to v1.1.1 - SQL id column length fix

### DIFF
--- a/root/pom.xml
+++ b/root/pom.xml
@@ -79,7 +79,7 @@
         <log4j.version>1.2.17</log4j.version>
         <metrics.version>3.0.2</metrics.version>
         <vertexium.version>2.2.11</vertexium.version>
-        <simple-orm.version>1.1.0</simple-orm.version>
+        <simple-orm.version>1.1.1</simple-orm.version>
         <groovy.version>2.4.5</groovy.version>
         <zip4j.version>1.3.1</zip4j.version>
         <zookeeper.version>3.4.7</zookeeper.version>


### PR DESCRIPTION
- [x] @sfeng88 @rygim @jharwig 
- [x] @srfarley @mwizeman 
- [x] @EvanOxfeld @joeybrk372 @dsingley

Waiting for publish to maven central: http://central.maven.org/maven2/com/v5analytics/simpleorm/simple-orm-core/1.1.1/simple-orm-core-1.1.1.pom