### PR TITLE
Allow Visallo to run at non-root context paths

### DIFF
--- a/web/war/src/main/webapp/index.hbs
+++ b/web/war/src/main/webapp/index.hbs
@@ -15,7 +15,7 @@
 
     <link href='css/visallo.css' rel='stylesheet' media='screen'>
     {{#each pluginCssResources}}
-    <link href='{{.}}' rel='stylesheet' media='screen'>
+    <link href='{{contextPath}}/{{.}}' rel='stylesheet' media='screen'>
     {{/each}}
 
     <script src='jsc/require.config.js'></script>
@@ -33,13 +33,13 @@
       require.urlArgs = window.visalloCacheBreaker = "vslo_v=" + versionParameter;
       window.visalloPluginResources = {
         beforeAuth: [
-        {{#each pluginJsResourcesBeforeAuth}}  '{{.}}'{{#unless @last}},{{/unless}}
+        {{#each pluginJsResourcesBeforeAuth}}  '{{contextPath}}{{.}}'{{#unless @last}},{{/unless}}
         {{/each}}],
         afterAuth: [
-        {{#each pluginJsResourcesAfterAuth}}  '{{.}}'{{#unless @last}},{{/unless}}
+        {{#each pluginJsResourcesAfterAuth}}  '{{contextPath}}{{.}}'{{#unless @last}},{{/unless}}
         {{/each}}],
         webWorker: [
-        {{#each pluginJsResourcesWebWorker}}  '{{.}}'{{#unless @last}},{{/unless}}
+        {{#each pluginJsResourcesWebWorker}}  '{{contextPath}}{{.}}'{{#unless @last}},{{/unless}}
         {{/each}}]
       };
     })();

--- a/web/war/src/main/webapp/js/dashboard/items/welcome/welcome.js
+++ b/web/war/src/main/webapp/js/dashboard/items/welcome/welcome.js
@@ -25,14 +25,14 @@ define([
                 map: 'hbs!dashboard/items/welcome/map'
             },
             icons = {
-                activity: '../img/glyphicons/white/glyphicons_023_cogwheels@2x.png',
-                admin: '../img/glyphicons/white/glyphicons_439_wrench@2x.png',
-                dashboard: '../img/visallo-icon@2x.png',
-                graph: '../img/glyphicons/white/glyphicons_326_share@2x.png',
-                logout: '../img/glyphicons/white/glyphicons_387_log_out@2x.png',
-                search: '../img/glyphicons/white/glyphicons_027_search@2x.png',
-                workspaces: '../img/glyphicons/white/glyphicons_153_more_windows@2x.png',
-                map: '../img/glyphicons/white/glyphicons_242_google_maps@2x.png'
+                activity: 'img/glyphicons/white/glyphicons_023_cogwheels@2x.png',
+                admin: 'img/glyphicons/white/glyphicons_439_wrench@2x.png',
+                dashboard: 'img/visallo-icon@2x.png',
+                graph: 'img/glyphicons/white/glyphicons_326_share@2x.png',
+                logout: 'img/glyphicons/white/glyphicons_387_log_out@2x.png',
+                search: 'img/glyphicons/white/glyphicons_027_search@2x.png',
+                workspaces: 'img/glyphicons/white/glyphicons_153_more_windows@2x.png',
+                map: 'img/glyphicons/white/glyphicons_242_google_maps@2x.png'
             },
             menubarExtensions = registry.extensionsForPoint('org.visallo.menubar');
 

--- a/web/web-base/src/main/java/org/visallo/web/routes/Index.java
+++ b/web/web-base/src/main/java/org/visallo/web/routes/Index.java
@@ -32,6 +32,7 @@ public class Index implements ParameterizedHandler {
     private static final String LOGO_IMAGE_DATA_URI = "logoDataUri";
     private static final String SHOW_VERSION_COMMENTS = "showVersionComments";
     private static final String LOGO_PATH_BUNDLE_KEY = "visallo.loading-logo.path";
+    private static final String CONTEXT_PATH = "contextPath";
     private static final Map<String, String> MESSAGE_BUNDLE_PARAMS = ImmutableMap.of(
             "title", "visallo.title",
             "description", "visallo.description"
@@ -59,6 +60,7 @@ public class Index implements ParameterizedHandler {
     private String getIndexHtml(HttpServletRequest request, WebApp app, ResourceBundle resourceBundle) throws IOException {
         if (indexHtml == null || app.isDevModeEnabled()) {
             Map<String, Object> context = new HashMap<>();
+            context.put(CONTEXT_PATH, request.getContextPath());
             context.put(PLUGIN_JS_RESOURCES_BEFORE_AUTH_PARAM, app.getPluginsJsResourcesBeforeAuth());
             context.put(PLUGIN_JS_RESOURCES_WEB_WORKER_PARAM, app.getPluginsJsResourcesWebWorker());
             context.put(PLUGIN_JS_RESOURCES_AFTER_AUTH_PARAM, app.getPluginsJsResourcesAfterAuth());


### PR DESCRIPTION
There were only a few fixes that needed to be made to allow Visallo to run at alternate context paths. I did not, however, test every plugin to make sure it doesn't do something that's not compatible with an alternate context path. Fortunately, these changes should have no affect when leaving things at the root (i.e. /) context.

- [x] @sfeng88 @rygim @jharwig 
- [x] @srfarley @joeferner
- [x] @EvanOxfeld @joeybrk372
- [x] @mwizeman @dsingley @kunklejr

