### PR TITLE
Detect Tomcat container and do not enable gzip filter

### DIFF
--- a/config/visallo.properties
+++ b/config/visallo.properties
@@ -70,3 +70,7 @@ security.visibilityTranslator=org.visallo.core.security.DirectVisibilityTranslat
 
 # Uncomment to allow plain HTTP. HTTPS is forced otherwise.
 #http.transportGuarantee=NONE
+
+# Enable/Disable Visallo Gzip filter (on Jetty the default is true, other containers default to false)
+#  The Visallo Gzip filter is known to have issues on Tomcat containers.
+#http.gzipEnabled=false

--- a/config/visallo.properties
+++ b/config/visallo.properties
@@ -70,6 +70,3 @@ security.visibilityTranslator=org.visallo.core.security.DirectVisibilityTranslat
 
 # Uncomment to allow plain HTTP. HTTPS is forced otherwise.
 #http.transportGuarantee=NONE
-
-# Uncomment when deploying to Tomcat
-#http.gzipEnabled=false

--- a/core/core/src/main/java/org/visallo/core/config/Configuration.java
+++ b/core/core/src/main/java/org/visallo/core/config/Configuration.java
@@ -85,7 +85,6 @@ public class Configuration {
     public static final String SYSTEM_PROPERTY_PREFIX = "visallo.";
 
     public static final String HTTP_GZIP_ENABLED = "http.gzipEnabled";
-    public static final boolean HTTP_GZIP_ENABLED_DEFAULT = true;
 
     private final ConfigurationLoader configurationLoader;
     private final VisalloResourceBundleManager visalloResourceBundleManager;

--- a/web/web-base/src/main/java/org/visallo/web/ApplicationBootstrap.java
+++ b/web/web-base/src/main/java/org/visallo/web/ApplicationBootstrap.java
@@ -235,12 +235,18 @@ public class ApplicationBootstrap implements ServletContextListener {
     }
 
     private boolean shouldAddGzipFilter(ServletContext context, Configuration config) {
-        if (System.getProperty("catalina.base") != null ||
-                System.getProperty("catalina.home") != null ||
-                (context.getServerInfo() != null && context.getServerInfo().toLowerCase().contains("tomcat"))) {
-            return false;
+        return config.getBoolean(Configuration.HTTP_GZIP_ENABLED, getGzipEnabledDefault(context));
+    }
+
+    private boolean getGzipEnabledDefault(ServletContext context) {
+        if (isJetty(context)) {
+            return true;
         }
-        return config.getBoolean(Configuration.HTTP_GZIP_ENABLED, Configuration.HTTP_GZIP_ENABLED_DEFAULT);
+        return false;
+    }
+
+    private boolean isJetty(ServletContext context) {
+        return context.getServerInfo() != null && context.getServerInfo().toLowerCase().contains("jetty");
     }
 
     private void addGzipFilter(ServletContext context) {

--- a/web/web-base/src/main/java/org/visallo/web/ApplicationBootstrap.java
+++ b/web/web-base/src/main/java/org/visallo/web/ApplicationBootstrap.java
@@ -192,7 +192,7 @@ public class ApplicationBootstrap implements ServletContextListener {
         addAtmosphereServlet(context, config);
         addDebugFilter(context);
         addCacheFilter(context);
-        if (config.getBoolean(Configuration.HTTP_GZIP_ENABLED, Configuration.HTTP_GZIP_ENABLED_DEFAULT)) {
+        if (shouldAddGzipFilter(config)) {
             addGzipFilter(context);
         }
         LOGGER.info("JavaScript / Less modifications will not be reflected on server. Run `grunt` from webapp directory in development");
@@ -232,6 +232,13 @@ public class ApplicationBootstrap implements ServletContextListener {
         for (String mapping : mappings) {
             filter.addMappingForUrlPatterns(EnumSet.of(DispatcherType.REQUEST), false, mapping);
         }
+    }
+
+    private boolean shouldAddGzipFilter(Configuration config) {
+        if (System.getProperty("catalina.home") != null || System.getProperty("catalina.base") != null) {
+            return false;
+        }
+        return config.getBoolean(Configuration.HTTP_GZIP_ENABLED, Configuration.HTTP_GZIP_ENABLED_DEFAULT);
     }
 
     private void addGzipFilter(ServletContext context) {

--- a/web/web-base/src/main/java/org/visallo/web/ApplicationBootstrap.java
+++ b/web/web-base/src/main/java/org/visallo/web/ApplicationBootstrap.java
@@ -192,7 +192,7 @@ public class ApplicationBootstrap implements ServletContextListener {
         addAtmosphereServlet(context, config);
         addDebugFilter(context);
         addCacheFilter(context);
-        if (shouldAddGzipFilter(config)) {
+        if (shouldAddGzipFilter(context, config)) {
             addGzipFilter(context);
         }
         LOGGER.info("JavaScript / Less modifications will not be reflected on server. Run `grunt` from webapp directory in development");
@@ -234,8 +234,10 @@ public class ApplicationBootstrap implements ServletContextListener {
         }
     }
 
-    private boolean shouldAddGzipFilter(Configuration config) {
-        if (System.getProperty("catalina.home") != null || System.getProperty("catalina.base") != null) {
+    private boolean shouldAddGzipFilter(ServletContext context, Configuration config) {
+        if (System.getProperty("catalina.base") != null ||
+                System.getProperty("catalina.home") != null ||
+                (context.getServerInfo() != null && context.getServerInfo().toLowerCase().contains("tomcat"))) {
             return false;
         }
         return config.getBoolean(Configuration.HTTP_GZIP_ENABLED, Configuration.HTTP_GZIP_ENABLED_DEFAULT);


### PR DESCRIPTION
This simple pull request attempts to detect when the web app is running under tomcat and prevent the gzip filter from being applied (it breaks Tomcat). This is important since the default config is to enable the filter. **The safer alternative to this PR is to make the default `false` and only enable it when you know it will work, like when running Jetty.** However, that is a change in the default setting that could impact current users.

- [x] @sfeng88 @rygim @jharwig 
- [x] @srfarley @joeferner
- [ ] @EvanOxfeld @joeybrk372
- [x] @mwizeman @dsingley
