### PR TITLE
Web: Initial public JS API

### DIFF
--- a/web/war/src/main/webapp/js/public/v1/api.js
+++ b/web/war/src/main/webapp/js/public/v1/api.js
@@ -1,0 +1,52 @@
+define([
+    'flight/lib/component',
+    'configuration/plugins/registry'
+], function(
+    defineComponent,
+    registry) {
+    'use strict';
+
+    return {
+        connect: connect,
+        defineComponent: defineComponent,
+        registry: registry
+    };
+
+    function connect() {
+        return Promise.all([
+            'util/element/list',
+            'util/ontology/conceptSelect',
+            'util/ontology/propertySelect',
+            'util/ontology/relationshipSelect',
+            'util/vertex/formatters',
+            'util/vertex/justification/viewer',
+            'util/visibility/edit',
+            'util/visibility/view',
+            'util/withDataRequest'
+        ].map(function(module) {
+            return Promise.require(module);
+        })).spread(function(
+            List,
+            ConceptSelector,
+            PropertySelector,
+            RelationshipSelector,
+            F,
+            JustificationViewer,
+            VisibilityEditor,
+            VisibilityViewer,
+            withDataRequest) {
+
+            return {
+                components: {
+                    JustificationViewer: JustificationViewer,
+                    List: List,
+                    OntologyConceptSelector: ConceptSelector,
+                    OntologyPropertySelector: PropertySelector,
+                    OntologyRelationshipSelector: RelationshipSelector
+                },
+                formatters: F,
+                dataRequest: withDataRequest.dataRequest
+            };
+        });
+    }
+});

--- a/web/war/src/main/webapp/js/public/v1/workerApi.js
+++ b/web/war/src/main/webapp/js/public/v1/workerApi.js
@@ -1,0 +1,9 @@
+define([
+    'data/web-worker/util/ajax'
+], function(ajax) {
+    'use strict';
+
+    return {
+        ajax: ajax
+    };
+});


### PR DESCRIPTION
- [ ] @sfeng88 @rygim @jharwig 
- [x] @srfarley @joeferner
- [ ] @EvanOxfeld @joeybrk372
- [ ] @mwizeman @dsingley

Exposes an API module with synchronous functions for registering Visallo extensions and defining flight components as well as a `connect` function that returns a promise with formatter functions and public built-in flight components. `connect` is purposefully asynchronous so as not to hide from the developer that asynchronous actions such as loading the ontology are performed. If this looks along the right lines I'll update the developer docs.

Here's are a couple requirejs examples:

```js
define(['public/v1/api'], function(api) {
  var registry = api.registry;
  registry.registerExtension([extension point name], [extension point object]);
});
```

```js
define(['public/v1/api'], function(api) {
  var defineComponent = api.defineComponent;
  return api
    .connect()
    .then(function(visallo) {
      var withDataRequest = visallo.withDataRequest;
      return defineComponent(MyDataRequestingComponent, withDataRequest);
    });

  function MyDataRequestingComponent() {
  }
});
```