### PR TITLE
Allow Compound Properties to Support a Blank Key

### DIFF
--- a/web/war/src/main/webapp/js/detail/dropdowns/propertyForm/propForm.js
+++ b/web/war/src/main/webapp/js/detail/dropdowns/propertyForm/propForm.js
@@ -385,9 +385,7 @@ define([
                             PropertyField.attachTo(config, {
                                 property: propertyDetails,
                                 vertex: self.attr.data,
-                                values: property.key ?
-                                    F.vertex.props(self.attr.data, propertyDetails.title, property.key) :
-                                    null
+                                values: F.vertex.props(self.attr.data, propertyDetails.title, property.key)
                             });
                         } else {
                             PropertyField.attachTo(config, {


### PR DESCRIPTION
- [x] @sfeng88 @rygim @jharwig 
- [x] @srfarley @joeferner
- [x] @EvanOxfeld @joeybrk372
- [x] @mwizeman @dsingley

If vertexium considers an empty string as a valid key, the ui should allow for a compound property's dependent properties to be edited if they have an empty key.