### PR TITLE
Make it much easier to create a default WAR file

### DIFF
--- a/config/visallo.properties
+++ b/config/visallo.properties
@@ -66,3 +66,10 @@ security.visibilityTranslator=org.visallo.core.security.DirectVisibilityTranslat
 # org.visallo.core.formula.FormulaEvaluator
 #
 #org.visallo.core.formula.FormulaEvaluator.max.threads=1
+
+
+# Uncomment to allow plain HTTP. HTTPS is forced otherwise.
+#http.transportGuarantee=NONE
+
+# Uncomment when deploying to Tomcat
+#http.gzipEnabled=false

--- a/config/x-visallo.properties
+++ b/config/x-visallo.properties
@@ -30,10 +30,3 @@ graph.sql.jdbc.password=${sql.password}
 graph.sql.jdbc.driverClass=${sql.driverClass}
 graph.sql.jdbc.url=${sql.connectionString}
 graph.tableNamePrefix=${sql.tablePrefixName}
-
-
-# Uncomment to allow plain http
-http.transportGuarantee=NONE
-
-# Uncomment when deploying to Tomcat
-http.gzipEnabled=false

--- a/config/x-visallo.properties
+++ b/config/x-visallo.properties
@@ -31,3 +31,9 @@ graph.sql.jdbc.driverClass=${sql.driverClass}
 graph.sql.jdbc.url=${sql.connectionString}
 graph.tableNamePrefix=${sql.tablePrefixName}
 
+
+# Uncomment to allow plain http
+http.transportGuarantee=NONE
+
+# Uncomment when deploying to Tomcat
+http.gzipEnabled=false

--- a/docs/getting-started/build.md
+++ b/docs/getting-started/build.md
@@ -28,9 +28,11 @@ It is a known issue that some unit tests fail on Windows. The following are expe
 
 Building the Visallo web application is very similar to running it. From the root directory of the Visallo project, run
 
-    mvn package -pl web/war -am -DskipTests -Dsource.skip=true
+    mvn package -pl web/war -am -Pdefault-webapp -DskipTests -Dsource.skip=true
 
-The previous command will create a WAR file in the `web/war/target` directory.
+The previous command will create a default WAR file in the `web/war/target` directory. This WAR file is meant to mimic
+the webapp that starts when you run the maven command described in the section on [running](running.md). You will need
+to set the `VISALLO_DIR` environment variable to point to the parent directory of your Visallo configuration files.
 
 <a name="web-plugin"/>
 ## Web Application Plugins

--- a/web/war/pom.xml
+++ b/web/war/pom.xml
@@ -175,5 +175,21 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>default-webapp</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.visallo</groupId>
+                    <artifactId>visallo-dev-jetty-server</artifactId>
+                    <version>${project.version}</version>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>org.visallo</groupId>
+                            <artifactId>visallo-jetty-server</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
This task is intended to make it much easier to create a standalone WAR file that mimics what is started by the Maven command in the docs describing running. 

Please note that the dependency exclusion in the modified POM does not work, despite all documentation I'm able to find suggesting that it should. It's failure has no bearing on the operation of the web app, but it does end up including jetty JAR files in the WAR.

- [x] @sfeng88 @rygim @jharwig 
- [x] @srfarley @joeferner
- [x] @EvanOxfeld @joeybrk372
- [x] @mwizeman @dsingley