### PR TITLE
Refactor search to allow searches to originate from the backend

### DIFF
--- a/core/core/src/main/java/org/visallo/core/model/search/EdgeSearchRunner.java
+++ b/core/core/src/main/java/org/visallo/core/model/search/EdgeSearchRunner.java
@@ -1,0 +1,34 @@
+package org.visallo.core.model.search;
+
+import com.google.inject.Inject;
+import org.vertexium.ElementType;
+import org.vertexium.Graph;
+import org.visallo.core.config.Configuration;
+import org.visallo.core.model.directory.DirectoryRepository;
+import org.visallo.core.model.ontology.OntologyRepository;
+
+import java.util.EnumSet;
+
+public class EdgeSearchRunner extends ElementSearchRunnerWithRelatedBase {
+    public static final String URI = "/edge/search";
+
+    @Inject
+    public EdgeSearchRunner(
+            OntologyRepository ontologyRepository,
+            Graph graph,
+            Configuration configuration,
+            DirectoryRepository directoryRepository
+    ) {
+        super(ontologyRepository, graph, configuration, directoryRepository);
+    }
+
+    @Override
+    protected EnumSet<ElementType> getResultType() {
+        return EnumSet.of(ElementType.EDGE);
+    }
+
+    @Override
+    public String getUri() {
+        return URI;
+    }
+}

--- a/core/core/src/main/java/org/visallo/core/model/search/ElementSearchRunner.java
+++ b/core/core/src/main/java/org/visallo/core/model/search/ElementSearchRunner.java
@@ -1,0 +1,55 @@
+package org.visallo.core.model.search;
+
+import com.google.inject.Inject;
+import org.json.JSONArray;
+import org.vertexium.Authorizations;
+import org.vertexium.ElementType;
+import org.vertexium.Graph;
+import org.vertexium.query.Query;
+import org.visallo.core.config.Configuration;
+import org.visallo.core.model.directory.DirectoryRepository;
+import org.visallo.core.model.ontology.OntologyRepository;
+import org.visallo.core.util.VisalloLogger;
+import org.visallo.core.util.VisalloLoggerFactory;
+
+import java.util.EnumSet;
+
+public class ElementSearchRunner extends ElementSearchRunnerWithRelatedBase {
+    private static final VisalloLogger LOGGER = VisalloLoggerFactory.getLogger(ElementSearchRunner.class);
+    public static final String URI = "/element/search";
+
+    @Inject
+    public ElementSearchRunner(
+            OntologyRepository ontologyRepository,
+            Graph graph,
+            Configuration configuration,
+            DirectoryRepository directoryRepository
+    ) {
+        super(ontologyRepository, graph, configuration, directoryRepository);
+    }
+
+    @Override
+    protected EnumSet<ElementType> getResultType() {
+        return EnumSet.of(ElementType.EDGE, ElementType.VERTEX);
+    }
+
+    @Override
+    public String getUri() {
+        return URI;
+    }
+
+    @Override
+    protected QueryAndData getQuery(SearchOptions searchOptions, final Authorizations authorizations) {
+        JSONArray filterJson = getFilterJson(searchOptions);
+        String queryString = searchOptions.getRequiredParameter("q", String.class);
+        LOGGER.debug("search %s\n%s", queryString, filterJson.toString(2));
+
+        Query graphQuery = query(queryString, authorizations);
+
+        return new QueryAndData(graphQuery);
+    }
+
+    private Query query(String query, Authorizations authorizations) {
+        return getGraph().query(query, authorizations);
+    }
+}

--- a/core/core/src/main/java/org/visallo/core/model/search/ElementSearchRunnerBase.java
+++ b/core/core/src/main/java/org/visallo/core/model/search/ElementSearchRunnerBase.java
@@ -1,0 +1,377 @@
+package org.visallo.core.model.search;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.vertexium.*;
+import org.vertexium.query.*;
+import org.visallo.core.config.Configuration;
+import org.visallo.core.exception.VisalloException;
+import org.visallo.core.model.directory.DirectoryRepository;
+import org.visallo.core.model.ontology.OntologyProperty;
+import org.visallo.core.model.ontology.OntologyRepository;
+import org.visallo.core.trace.Trace;
+import org.visallo.core.trace.TraceSpan;
+import org.visallo.core.user.User;
+import org.visallo.core.util.ClientApiConverter;
+import org.visallo.core.util.JSONUtil;
+import org.visallo.web.clientapi.model.PropertyType;
+
+import java.text.ParseException;
+import java.util.*;
+
+public abstract class ElementSearchRunnerBase extends SearchRunner {
+    private final Graph graph;
+    private final DirectoryRepository directoryRepository;
+    private final OntologyRepository ontologyRepository;
+    private int defaultSearchResultCount;
+
+    protected ElementSearchRunnerBase(
+            OntologyRepository ontologyRepository,
+            Graph graph,
+            Configuration configuration,
+            DirectoryRepository directoryRepository
+    ) {
+        this.ontologyRepository = ontologyRepository;
+        this.graph = graph;
+        this.directoryRepository = directoryRepository;
+        defaultSearchResultCount = configuration.getInt(Configuration.DEFAULT_SEARCH_RESULT_COUNT, 100);
+    }
+
+    @Override
+    public QueryResultsIterableSearchResults run(
+            SearchOptions searchOptions,
+            User user,
+            Authorizations authorizations
+    ) {
+        JSONArray filterJson = getFilterJson(searchOptions);
+
+        QueryAndData queryAndData = getQuery(searchOptions, authorizations);
+        applyFiltersToQuery(queryAndData, filterJson, user);
+        applyConceptTypeFilterToQuery(queryAndData, searchOptions);
+        applyEdgeLabelFilterToQuery(queryAndData, searchOptions);
+        applySortToQuery(queryAndData, searchOptions);
+        applyAggregationsToQuery(queryAndData, searchOptions);
+
+        EnumSet<FetchHint> fetchHints = getFetchHints(searchOptions);
+        final int offset = searchOptions.getOptionalParameter("offset", 0);
+        final int size = searchOptions.getOptionalParameter("size", defaultSearchResultCount);
+        queryAndData.getQuery().limit(size);
+        queryAndData.getQuery().skip(offset);
+
+        QueryResultsIterable<? extends Element> searchResults = getSearchResults(queryAndData, fetchHints);
+
+        return new QueryResultsIterableSearchResults(searchResults, queryAndData, offset, size);
+    }
+
+    private EnumSet<FetchHint> getFetchHints(SearchOptions searchOptions) {
+        String fetchHintsString = searchOptions.getOptionalParameter("fetchHints", String.class);
+        if (fetchHintsString == null) {
+            return ClientApiConverter.SEARCH_FETCH_HINTS;
+        }
+        return FetchHint.parse(fetchHintsString);
+    }
+
+    private void applyAggregationsToQuery(QueryAndData queryAndData, SearchOptions searchOptions) {
+        Query query = queryAndData.getQuery();
+        String[] aggregates = searchOptions.getOptionalParameter("aggregations[]", String[].class);
+        if (aggregates == null) {
+            return;
+        }
+        for (String aggregate : aggregates) {
+            JSONObject aggregateJson = new JSONObject(aggregate);
+            Aggregation aggregation = getAggregation(aggregateJson);
+            query.addAggregation(aggregation);
+        }
+    }
+
+    private Aggregation getAggregation(JSONObject aggregateJson) {
+        String field;
+        String aggregationName = aggregateJson.getString("name");
+        String type = aggregateJson.getString("type");
+        Aggregation aggregation;
+        switch (type) {
+            case "term":
+                field = aggregateJson.getString("field");
+                aggregation = new TermsAggregation(aggregationName, field);
+                break;
+            case "geohash":
+                field = aggregateJson.getString("field");
+                int precision = aggregateJson.getInt("precision");
+                aggregation = new GeohashAggregation(aggregationName, field, precision);
+                break;
+            case "histogram":
+                field = aggregateJson.getString("field");
+                String interval = aggregateJson.getString("interval");
+                Long minDocumentCount = JSONUtil.getOptionalLong(aggregateJson, "minDocumentCount");
+                aggregation = new HistogramAggregation(aggregationName, field, interval, minDocumentCount);
+                break;
+            case "statistics":
+                field = aggregateJson.getString("field");
+                aggregation = new StatisticsAggregation(aggregationName, field);
+                break;
+            default:
+                throw new VisalloException("Invalid aggregation type: " + type);
+        }
+
+        JSONArray nestedAggregates = aggregateJson.optJSONArray("nested");
+        if (nestedAggregates != null && nestedAggregates.length() > 0) {
+            if (!(aggregation instanceof SupportsNestedAggregationsAggregation)) {
+                throw new VisalloException("Aggregation does not support nesting: " + aggregation.getClass().getName());
+            }
+            for (int i = 0; i < nestedAggregates.length(); i++) {
+                JSONObject nestedAggregateJson = nestedAggregates.getJSONObject(i);
+                Aggregation nestedAggregate = getAggregation(nestedAggregateJson);
+                ((SupportsNestedAggregationsAggregation) aggregation).addNestedAggregation(nestedAggregate);
+            }
+        }
+
+        return aggregation;
+    }
+
+    protected void applySortToQuery(QueryAndData queryAndData, SearchOptions searchOptions) {
+        String[] sorts = searchOptions.getOptionalParameter("sort[]", String[].class);
+        if (sorts == null) {
+            return;
+        }
+        for (String sort : sorts) {
+            String propertyName = sort;
+            SortDirection direction = SortDirection.ASCENDING;
+            if (propertyName.toUpperCase().endsWith(":ASCENDING")) {
+                direction = SortDirection.ASCENDING;
+                propertyName = propertyName.substring(0, propertyName.length() - ":ASCENDING".length());
+            } else if (propertyName.toUpperCase().endsWith(":DESCENDING")) {
+                direction = SortDirection.DESCENDING;
+                propertyName = propertyName.substring(0, propertyName.length() - ":DESCENDING".length());
+            }
+            queryAndData.getQuery().sort(propertyName, direction);
+        }
+    }
+
+    protected QueryResultsIterable<? extends Element> getSearchResults(QueryAndData queryAndData, EnumSet<FetchHint> fetchHints) {
+        //noinspection unused
+        try (TraceSpan trace = Trace.start("getSearchResults")) {
+            if (getResultType().contains(ElementType.VERTEX) && getResultType().contains(ElementType.EDGE)) {
+                return queryAndData.getQuery().elements(fetchHints);
+            } else if (getResultType().contains(ElementType.VERTEX)) {
+                return queryAndData.getQuery().vertices(fetchHints);
+            } else if (getResultType().contains(ElementType.EDGE)) {
+                return queryAndData.getQuery().edges(fetchHints);
+            } else {
+                throw new VisalloException("Unexpected result type: " + getResultType());
+            }
+        }
+    }
+
+    protected abstract EnumSet<ElementType> getResultType();
+
+    protected abstract QueryAndData getQuery(SearchOptions searchOptions, Authorizations authorizations);
+
+    protected void applyConceptTypeFilterToQuery(QueryAndData queryAndData, SearchOptions searchOptions) {
+        final String conceptType = searchOptions.getOptionalParameter("conceptType", String.class);
+        final String includeChildNodes = searchOptions.getOptionalParameter("includeChildNodes", String.class);
+        Query query = queryAndData.getQuery();
+        if (conceptType != null) {
+            boolean includeChildNodesBoolean = includeChildNodes == null || !includeChildNodes.equals("false");
+            ontologyRepository.addConceptTypeFilterToQuery(query, conceptType, includeChildNodesBoolean);
+        }
+    }
+
+    protected void applyEdgeLabelFilterToQuery(QueryAndData queryAndData, SearchOptions searchOptions) {
+        final String edgeLabel = searchOptions.getOptionalParameter("edgeLabel", String.class);
+        final String includeChildNodes = searchOptions.getOptionalParameter("includeChildNodes", String.class);
+        Query query = queryAndData.getQuery();
+        if (edgeLabel != null) {
+            boolean includeChildNodesBoolean = includeChildNodes == null || !includeChildNodes.equals("false");
+            ontologyRepository.addEdgeLabelFilterToQuery(query, edgeLabel, includeChildNodesBoolean);
+        }
+    }
+
+    protected void applyFiltersToQuery(QueryAndData queryAndData, JSONArray filterJson, User user) {
+        for (int i = 0; i < filterJson.length(); i++) {
+            JSONObject obj = filterJson.getJSONObject(i);
+            if (obj.length() > 0) {
+                updateQueryWithFilter(queryAndData.getQuery(), obj, user);
+            }
+        }
+    }
+
+    protected JSONArray getFilterJson(SearchOptions searchOptions) {
+        JSONArray filterJson = searchOptions.getRequiredParameter("filter", JSONArray.class);
+        ontologyRepository.resolvePropertyIds(filterJson);
+        return filterJson;
+    }
+
+    private void updateQueryWithFilter(Query graphQuery, JSONObject obj, User user) {
+        try {
+            String predicateString = obj.optString("predicate");
+            String propertyName = obj.getString("propertyName");
+            if ("has".equals(predicateString)) {
+                graphQuery.has(propertyName);
+            } else if ("hasNot".equals(predicateString)) {
+                graphQuery.hasNot(propertyName);
+            } else if ("in".equals(predicateString)) {
+                graphQuery.has(propertyName, Contains.IN, JSONUtil.toList(obj.getJSONArray("values")));
+            } else {
+                PropertyType propertyDataType = PropertyType.convert(obj.optString("propertyDataType"));
+                JSONArray values = obj.getJSONArray("values");
+                Object value0 = jsonValueToObject(values, propertyDataType, 0);
+
+                if (PropertyType.STRING.equals(propertyDataType) && (predicateString == null || "~".equals(predicateString) || "".equals(predicateString))) {
+                    graphQuery.has(propertyName, TextPredicate.CONTAINS, value0);
+                } else if (PropertyType.DATE.equals(propertyDataType)) {
+                    applyDateToQuery(graphQuery, obj, predicateString, values);
+                } else if (PropertyType.BOOLEAN.equals(propertyDataType)) {
+                    graphQuery.has(propertyName, Compare.EQUAL, value0);
+                } else if (PropertyType.GEO_LOCATION.equals(propertyDataType)) {
+                    graphQuery.has(propertyName, GeoCompare.WITHIN, value0);
+                } else if ("<".equals(predicateString)) {
+                    graphQuery.has(propertyName, Compare.LESS_THAN, value0);
+                } else if (">".equals(predicateString)) {
+                    graphQuery.has(propertyName, Compare.GREATER_THAN, value0);
+                } else if ("range".equals(predicateString)) {
+                    graphQuery.has(propertyName, Compare.GREATER_THAN_EQUAL, value0);
+                    graphQuery.has(propertyName, Compare.LESS_THAN_EQUAL, jsonValueToObject(values, propertyDataType, 1));
+                } else if ("=".equals(predicateString) || "equal".equals(predicateString)) {
+                    if (PropertyType.DIRECTORY_ENTITY.equals(propertyDataType) && value0 instanceof JSONObject) {
+                        applyDirectoryEntityJsonObjectEqualityToQuery(graphQuery, propertyName, (JSONObject) value0, user);
+                    } else if (PropertyType.DOUBLE.equals(propertyDataType)) {
+                        applyDoubleEqualityToQuery(graphQuery, obj, value0);
+                    } else {
+                        graphQuery.has(propertyName, Compare.EQUAL, value0);
+                    }
+                } else {
+                    throw new VisalloException("unhandled query\n" + obj.toString(2));
+                }
+            }
+        } catch (ParseException ex) {
+            throw new VisalloException("Could not update query with filter:\n" + obj.toString(2), ex);
+        }
+    }
+
+    private void applyDirectoryEntityJsonObjectEqualityToQuery(Query graphQuery, String propertyName, JSONObject value0, User user) {
+        String directoryEntityId = value0.optString("directoryEntityId", null);
+        if (directoryEntityId != null) {
+            graphQuery.has(propertyName, Compare.EQUAL, directoryEntityId);
+        } else if (value0.optBoolean("currentUser", false)) {
+            directoryEntityId = directoryRepository.getDirectoryEntityId(user);
+            graphQuery.has(propertyName, Compare.EQUAL, directoryEntityId);
+        } else {
+            throw new VisalloException("Invalid directory entity JSONObject filter:\n" + value0.toString(2));
+        }
+    }
+
+    private void applyDoubleEqualityToQuery(Query graphQuery, JSONObject obj, Object value0) throws ParseException {
+        String propertyName = obj.getString("propertyName");
+        JSONObject metadata = obj.has("metadata") ? obj.getJSONObject("metadata") : null;
+
+        if (metadata != null && metadata.has("http://visallo.org#inputPrecision") && value0 instanceof Double) {
+            double doubleParam = (double) value0;
+            double buffer = Math.pow(10, -(Math.abs(metadata.getInt("http://visallo.org#inputPrecision")) + 1)) * 5;
+
+            graphQuery.has(propertyName, Compare.GREATER_THAN, doubleParam - buffer);
+            graphQuery.has(propertyName, Compare.LESS_THAN, doubleParam + buffer);
+        } else {
+            graphQuery.has(propertyName, Compare.EQUAL, value0);
+        }
+    }
+
+    private void applyDateToQuery(Query graphQuery, JSONObject obj, String predicate, JSONArray values) throws ParseException {
+        String propertyName = obj.getString("propertyName");
+        PropertyType propertyDataType = PropertyType.DATE;
+        OntologyProperty property = ontologyRepository.getPropertyByIRI(propertyName);
+
+        if (property != null && values.length() > 0) {
+            String displayType = property.getDisplayType();
+            boolean isDateOnly = displayType != null && displayType.equals("dateOnly");
+            boolean isRelative = values.get(0) instanceof JSONObject;
+
+            Calendar calendar = new GregorianCalendar();
+            calendar.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+            if (isRelative) {
+                JSONObject fromNow = (JSONObject) values.get(0);
+                calendar.setTime(new Date());
+                moveDateToStart(calendar, isDateOnly);
+                //noinspection MagicConstant
+                calendar.add(fromNow.getInt("unit"), fromNow.getInt("amount"));
+            } else {
+                Date date0 = (Date) jsonValueToObject(values, propertyDataType, 0);
+                calendar.setTime(date0);
+            }
+
+            if (predicate == null || predicate.equals("equal") || predicate.equals("=")) {
+                moveDateToStart(calendar, isDateOnly);
+                graphQuery.has(propertyName, Compare.GREATER_THAN_EQUAL, calendar.getTime());
+
+                moveDateToEnd(calendar, isDateOnly);
+                graphQuery.has(propertyName, Compare.LESS_THAN, calendar.getTime());
+            } else if (predicate.equals("range")) {
+                if (!isRelative) {
+                    moveDateToStart(calendar, isDateOnly);
+                }
+                graphQuery.has(propertyName, Compare.GREATER_THAN_EQUAL, calendar.getTime());
+
+                if (values.get(1) instanceof JSONObject) {
+                    JSONObject fromNow = (JSONObject) values.get(1);
+                    calendar.setTime(new Date());
+                    moveDateToStart(calendar, isDateOnly);
+                    //noinspection MagicConstant
+                    calendar.add(fromNow.getInt("unit"), fromNow.getInt("amount"));
+                    moveDateToEnd(calendar, isDateOnly);
+                    graphQuery.has(propertyName, Compare.LESS_THAN, calendar.getTime());
+                } else {
+                    calendar.setTime((Date) jsonValueToObject(values, propertyDataType, 1));
+                    moveDateToEnd(calendar, isDateOnly);
+                    graphQuery.has(propertyName, Compare.LESS_THAN, calendar.getTime());
+                }
+            } else if (predicate.equals("<")) {
+                moveDateToStart(calendar, isDateOnly);
+                graphQuery.has(propertyName, Compare.LESS_THAN, calendar.getTime());
+            } else if (predicate.equals(">")) {
+                moveDateToEnd(calendar, isDateOnly);
+                graphQuery.has(propertyName, Compare.GREATER_THAN_EQUAL, calendar.getTime());
+            }
+        }
+    }
+
+    private void moveDateToStart(Calendar calendar, boolean dateOnly) {
+        if (dateOnly) {
+            calendar.set(Calendar.HOUR_OF_DAY, 0);
+            calendar.set(Calendar.MINUTE, 0);
+        }
+        calendar.set(Calendar.SECOND, 0);
+        calendar.set(Calendar.MILLISECOND, 0);
+    }
+
+    private void moveDateToEnd(Calendar calendar, boolean dateOnly) {
+        if (dateOnly) {
+            calendar.add(Calendar.DAY_OF_MONTH, 1);
+        } else {
+            calendar.add(Calendar.MINUTE, 1);
+        }
+    }
+
+    private Object jsonValueToObject(JSONArray values, PropertyType propertyDataType, int index) throws ParseException {
+        // JSONObject can be sent to search in the case of relative date searching or advanced directory entry searching
+        if (values.get(index) instanceof JSONObject) {
+            return values.get(index);
+        }
+        return OntologyProperty.convert(values, propertyDataType, index);
+    }
+
+    protected Graph getGraph() {
+        return graph;
+    }
+
+    public static class QueryAndData {
+        private final Query query;
+
+        public QueryAndData(Query query) {
+            this.query = query;
+        }
+
+        public Query getQuery() {
+            return query;
+        }
+    }
+}

--- a/core/core/src/main/java/org/visallo/core/model/search/ElementsSearchResults.java
+++ b/core/core/src/main/java/org/visallo/core/model/search/ElementsSearchResults.java
@@ -1,0 +1,12 @@
+package org.visallo.core.model.search;
+
+import org.vertexium.Element;
+
+public abstract class ElementsSearchResults extends SearchResults implements AutoCloseable {
+    @Override
+    public void close() throws Exception {
+
+    }
+
+    public abstract Iterable<? extends Element> getElements();
+}

--- a/core/core/src/main/java/org/visallo/core/model/search/QueryResultsIterableSearchResults.java
+++ b/core/core/src/main/java/org/visallo/core/model/search/QueryResultsIterableSearchResults.java
@@ -1,0 +1,49 @@
+package org.visallo.core.model.search;
+
+import org.vertexium.Element;
+import org.vertexium.query.QueryResultsIterable;
+
+public class QueryResultsIterableSearchResults extends ElementsSearchResults implements AutoCloseable {
+    private final QueryResultsIterable<? extends Element> searchResults;
+    private final ElementSearchRunnerBase.QueryAndData queryAndData;
+    private final long offset;
+    private final long size;
+
+    public QueryResultsIterableSearchResults(
+            QueryResultsIterable<? extends Element> searchResults,
+            ElementSearchRunnerBase.QueryAndData queryAndData,
+            long offset,
+            long size
+    ) {
+        this.searchResults = searchResults;
+        this.queryAndData = queryAndData;
+        this.offset = offset;
+        this.size = size;
+    }
+
+    public QueryResultsIterable<? extends Element> getQueryResultsIterable() {
+        return searchResults;
+    }
+
+    public ElementSearchRunnerBase.QueryAndData getQueryAndData() {
+        return queryAndData;
+    }
+
+    public long getOffset() {
+        return offset;
+    }
+
+    public long getSize() {
+        return size;
+    }
+
+    @Override
+    public void close() throws Exception {
+        this.searchResults.close();
+    }
+
+    @Override
+    public Iterable<? extends Element> getElements() {
+        return searchResults;
+    }
+}

--- a/core/core/src/main/java/org/visallo/core/model/search/SearchOptions.java
+++ b/core/core/src/main/java/org/visallo/core/model/search/SearchOptions.java
@@ -1,0 +1,70 @@
+package org.visallo.core.model.search;
+
+import org.json.JSONArray;
+import org.visallo.core.exception.VisalloException;
+
+import java.lang.reflect.Array;
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class SearchOptions {
+    private final Map<String, Object> parameters;
+    private final String workspaceId;
+
+    public SearchOptions(Map<String, Object> parameters, String workspaceId) {
+        this.parameters = parameters;
+        this.workspaceId = workspaceId;
+    }
+
+    public String getWorkspaceId() {
+        return workspaceId;
+    }
+
+    public <T> T getOptionalParameter(String parameterName, Class<T> resultType) {
+        Object obj = parameters.get(parameterName);
+        if (obj == null) {
+            return null;
+        }
+        try {
+            if (resultType.isArray() && !obj.getClass().isArray()) {
+                Object[] array = (Object[]) Array.newInstance(resultType.getComponentType(), 1);
+                array[0] = objectToType(obj, resultType.getComponentType());
+                return objectToType(array, resultType);
+            }
+            return objectToType(obj, resultType);
+        } catch (Exception ex) {
+            throw new VisalloException("Could not cast object \"" + obj + "\" to type \"" + resultType.getName() + "\"", ex);
+        }
+    }
+
+    private <T> T objectToType(Object obj, Class<T> resultType) {
+        if (resultType == Integer.class && obj instanceof String) {
+            return resultType.cast(Integer.parseInt((String) obj));
+        }
+        if (resultType == Double.class && obj instanceof String) {
+            return resultType.cast(Double.parseDouble((String) obj));
+        }
+        if (resultType == JSONArray.class && obj instanceof String) {
+            return resultType.cast(new JSONArray((String) obj));
+        }
+        return resultType.cast(obj);
+    }
+
+    public <T> T getOptionalParameter(String parameterName, T defaultValue) {
+        checkNotNull(defaultValue, "defaultValue cannot be null");
+        T obj = (T) getOptionalParameter(parameterName, defaultValue.getClass());
+        if (obj == null) {
+            return defaultValue;
+        }
+        return obj;
+    }
+
+    public <T> T getRequiredParameter(String parameterName, Class<T> resultType) {
+        T obj = getOptionalParameter(parameterName, resultType);
+        if (obj == null) {
+            throw new VisalloException("Missing parameter: " + parameterName);
+        }
+        return obj;
+    }
+}

--- a/core/core/src/main/java/org/visallo/core/model/search/SearchRepository.java
+++ b/core/core/src/main/java/org/visallo/core/model/search/SearchRepository.java
@@ -1,11 +1,21 @@
 package org.visallo.core.model.search;
 
 import org.json.JSONObject;
+import org.visallo.core.bootstrap.InjectHelper;
+import org.visallo.core.config.Configuration;
 import org.visallo.core.user.User;
 import org.visallo.web.clientapi.model.ClientApiSearch;
 import org.visallo.web.clientapi.model.ClientApiSearchListResponse;
 
+import java.util.Collection;
+
 public abstract class SearchRepository {
+    private final Collection<SearchRunner> searchRunners;
+
+    protected SearchRepository(Configuration configuration) {
+        searchRunners = InjectHelper.getInjectedServices(SearchRunner.class, configuration);
+    }
+
     public abstract String saveSearch(
             String id,
             String name,
@@ -27,4 +37,13 @@ public abstract class SearchRepository {
     public abstract ClientApiSearch getSavedSearch(String id, User user);
 
     public abstract void deleteSearch(String id, User user);
+
+    public SearchRunner findSearchRunnerByUri(String searchUri) {
+        for (SearchRunner searchRunner : searchRunners) {
+            if (searchRunner.getUri().equals(searchUri)) {
+                return searchRunner;
+            }
+        }
+        return null;
+    }
 }

--- a/core/core/src/main/java/org/visallo/core/model/search/SearchResults.java
+++ b/core/core/src/main/java/org/visallo/core/model/search/SearchResults.java
@@ -1,0 +1,4 @@
+package org.visallo.core.model.search;
+
+public class SearchResults {
+}

--- a/core/core/src/main/java/org/visallo/core/model/search/SearchRunner.java
+++ b/core/core/src/main/java/org/visallo/core/model/search/SearchRunner.java
@@ -1,0 +1,14 @@
+package org.visallo.core.model.search;
+
+import org.vertexium.Authorizations;
+import org.visallo.core.user.User;
+
+public abstract class SearchRunner {
+    public abstract String getUri();
+
+    public abstract SearchResults run(
+            SearchOptions searchOptions,
+            User user,
+            Authorizations authorizations
+    );
+}

--- a/core/core/src/main/java/org/visallo/core/model/search/VertexFindRelatedSearchResults.java
+++ b/core/core/src/main/java/org/visallo/core/model/search/VertexFindRelatedSearchResults.java
@@ -1,0 +1,22 @@
+package org.visallo.core.model.search;
+
+import org.vertexium.Element;
+
+public class VertexFindRelatedSearchResults extends ElementsSearchResults {
+    private final Iterable<? extends Element> elements;
+    private final long count;
+
+    public VertexFindRelatedSearchResults(Iterable<? extends Element> elements, long count) {
+        this.elements = elements;
+        this.count = count;
+    }
+
+    @Override
+    public Iterable<? extends Element> getElements() {
+        return elements;
+    }
+
+    public long getCount() {
+        return count;
+    }
+}

--- a/core/core/src/main/java/org/visallo/core/model/search/VertexFindRelatedSearchRunner.java
+++ b/core/core/src/main/java/org/visallo/core/model/search/VertexFindRelatedSearchRunner.java
@@ -1,0 +1,100 @@
+package org.visallo.core.model.search;
+
+import com.google.common.collect.Lists;
+import com.google.inject.Inject;
+import org.vertexium.*;
+import org.visallo.core.model.ontology.Concept;
+import org.visallo.core.model.ontology.OntologyRepository;
+import org.visallo.core.model.properties.VisalloProperties;
+import org.visallo.core.user.User;
+import org.visallo.core.util.ClientApiConverter;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class VertexFindRelatedSearchRunner extends SearchRunner {
+    public static final String URI = "/vertex/find-related";
+    private final OntologyRepository ontologyRepository;
+    private final Graph graph;
+
+    @Inject
+    public VertexFindRelatedSearchRunner(
+            Graph graph,
+            OntologyRepository ontologyRepository
+    ) {
+        this.graph = graph;
+        this.ontologyRepository = ontologyRepository;
+    }
+
+    @Override
+    public String getUri() {
+        return URI;
+    }
+
+    @Override
+    public VertexFindRelatedSearchResults run(SearchOptions searchOptions, User user, Authorizations authorizations) {
+        String[] graphVertexIds = searchOptions.getRequiredParameter("graphVertexIds[]", String[].class);
+        String limitParentConceptId = searchOptions.getOptionalParameter("limitParentConceptId", String.class);
+        String limitEdgeLabel = searchOptions.getOptionalParameter("limitEdgeLabel", String.class);
+        long maxVerticesToReturn = searchOptions.getOptionalParameter("maxVerticesToReturn", 250L);
+
+        Set<String> limitConceptIds = new HashSet<>();
+
+        if (limitParentConceptId != null) {
+            Set<Concept> limitConcepts = ontologyRepository.getConceptAndAllChildrenByIri(limitParentConceptId);
+            if (limitConcepts == null) {
+                throw new RuntimeException("Bad 'limitParentConceptId', no concept found for id: " +
+                        limitParentConceptId);
+            }
+            for (Concept con : limitConcepts) {
+                limitConceptIds.add(con.getIRI());
+            }
+        }
+
+        return getSearchResults(
+                searchOptions.getWorkspaceId(),
+                graphVertexIds,
+                limitEdgeLabel,
+                limitConceptIds,
+                maxVerticesToReturn,
+                authorizations
+        );
+    }
+
+    private VertexFindRelatedSearchResults getSearchResults(
+            String workspaceId,
+            String[] graphVertexIds,
+            String limitEdgeLabel,
+            Set<String> limitConceptIds,
+            long maxVerticesToReturn,
+            Authorizations authorizations
+    ) {
+        Set<String> visitedIds = new HashSet<>();
+        long count = visitedIds.size();
+        Iterable<Vertex> vertices = graph.getVertices(Lists.newArrayList(graphVertexIds), FetchHint.EDGE_REFS, authorizations);
+        List<Vertex> elements = new ArrayList<>();
+        for (Vertex v : vertices) {
+            Iterable<Vertex> relatedVertices = v.getVertices(Direction.BOTH, limitEdgeLabel, ClientApiConverter.SEARCH_FETCH_HINTS, authorizations);
+            for (Vertex vertex : relatedVertices) {
+                if (!visitedIds.add(vertex.getId())) {
+                    continue;
+                }
+                if (limitConceptIds.size() == 0 || !isLimited(vertex, limitConceptIds)) {
+                    if (count < maxVerticesToReturn) {
+                        elements.add(vertex);
+                    }
+                    count++;
+                }
+            }
+        }
+        return new VertexFindRelatedSearchResults(elements, count);
+    }
+
+    private boolean isLimited(Vertex vertex, Set<String> limitConceptIds) {
+        String conceptId = VisalloProperties.CONCEPT_TYPE.getPropertyValue(vertex);
+        return !limitConceptIds.contains(conceptId);
+    }
+}
+

--- a/core/core/src/main/java/org/visallo/core/model/search/VertexSearchRunner.java
+++ b/core/core/src/main/java/org/visallo/core/model/search/VertexSearchRunner.java
@@ -1,0 +1,34 @@
+package org.visallo.core.model.search;
+
+import com.google.inject.Inject;
+import org.vertexium.ElementType;
+import org.vertexium.Graph;
+import org.visallo.core.config.Configuration;
+import org.visallo.core.model.directory.DirectoryRepository;
+import org.visallo.core.model.ontology.OntologyRepository;
+
+import java.util.EnumSet;
+
+public class VertexSearchRunner extends ElementSearchRunnerWithRelatedBase {
+    public static final String URI = "/vertex/search";
+
+    @Inject
+    public VertexSearchRunner(
+            OntologyRepository ontologyRepository,
+            Graph graph,
+            Configuration configuration,
+            DirectoryRepository directoryRepository
+    ) {
+        super(ontologyRepository, graph, configuration, directoryRepository);
+    }
+
+    @Override
+    protected EnumSet<ElementType> getResultType() {
+        return EnumSet.of(ElementType.VERTEX);
+    }
+
+    @Override
+    public String getUri() {
+        return URI;
+    }
+}

--- a/core/core/src/main/resources/META-INF/services/org.visallo.core.model.search.SearchRunner
+++ b/core/core/src/main/resources/META-INF/services/org.visallo.core.model.search.SearchRunner
@@ -1,0 +1,3 @@
+org.visallo.core.model.search.VertexSearchRunner
+org.visallo.core.model.search.ElementSearchRunner
+org.visallo.core.model.search.EdgeSearchRunner

--- a/core/core/src/test/java/org/visallo/core/model/search/EdgeSearchRunnerTest.java
+++ b/core/core/src/test/java/org/visallo/core/model/search/EdgeSearchRunnerTest.java
@@ -1,0 +1,53 @@
+package org.visallo.core.model.search;
+
+import org.json.JSONArray;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.vertexium.Vertex;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.google.common.collect.Iterables.size;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(MockitoJUnitRunner.class)
+public class EdgeSearchRunnerTest extends SearchRunnerTestBase {
+    private EdgeSearchRunner edgeSearchRunner;
+
+    @Before
+    public void before() {
+        super.before();
+
+        edgeSearchRunner = new EdgeSearchRunner(
+                ontologyRepository,
+                graph,
+                configuration,
+                directoryRepository
+        );
+    }
+
+    @Test
+    public void testSearch() throws Exception {
+        Vertex v1 = graph.addVertex("v1", visibility, authorizations);
+        Vertex v2 = graph.addVertex("v2", visibility, authorizations);
+        Vertex v3 = graph.addVertex("v3", visibility, authorizations);
+        graph.prepareEdge("e1", v1, v2, "label1", visibility)
+                .addPropertyValue("k1", "name", "Joe", visibility)
+                .save(authorizations);
+        graph.prepareEdge("e2", v1, v3, "label1", visibility)
+                .addPropertyValue("k1", "name", "Bob", visibility)
+                .save(authorizations);
+        graph.flush();
+
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("q", "*");
+        parameters.put("filter", new JSONArray());
+        SearchOptions searchOptions = new SearchOptions(parameters, "workspace1");
+
+        QueryResultsIterableSearchResults results = edgeSearchRunner.run(searchOptions, user, authorizations);
+        assertEquals(2, size(results.getElements()));
+    }
+}

--- a/core/core/src/test/java/org/visallo/core/model/search/ElementSearchRunnerTest.java
+++ b/core/core/src/test/java/org/visallo/core/model/search/ElementSearchRunnerTest.java
@@ -1,0 +1,59 @@
+package org.visallo.core.model.search;
+
+import org.json.JSONArray;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.vertexium.Vertex;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.google.common.collect.Iterables.size;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ElementSearchRunnerTest extends SearchRunnerTestBase {
+    private ElementSearchRunner elementSearchRunner;
+
+    @Before
+    public void before() {
+        super.before();
+
+        elementSearchRunner = new ElementSearchRunner(
+                ontologyRepository,
+                graph,
+                configuration,
+                directoryRepository
+        );
+    }
+
+    @Test
+    public void testSearch() throws Exception {
+        Vertex v1 = graph.prepareVertex("v1", visibility)
+                .addPropertyValue("k1", "name", "Tom", visibility)
+                .save(authorizations);
+        Vertex v2 = graph.prepareVertex("v2", visibility)
+                .addPropertyValue("k1", "name", "Jack", visibility)
+                .save(authorizations);
+        Vertex v3 = graph.prepareVertex("v3", visibility)
+                .addPropertyValue("k1", "name", "Phil", visibility)
+                .save(authorizations);
+        graph.prepareEdge("e1", v1, v2, "label1", visibility)
+                .addPropertyValue("k1", "name", "Joe", visibility)
+                .save(authorizations);
+        graph.prepareEdge("e2", v1, v3, "label1", visibility)
+                .addPropertyValue("k1", "name", "Bob", visibility)
+                .save(authorizations);
+        graph.flush();
+
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("q", "*");
+        parameters.put("filter", new JSONArray());
+        SearchOptions searchOptions = new SearchOptions(parameters, "workspace1");
+
+        QueryResultsIterableSearchResults results = elementSearchRunner.run(searchOptions, user, authorizations);
+        assertEquals(5, size(results.getElements()));
+    }
+}

--- a/core/core/src/test/java/org/visallo/core/model/search/SearchRunnerTestBase.java
+++ b/core/core/src/test/java/org/visallo/core/model/search/SearchRunnerTestBase.java
@@ -1,0 +1,49 @@
+package org.visallo.core.model.search;
+
+import org.mockito.Mock;
+import org.vertexium.Authorizations;
+import org.vertexium.Graph;
+import org.vertexium.Visibility;
+import org.vertexium.inmemory.InMemoryGraph;
+import org.visallo.core.config.Configuration;
+import org.visallo.core.config.ConfigurationLoader;
+import org.visallo.core.config.HashMapConfigurationLoader;
+import org.visallo.core.model.directory.DirectoryRepository;
+import org.visallo.core.model.ontology.OntologyRepository;
+import org.visallo.core.user.User;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public abstract class SearchRunnerTestBase {
+    protected Visibility visibility;
+    protected Authorizations authorizations;
+    protected Graph graph;
+    protected Configuration configuration;
+
+    @Mock
+    protected DirectoryRepository directoryRepository;
+
+    @Mock
+    protected SearchRepository searchRepository;
+
+    @Mock
+    protected OntologyRepository ontologyRepository;
+
+    @Mock
+    protected User user;
+
+    public void before() {
+        Map config = new HashMap();
+        ConfigurationLoader hashMapConfigurationLoader = new HashMapConfigurationLoader(config);
+        configuration = new Configuration(hashMapConfigurationLoader, new HashMap<>());
+
+        graph = InMemoryGraph.create(getGraphConfiguration());
+        visibility = new Visibility("");
+        authorizations = graph.createAuthorizations("");
+    }
+
+    protected Map<String, Object> getGraphConfiguration() {
+        return new HashMap<>();
+    }
+}

--- a/core/core/src/test/java/org/visallo/core/model/search/VertexFindRelatedSearchRunnerTest.java
+++ b/core/core/src/test/java/org/visallo/core/model/search/VertexFindRelatedSearchRunnerTest.java
@@ -1,0 +1,48 @@
+package org.visallo.core.model.search;
+
+import org.json.JSONArray;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.vertexium.Vertex;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.google.common.collect.Iterables.size;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(MockitoJUnitRunner.class)
+public class VertexFindRelatedSearchRunnerTest extends SearchRunnerTestBase {
+    private VertexFindRelatedSearchRunner vertexFindRelatedSearchRunner;
+
+    @Before
+    public void before() {
+        super.before();
+
+        vertexFindRelatedSearchRunner = new VertexFindRelatedSearchRunner(
+                graph,
+                ontologyRepository
+        );
+    }
+
+    @Test
+    public void testSearch() throws Exception {
+        Vertex v1 = graph.prepareVertex("v1", visibility).save(authorizations);
+        Vertex v2 = graph.prepareVertex("v2", visibility).save(authorizations);
+        Vertex v3 = graph.prepareVertex("v3", visibility).save(authorizations);
+        graph.addEdge("e1", v1, v2, "label1", visibility, authorizations);
+        graph.addEdge("e2", v1, v3, "label1", visibility, authorizations);
+        graph.flush();
+
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("graphVertexIds[]", new String[]{"v1"});
+        parameters.put("q", "*");
+        parameters.put("filter", new JSONArray());
+        SearchOptions searchOptions = new SearchOptions(parameters, "workspace1");
+
+        VertexFindRelatedSearchResults results = vertexFindRelatedSearchRunner.run(searchOptions, user, authorizations);
+        assertEquals(2, size(results.getElements()));
+    }
+}

--- a/core/core/src/test/java/org/visallo/core/model/search/VertexSearchRunnerTest.java
+++ b/core/core/src/test/java/org/visallo/core/model/search/VertexSearchRunnerTest.java
@@ -1,0 +1,76 @@
+package org.visallo.core.model.search;
+
+import org.json.JSONArray;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.vertexium.ElementBuilder;
+import org.vertexium.Vertex;
+import org.visallo.core.model.properties.VisalloProperties;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.google.common.collect.Iterables.size;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(MockitoJUnitRunner.class)
+public class VertexSearchRunnerTest extends SearchRunnerTestBase {
+    private VertexSearchRunner vertexSearchRunner;
+
+    @Before
+    public void before() {
+        super.before();
+
+        vertexSearchRunner = new VertexSearchRunner(
+                ontologyRepository,
+                graph,
+                configuration,
+                directoryRepository
+        );
+    }
+
+    @Test
+    public void testSearchRelated() throws Exception {
+        ElementBuilder<Vertex> v1Mutation = graph.prepareVertex("v1", visibility);
+        ElementBuilder<Vertex> v2Mutation = graph.prepareVertex("v2", visibility);
+        ElementBuilder<Vertex> v3Mutation = graph.prepareVertex("v3", visibility);
+        VisalloProperties.CONCEPT_TYPE.setProperty(v1Mutation, "testConcept", visibility);
+        VisalloProperties.CONCEPT_TYPE.setProperty(v2Mutation, "testConcept", visibility);
+        VisalloProperties.CONCEPT_TYPE.setProperty(v3Mutation, "testConcept", visibility);
+        Vertex v1 = v1Mutation.save(authorizations);
+        Vertex v2 = v2Mutation.save(authorizations);
+        Vertex v3 = v3Mutation.save(authorizations);
+        graph.addEdge("e1", v1, v2, "label1", visibility, authorizations);
+        graph.addEdge("e2", v1, v3, "label1", visibility, authorizations);
+        graph.flush();
+
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("relatedToVertexIds[]", new String[]{"v1"});
+        parameters.put("filter", new JSONArray());
+        SearchOptions searchOptions = new SearchOptions(parameters, "workspace1");
+
+        QueryResultsIterableSearchResults results = vertexSearchRunner.run(searchOptions, user, authorizations);
+        assertEquals(2, size(results.getElements()));
+    }
+
+    @Test
+    public void testSearch() throws Exception {
+        graph.prepareVertex("v1", visibility)
+                .addPropertyValue("k1", "name", "Joe", visibility)
+                .save(authorizations);
+        graph.prepareVertex("v2", visibility)
+                .addPropertyValue("k1", "name", "Bob", visibility)
+                .save(authorizations);
+        graph.flush();
+
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("q", "*");
+        parameters.put("filter", new JSONArray());
+        SearchOptions searchOptions = new SearchOptions(parameters, "workspace1");
+
+        QueryResultsIterableSearchResults results = vertexSearchRunner.run(searchOptions, user, authorizations);
+        assertEquals(2, size(results.getElements()));
+    }
+}

--- a/core/plugins/model-vertexium/src/main/java/org/visallo/vertexium/model/search/VertexiumSearchRepository.java
+++ b/core/plugins/model-vertexium/src/main/java/org/visallo/vertexium/model/search/VertexiumSearchRepository.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
 import org.json.JSONObject;
 import org.vertexium.*;
+import org.visallo.core.config.Configuration;
 import org.visallo.core.exception.VisalloAccessDeniedException;
 import org.visallo.core.model.properties.VisalloProperties;
 import org.visallo.core.model.search.SearchProperties;
@@ -18,7 +19,6 @@ import org.visallo.web.clientapi.model.ClientApiSearchListResponse;
 import org.visallo.web.clientapi.model.Privilege;
 
 import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.visallo.core.util.StreamUtil.stream;
@@ -34,8 +34,10 @@ public class VertexiumSearchRepository extends SearchRepository {
     public VertexiumSearchRepository(
             Graph graph,
             UserRepository userRepository,
+            Configuration configuration,
             AuthorizationRepository authorizationRepository
     ) {
+        super(configuration);
         this.graph = graph;
         this.userRepository = userRepository;
         authorizationRepository.addAuthorizationToGraph(VISIBILITY_STRING);

--- a/core/plugins/model-vertexium/src/test/java/org/visallo/vertexium/model/search/VertexiumSearchRepositoryTest.java
+++ b/core/plugins/model-vertexium/src/test/java/org/visallo/vertexium/model/search/VertexiumSearchRepositoryTest.java
@@ -1,5 +1,6 @@
 package org.visallo.vertexium.model.search;
 
+import com.google.inject.Injector;
 import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
@@ -8,6 +9,8 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.vertexium.*;
 import org.vertexium.inmemory.InMemoryGraph;
+import org.visallo.core.bootstrap.InjectHelper;
+import org.visallo.core.config.Configuration;
 import org.visallo.core.exception.VisalloException;
 import org.visallo.core.model.properties.VisalloProperties;
 import org.visallo.core.model.search.SearchProperties;
@@ -30,6 +33,7 @@ public class VertexiumSearchRepositoryTest {
     private VertexiumSearchRepository searchRepository;
     private InMemoryGraph graph;
     private Authorizations authorizations;
+    private String userId;
 
     @Mock
     private UserRepository userRepository;
@@ -38,17 +42,24 @@ public class VertexiumSearchRepositoryTest {
     private AuthorizationRepository authorizationRepository;
 
     @Mock
+    private Configuration configuration;
+
+    @Mock
     private User user;
-    private String userId;
+
+    @Mock
+    private Injector injector;
 
     @Mock
     private User systemUser;
 
     @Before
     public void setUp() {
+        InjectHelper.setInjector(injector);
+
         graph = InMemoryGraph.create();
         authorizations = graph.createAuthorizations(VertexiumSearchRepository.VISIBILITY_STRING, UserRepository.VISIBILITY_STRING);
-        searchRepository = new VertexiumSearchRepository(graph, userRepository, authorizationRepository);
+        searchRepository = new VertexiumSearchRepository(graph, userRepository, configuration, authorizationRepository);
 
         userId = "USER123";
         when(user.getUserId()).thenReturn(userId);

--- a/root/pom.xml
+++ b/root/pom.xml
@@ -814,6 +814,13 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>${plugin.maven.jar.version}</version>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>test-jar</goal>
+                            </goals>
+                        </execution>
+                    </executions>
                     <configuration>
                         <archive>
                             <manifest>

--- a/web/web-base/src/main/java/org/visallo/web/routes/edge/EdgeSearch.java
+++ b/web/web-base/src/main/java/org/visallo/web/routes/edge/EdgeSearch.java
@@ -2,45 +2,14 @@ package org.visallo.web.routes.edge;
 
 import com.google.inject.Inject;
 import com.v5analytics.webster.ParameterizedHandler;
-import com.v5analytics.webster.annotations.Handle;
-import org.vertexium.Authorizations;
-import org.vertexium.ElementType;
-import org.vertexium.Graph;
-import org.visallo.core.config.Configuration;
-import org.visallo.core.model.directory.DirectoryRepository;
-import org.visallo.core.model.ontology.OntologyRepository;
-import org.visallo.core.user.User;
-import org.visallo.web.clientapi.model.ClientApiElementSearchResponse;
-import org.visallo.web.parameterProviders.ActiveWorkspaceId;
-import org.visallo.web.routes.vertex.ElementSearchWithRelatedBase;
+import org.visallo.core.model.search.EdgeSearchRunner;
+import org.visallo.core.model.search.ElementSearchRunnerBase;
+import org.visallo.core.model.search.SearchRepository;
+import org.visallo.web.routes.vertex.ElementSearchBase;
 
-import javax.servlet.http.HttpServletRequest;
-import java.util.EnumSet;
-
-public class EdgeSearch extends ElementSearchWithRelatedBase implements ParameterizedHandler {
+public class EdgeSearch extends ElementSearchBase implements ParameterizedHandler {
     @Inject
-    public EdgeSearch(
-            OntologyRepository ontologyRepository,
-            Graph graph,
-            Configuration configuration,
-            DirectoryRepository directoryRepository
-    ) {
-        super(ontologyRepository, graph, configuration, directoryRepository);
-    }
-
-    @Override
-    @Handle
-    public ClientApiElementSearchResponse handle(
-            HttpServletRequest request,
-            @ActiveWorkspaceId String workspaceId,
-            User user,
-            Authorizations authorizations
-    ) throws Exception {
-        return super.handle(request, workspaceId, user, authorizations);
-    }
-
-    @Override
-    protected EnumSet<ElementType> getResultType() {
-        return EnumSet.of(ElementType.EDGE);
+    public EdgeSearch(SearchRepository searchRepository) {
+        super((ElementSearchRunnerBase) searchRepository.findSearchRunnerByUri(EdgeSearchRunner.URI));
     }
 }

--- a/web/web-base/src/main/java/org/visallo/web/routes/element/ElementSearch.java
+++ b/web/web-base/src/main/java/org/visallo/web/routes/element/ElementSearch.java
@@ -2,67 +2,14 @@ package org.visallo.web.routes.element;
 
 import com.google.inject.Inject;
 import com.v5analytics.webster.ParameterizedHandler;
-import com.v5analytics.webster.annotations.Handle;
-import org.json.JSONArray;
-import org.vertexium.Authorizations;
-import org.vertexium.ElementType;
-import org.vertexium.Graph;
-import org.vertexium.query.Query;
-import org.visallo.core.config.Configuration;
-import org.visallo.core.model.directory.DirectoryRepository;
-import org.visallo.core.model.ontology.OntologyRepository;
-import org.visallo.core.user.User;
-import org.visallo.core.util.VisalloLogger;
-import org.visallo.core.util.VisalloLoggerFactory;
-import org.visallo.web.clientapi.model.ClientApiElementSearchResponse;
-import org.visallo.web.parameterProviders.ActiveWorkspaceId;
-import org.visallo.web.parameterProviders.VisalloBaseParameterProvider;
+import org.visallo.core.model.search.ElementSearchRunner;
+import org.visallo.core.model.search.ElementSearchRunnerBase;
+import org.visallo.core.model.search.SearchRepository;
 import org.visallo.web.routes.vertex.ElementSearchBase;
 
-import javax.servlet.http.HttpServletRequest;
-import java.util.EnumSet;
-
 public class ElementSearch extends ElementSearchBase implements ParameterizedHandler {
-    private static final VisalloLogger LOGGER = VisalloLoggerFactory.getLogger(ElementSearch.class);
-
     @Inject
-    public ElementSearch(
-            OntologyRepository ontologyRepository,
-            Graph graph,
-            Configuration configuration,
-            DirectoryRepository directoryRepository
-    ) {
-        super(ontologyRepository, graph, configuration, directoryRepository);
-    }
-
-    @Override
-    protected EnumSet<ElementType> getResultType() {
-        return EnumSet.of(ElementType.EDGE, ElementType.VERTEX);
-    }
-
-    @Override
-    @Handle
-    public ClientApiElementSearchResponse handle(
-            HttpServletRequest request,
-            @ActiveWorkspaceId String workspaceId,
-            User user,
-            Authorizations authorizations
-    ) throws Exception {
-        return super.handle(request, workspaceId, user, authorizations);
-    }
-
-    @Override
-    protected QueryAndData getQuery(HttpServletRequest request, final Authorizations authorizations) {
-        final JSONArray filterJson = getFilterJson(request);
-        final String queryString = VisalloBaseParameterProvider.getRequiredParameter(request, "q");
-        LOGGER.debug("search %s\n%s", queryString, filterJson.toString(2));
-
-        Query graphQuery = query(queryString, authorizations);
-
-        return new QueryAndData(graphQuery);
-    }
-
-    private Query query(String query, Authorizations authorizations) {
-        return getGraph().query(query, authorizations);
+    public ElementSearch(SearchRepository searchRepository) {
+        super((ElementSearchRunnerBase) searchRepository.findSearchRunnerByUri(ElementSearchRunner.URI));
     }
 }

--- a/web/web-base/src/main/java/org/visallo/web/routes/search/WebSearchOptionsFactory.java
+++ b/web/web-base/src/main/java/org/visallo/web/routes/search/WebSearchOptionsFactory.java
@@ -1,0 +1,42 @@
+package org.visallo.web.routes.search;
+
+import org.visallo.core.model.search.SearchOptions;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+
+public class WebSearchOptionsFactory {
+    public static SearchOptions create(HttpServletRequest request, String workspaceId) {
+        Map<String, Object> parameters = new HashMap<>();
+        copyRequestAttributesToParameters(request, parameters);
+        copyRequestParametersToParameters(request, parameters);
+        return new SearchOptions(parameters, workspaceId);
+    }
+
+    private static void copyRequestParametersToParameters(HttpServletRequest request, Map<String, Object> parameters) {
+        Map<String, String[]> requestParameters = request.getParameterMap();
+        for (Map.Entry<String, String[]> requestParameter : requestParameters.entrySet()) {
+            String[] requestParameterValues = requestParameter.getValue();
+            Object value;
+            if (requestParameterValues.length == 0) {
+                value = null;
+            } else if (requestParameterValues.length == 1) {
+                value = requestParameterValues[0];
+            } else {
+                value = requestParameterValues;
+            }
+            parameters.put(requestParameter.getKey(), value);
+        }
+    }
+
+    private static void copyRequestAttributesToParameters(HttpServletRequest request, Map<String, Object> parameters) {
+        Enumeration<String> attributeNames = request.getAttributeNames();
+        while (attributeNames.hasMoreElements()) {
+            String attributeName = attributeNames.nextElement();
+            Object attributeValue = request.getAttribute(attributeName);
+            parameters.put(attributeName, attributeValue);
+        }
+    }
+}

--- a/web/web-base/src/main/java/org/visallo/web/routes/vertex/ElementSearchBase.java
+++ b/web/web-base/src/main/java/org/visallo/web/routes/vertex/ElementSearchBase.java
@@ -1,24 +1,24 @@
 package org.visallo.web.routes.vertex;
 
-import com.google.inject.Inject;
-import org.json.JSONArray;
-import org.json.JSONObject;
-import org.vertexium.*;
+import com.v5analytics.webster.annotations.Handle;
+import org.vertexium.Authorizations;
+import org.vertexium.Edge;
+import org.vertexium.Element;
+import org.vertexium.Vertex;
 import org.vertexium.query.*;
-import org.visallo.core.config.Configuration;
 import org.visallo.core.exception.VisalloException;
-import org.visallo.core.model.directory.DirectoryRepository;
-import org.visallo.core.model.ontology.OntologyProperty;
-import org.visallo.core.model.ontology.OntologyRepository;
-import org.visallo.core.trace.Trace;
-import org.visallo.core.trace.TraceSpan;
+import org.visallo.core.model.search.QueryResultsIterableSearchResults;
+import org.visallo.core.model.search.ElementSearchRunnerBase;
+import org.visallo.core.model.search.SearchOptions;
 import org.visallo.core.user.User;
 import org.visallo.core.util.ClientApiConverter;
-import org.visallo.core.util.JSONUtil;
 import org.visallo.core.util.VisalloLogger;
 import org.visallo.core.util.VisalloLoggerFactory;
-import org.visallo.web.clientapi.model.*;
-import org.visallo.web.parameterProviders.VisalloBaseParameterProvider;
+import org.visallo.web.clientapi.model.ClientApiElement;
+import org.visallo.web.clientapi.model.ClientApiElementSearchResponse;
+import org.visallo.web.clientapi.model.ClientApiSearchResponse;
+import org.visallo.web.parameterProviders.ActiveWorkspaceId;
+import org.visallo.web.routes.search.WebSearchOptionsFactory;
 
 import javax.servlet.http.HttpServletRequest;
 import java.text.DateFormat;
@@ -27,82 +27,56 @@ import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.regex.Pattern;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 public abstract class ElementSearchBase {
     private static final VisalloLogger LOGGER = VisalloLoggerFactory.getLogger(ElementSearchBase.class);
-    private static final Pattern dateTimePattern = Pattern.compile("^\\d{4}-\\d{2}-\\d{2}T.*");
-    private final Graph graph;
-    private final DirectoryRepository directoryRepository;
-    private final OntologyRepository ontologyRepository;
-    private int defaultSearchResultCount;
+    private static final Pattern DATE_TIME_PATTERN = Pattern.compile("^\\d{4}-\\d{2}-\\d{2}T.*");
+    private final ElementSearchRunnerBase searchRunner;
 
-    @Inject
-    public ElementSearchBase(
-            OntologyRepository ontologyRepository,
-            Graph graph,
-            Configuration configuration,
-            DirectoryRepository directoryRepository
-    ) {
-        this.ontologyRepository = ontologyRepository;
-        this.graph = graph;
-        this.directoryRepository = directoryRepository;
-        defaultSearchResultCount = configuration.getInt(Configuration.DEFAULT_SEARCH_RESULT_COUNT, 100);
+    public ElementSearchBase(ElementSearchRunnerBase searchRunner) {
+        checkNotNull(searchRunner, "searchRunner is required");
+        this.searchRunner = searchRunner;
     }
 
-    protected ClientApiElementSearchResponse handle(
+    @Handle
+    public ClientApiElementSearchResponse handle(
             HttpServletRequest request,
-            String workspaceId,
+            @ActiveWorkspaceId String workspaceId,
             User user,
             Authorizations authorizations
     ) throws Exception {
-        long totalStartTime = System.nanoTime();
+        SearchOptions searchOptions = WebSearchOptionsFactory.create(request, workspaceId);
+        try (QueryResultsIterableSearchResults searchResults = this.searchRunner.run(searchOptions, user, authorizations)) {
+            Map<String, Double> scores = null;
+            if (searchResults.getQueryResultsIterable() instanceof IterableWithScores) {
+                scores = ((IterableWithScores<?>) searchResults.getQueryResultsIterable()).getScores();
+            }
 
-        long startTime = System.nanoTime();
+            List<ClientApiElement> elementList = convertElementsToClientApi(
+                    searchResults.getQueryAndData(),
+                    searchResults.getQueryResultsIterable(),
+                    scores,
+                    searchOptions.getWorkspaceId(),
+                    authorizations
+            );
 
-        JSONArray filterJson = getFilterJson(request);
+            ClientApiElementSearchResponse results = new ClientApiElementSearchResponse();
+            results.getElements().addAll(elementList);
+            results.setNextOffset((int) (searchResults.getOffset() + searchResults.getSize()));
 
-        QueryAndData queryAndData = getQuery(request, authorizations);
-        applyFiltersToQuery(queryAndData, filterJson, user);
-        applyConceptTypeFilterToQuery(queryAndData, request);
-        applyEdgeLabelFilterToQuery(queryAndData, request);
-        applySortToQuery(queryAndData, request);
-        applyAggregationsToQuery(queryAndData, request);
+            addSearchResultsDataToResults(results, searchResults.getQueryAndData(), searchResults.getQueryResultsIterable());
 
-        EnumSet<FetchHint> fetchHints = VisalloBaseParameterProvider.getOptionalParameterFetchHints(request, "fetchHints", ClientApiConverter.SEARCH_FETCH_HINTS);
-        final int offset = VisalloBaseParameterProvider.getOptionalParameterInt(request, "offset", 0);
-        final int size = VisalloBaseParameterProvider.getOptionalParameterInt(request, "size", defaultSearchResultCount);
-        queryAndData.getQuery().limit(size);
-        queryAndData.getQuery().skip(offset);
-
-        QueryResultsIterable<? extends Element> searchResults = getSearchResults(queryAndData, fetchHints);
-
-        Map<String, Double> scores = null;
-        if (searchResults instanceof IterableWithScores) {
-            scores = ((IterableWithScores<?>) searchResults).getScores();
+            return results;
         }
-
-        long retrievalStartTime = System.nanoTime();
-        List<ClientApiElement> elementList = convertElementsToClientApi(queryAndData, searchResults, scores, workspaceId, authorizations);
-        long retrievalEndTime = System.nanoTime();
-
-        long totalEndTime = System.nanoTime();
-
-        ClientApiElementSearchResponse results = new ClientApiElementSearchResponse();
-        results.getElements().addAll(elementList);
-        results.setNextOffset(offset + size);
-        results.setRetrievalTime(retrievalEndTime - retrievalStartTime);
-        results.setTotalTime(totalEndTime - totalStartTime);
-
-        addSearchResultsDataToResults(results, queryAndData, searchResults);
-
-        long endTime = System.nanoTime();
-        LOGGER.info("Search found %d vertices in %dms", elementList.size(), (endTime - startTime) / 1000 / 1000);
-
-        searchResults.close();
-
-        return results;
     }
 
-    private void addSearchResultsDataToResults(ClientApiElementSearchResponse results, QueryAndData queryAndData, QueryResultsIterable<? extends Element> searchResults) {
+
+    private void addSearchResultsDataToResults(
+            ClientApiElementSearchResponse results,
+            ElementSearchRunnerBase.QueryAndData queryAndData,
+            QueryResultsIterable<? extends Element> searchResults
+    ) {
         results.setTotalHits(searchResults.getTotalHits());
 
         if (searchResults instanceof IterableWithSearchTime) {
@@ -177,7 +151,7 @@ public abstract class ElementSearchBase {
                     toClientApiNestedResults(histogramBucket.getNestedResults())
             );
             String key = histogramBucket.getKey().toString();
-            if (dateTimePattern.matcher(key).matches()) {
+            if (DATE_TIME_PATTERN.matcher(key).matches()) {
                 try {
                     Date date = bucketDateFormat.parse(key);
                     if (date != null) {
@@ -219,84 +193,8 @@ public abstract class ElementSearchBase {
         return result;
     }
 
-    private void applyAggregationsToQuery(QueryAndData queryAndData, HttpServletRequest request) {
-        Query query = queryAndData.getQuery();
-        String[] aggregates = VisalloBaseParameterProvider.getOptionalParameterAsStringArray(request, "aggregations[]");
-        if (aggregates == null) {
-            return;
-        }
-        for (String aggregate : aggregates) {
-            JSONObject aggregateJson = new JSONObject(aggregate);
-            Aggregation aggregation = getAggregation(aggregateJson);
-            query.addAggregation(aggregation);
-        }
-    }
-
-    private Aggregation getAggregation(JSONObject aggregateJson) {
-        String field;
-        String aggregationName = aggregateJson.getString("name");
-        String type = aggregateJson.getString("type");
-        Aggregation aggregation;
-        switch (type) {
-            case "term":
-                field = aggregateJson.getString("field");
-                aggregation = new TermsAggregation(aggregationName, field);
-                break;
-            case "geohash":
-                field = aggregateJson.getString("field");
-                int precision = aggregateJson.getInt("precision");
-                aggregation = new GeohashAggregation(aggregationName, field, precision);
-                break;
-            case "histogram":
-                field = aggregateJson.getString("field");
-                String interval = aggregateJson.getString("interval");
-                Long minDocumentCount = JSONUtil.getOptionalLong(aggregateJson, "minDocumentCount");
-                aggregation = new HistogramAggregation(aggregationName, field, interval, minDocumentCount);
-                break;
-            case "statistics":
-                field = aggregateJson.getString("field");
-                aggregation = new StatisticsAggregation(aggregationName, field);
-                break;
-            default:
-                throw new VisalloException("Invalid aggregation type: " + type);
-        }
-
-        JSONArray nestedAggregates = aggregateJson.optJSONArray("nested");
-        if (nestedAggregates != null && nestedAggregates.length() > 0) {
-            if (!(aggregation instanceof SupportsNestedAggregationsAggregation)) {
-                throw new VisalloException("Aggregation does not support nesting: " + aggregation.getClass().getName());
-            }
-            for (int i = 0; i < nestedAggregates.length(); i++) {
-                JSONObject nestedAggregateJson = nestedAggregates.getJSONObject(i);
-                Aggregation nestedAggregate = getAggregation(nestedAggregateJson);
-                ((SupportsNestedAggregationsAggregation) aggregation).addNestedAggregation(nestedAggregate);
-            }
-        }
-
-        return aggregation;
-    }
-
-    protected void applySortToQuery(QueryAndData queryAndData, HttpServletRequest request) {
-        String[] sorts = VisalloBaseParameterProvider.getOptionalParameterAsStringArray(request, "sort[]");
-        if (sorts == null) {
-            return;
-        }
-        for (String sort : sorts) {
-            String propertyName = sort;
-            SortDirection direction = SortDirection.ASCENDING;
-            if (propertyName.toUpperCase().endsWith(":ASCENDING")) {
-                direction = SortDirection.ASCENDING;
-                propertyName = propertyName.substring(0, propertyName.length() - ":ASCENDING".length());
-            } else if (propertyName.toUpperCase().endsWith(":DESCENDING")) {
-                direction = SortDirection.DESCENDING;
-                propertyName = propertyName.substring(0, propertyName.length() - ":DESCENDING".length());
-            }
-            queryAndData.getQuery().sort(propertyName, direction);
-        }
-    }
-
     protected List<ClientApiElement> convertElementsToClientApi(
-            QueryAndData queryAndData,
+            ElementSearchRunnerBase.QueryAndData queryAndData,
             Iterable<? extends Element> searchResults,
             Map<String, Double> scores,
             String workspaceId,
@@ -321,232 +219,7 @@ public abstract class ElementSearchBase {
         return elementsList;
     }
 
-    protected QueryResultsIterable<? extends Element> getSearchResults(QueryAndData queryAndData, EnumSet<FetchHint> fetchHints) {
-        //noinspection unused
-        try (TraceSpan trace = Trace.start("getSearchResults")) {
-            if (getResultType().contains(ElementType.VERTEX) && getResultType().contains(ElementType.EDGE)) {
-                return queryAndData.getQuery().elements(fetchHints);
-            } else if (getResultType().contains(ElementType.VERTEX)) {
-                return queryAndData.getQuery().vertices(fetchHints);
-            } else if (getResultType().contains(ElementType.EDGE)) {
-                return queryAndData.getQuery().edges(fetchHints);
-            } else {
-                throw new VisalloException("Unexpected result type: " + getResultType());
-            }
-        }
-    }
-
-    protected abstract EnumSet<ElementType> getResultType();
-
-    protected Integer getCommonCount(QueryAndData queryAndData, Element element) {
+    protected Integer getCommonCount(ElementSearchRunnerBase.QueryAndData queryAndData, Element element) {
         return null;
-    }
-
-    protected abstract QueryAndData getQuery(HttpServletRequest request, Authorizations authorizations);
-
-    protected void applyConceptTypeFilterToQuery(QueryAndData queryAndData, HttpServletRequest request) {
-        final String conceptType = VisalloBaseParameterProvider.getOptionalParameter(request, "conceptType");
-        final String includeChildNodes = VisalloBaseParameterProvider.getOptionalParameter(request, "includeChildNodes");
-        Query query = queryAndData.getQuery();
-        if (conceptType != null) {
-            boolean includeChildNodesBoolean = includeChildNodes == null || !includeChildNodes.equals("false");
-            ontologyRepository.addConceptTypeFilterToQuery(query, conceptType, includeChildNodesBoolean);
-        }
-    }
-
-    protected void applyEdgeLabelFilterToQuery(QueryAndData queryAndData, HttpServletRequest request) {
-        final String edgeLabel = VisalloBaseParameterProvider.getOptionalParameter(request, "edgeLabel");
-        final String includeChildNodes = VisalloBaseParameterProvider.getOptionalParameter(request, "includeChildNodes");
-        Query query = queryAndData.getQuery();
-        if (edgeLabel != null) {
-            boolean includeChildNodesBoolean = includeChildNodes == null || !includeChildNodes.equals("false");
-            ontologyRepository.addEdgeLabelFilterToQuery(query, edgeLabel, includeChildNodesBoolean);
-        }
-    }
-
-    protected void applyFiltersToQuery(QueryAndData queryAndData, JSONArray filterJson, User user) throws ParseException {
-        for (int i = 0; i < filterJson.length(); i++) {
-            JSONObject obj = filterJson.getJSONObject(i);
-            if (obj.length() > 0) {
-                updateQueryWithFilter(queryAndData.getQuery(), obj, user);
-            }
-        }
-    }
-
-    protected JSONArray getFilterJson(HttpServletRequest request) {
-        final String filter = VisalloBaseParameterProvider.getRequiredParameter(request, "filter");
-        JSONArray filterJson = new JSONArray(filter);
-        ontologyRepository.resolvePropertyIds(filterJson);
-        return filterJson;
-    }
-
-    private void updateQueryWithFilter(Query graphQuery, JSONObject obj, User user) throws ParseException {
-        String predicateString = obj.optString("predicate");
-        String propertyName = obj.getString("propertyName");
-        if ("has".equals(predicateString)) {
-            graphQuery.has(propertyName);
-        } else if ("hasNot".equals(predicateString)) {
-            graphQuery.hasNot(propertyName);
-        } else if ("in".equals(predicateString)) {
-            graphQuery.has(propertyName, Contains.IN, JSONUtil.toList(obj.getJSONArray("values")));
-        } else {
-            PropertyType propertyDataType = PropertyType.convert(obj.optString("propertyDataType"));
-            JSONArray values = obj.getJSONArray("values");
-            Object value0 = jsonValueToObject(values, propertyDataType, 0);
-
-            if (PropertyType.STRING.equals(propertyDataType) && (predicateString == null || "~".equals(predicateString) || "".equals(predicateString))) {
-                graphQuery.has(propertyName, TextPredicate.CONTAINS, value0);
-            } else if (PropertyType.DATE.equals(propertyDataType)) {
-                applyDateToQuery(graphQuery, obj, predicateString, values);
-            } else if (PropertyType.BOOLEAN.equals(propertyDataType)) {
-                graphQuery.has(propertyName, Compare.EQUAL, value0);
-            } else if (PropertyType.GEO_LOCATION.equals(propertyDataType)) {
-                graphQuery.has(propertyName, GeoCompare.WITHIN, value0);
-            } else if ("<".equals(predicateString)) {
-                graphQuery.has(propertyName, Compare.LESS_THAN, value0);
-            } else if (">".equals(predicateString)) {
-                graphQuery.has(propertyName, Compare.GREATER_THAN, value0);
-            } else if ("range".equals(predicateString)) {
-                graphQuery.has(propertyName, Compare.GREATER_THAN_EQUAL, value0);
-                graphQuery.has(propertyName, Compare.LESS_THAN_EQUAL, jsonValueToObject(values, propertyDataType, 1));
-            } else if ("=".equals(predicateString) || "equal".equals(predicateString)) {
-                if (PropertyType.DIRECTORY_ENTITY.equals(propertyDataType) && value0 instanceof JSONObject) {
-                    applyDirectoryEntityJsonObjectEqualityToQuery(graphQuery, propertyName, (JSONObject) value0, user);
-                } else if (PropertyType.DOUBLE.equals(propertyDataType)) {
-                    applyDoubleEqualityToQuery(graphQuery, obj, value0);
-                } else {
-                    graphQuery.has(propertyName, Compare.EQUAL, value0);
-                }
-            } else {
-                throw new VisalloException("unhandled query\n" + obj.toString(2));
-            }
-        }
-    }
-
-    private void applyDirectoryEntityJsonObjectEqualityToQuery(Query graphQuery, String propertyName, JSONObject value0, User user) {
-        String directoryEntityId = value0.optString("directoryEntityId", null);
-        if (directoryEntityId != null) {
-            graphQuery.has(propertyName, Compare.EQUAL, directoryEntityId);
-        } else if (value0.optBoolean("currentUser", false)) {
-            directoryEntityId = directoryRepository.getDirectoryEntityId(user);
-            graphQuery.has(propertyName, Compare.EQUAL, directoryEntityId);
-        } else {
-            throw new VisalloException("Invalid directory entity JSONObject filter:\n" + value0.toString(2));
-        }
-    }
-
-    private void applyDoubleEqualityToQuery(Query graphQuery, JSONObject obj, Object value0) throws ParseException {
-        String propertyName = obj.getString("propertyName");
-        JSONObject metadata = obj.has("metadata") ? obj.getJSONObject("metadata") : null;
-
-        if (metadata != null && metadata.has("http://visallo.org#inputPrecision") && value0 instanceof Double) {
-            double doubleParam = (double) value0;
-            double buffer = Math.pow(10, -(Math.abs(metadata.getInt("http://visallo.org#inputPrecision")) + 1)) * 5;
-
-            graphQuery.has(propertyName, Compare.GREATER_THAN, doubleParam - buffer);
-            graphQuery.has(propertyName, Compare.LESS_THAN, doubleParam + buffer);
-        } else {
-            graphQuery.has(propertyName, Compare.EQUAL, value0);
-        }
-    }
-
-    private void applyDateToQuery(Query graphQuery, JSONObject obj, String predicate, JSONArray values) throws ParseException {
-        String propertyName = obj.getString("propertyName");
-        PropertyType propertyDataType = PropertyType.DATE;
-        OntologyProperty property = ontologyRepository.getPropertyByIRI(propertyName);
-
-        if (property != null && values.length() > 0) {
-            String displayType = property.getDisplayType();
-            boolean isDateOnly = displayType != null && displayType.equals("dateOnly");
-            boolean isRelative = values.get(0) instanceof JSONObject;
-
-            Calendar calendar = new GregorianCalendar();
-            calendar.setTimeZone(TimeZone.getTimeZone("UTC"));
-
-            if (isRelative) {
-                JSONObject fromNow = (JSONObject) values.get(0);
-                calendar.setTime(new Date());
-                moveDateToStart(calendar, isDateOnly);
-                //noinspection MagicConstant
-                calendar.add(fromNow.getInt("unit"), fromNow.getInt("amount"));
-            } else {
-                Date date0 = (Date) jsonValueToObject(values, propertyDataType, 0);
-                calendar.setTime(date0);
-            }
-
-            if (predicate == null || predicate.equals("equal") || predicate.equals("=")) {
-                moveDateToStart(calendar, isDateOnly);
-                graphQuery.has(propertyName, Compare.GREATER_THAN_EQUAL, calendar.getTime());
-
-                moveDateToEnd(calendar, isDateOnly);
-                graphQuery.has(propertyName, Compare.LESS_THAN, calendar.getTime());
-            } else if (predicate.equals("range")) {
-                if (!isRelative) {
-                    moveDateToStart(calendar, isDateOnly);
-                }
-                graphQuery.has(propertyName, Compare.GREATER_THAN_EQUAL, calendar.getTime());
-
-                if (values.get(1) instanceof JSONObject) {
-                    JSONObject fromNow = (JSONObject) values.get(1);
-                    calendar.setTime(new Date());
-                    moveDateToStart(calendar, isDateOnly);
-                    //noinspection MagicConstant
-                    calendar.add(fromNow.getInt("unit"), fromNow.getInt("amount"));
-                    moveDateToEnd(calendar, isDateOnly);
-                    graphQuery.has(propertyName, Compare.LESS_THAN, calendar.getTime());
-                } else {
-                    calendar.setTime((Date) jsonValueToObject(values, propertyDataType, 1));
-                    moveDateToEnd(calendar, isDateOnly);
-                    graphQuery.has(propertyName, Compare.LESS_THAN, calendar.getTime());
-                }
-            } else if (predicate.equals("<")) {
-                moveDateToStart(calendar, isDateOnly);
-                graphQuery.has(propertyName, Compare.LESS_THAN, calendar.getTime());
-            } else if (predicate.equals(">")) {
-                moveDateToEnd(calendar, isDateOnly);
-                graphQuery.has(propertyName, Compare.GREATER_THAN_EQUAL, calendar.getTime());
-            }
-        }
-    }
-
-    private void moveDateToStart(Calendar calendar, boolean dateOnly) {
-        if (dateOnly) {
-            calendar.set(Calendar.HOUR_OF_DAY, 0);
-            calendar.set(Calendar.MINUTE, 0);
-        }
-        calendar.set(Calendar.SECOND, 0);
-        calendar.set(Calendar.MILLISECOND, 0);
-    }
-
-    private void moveDateToEnd(Calendar calendar, boolean dateOnly) {
-        if (dateOnly) {
-            calendar.add(Calendar.DAY_OF_MONTH, 1);
-        } else {
-            calendar.add(Calendar.MINUTE, 1);
-        }
-    }
-
-    private Object jsonValueToObject(JSONArray values, PropertyType propertyDataType, int index) throws ParseException {
-        // JSONObject can be sent to search in the case of relative date searching or advanced directory entry searching
-        if (values.get(index) instanceof JSONObject) {
-            return values.get(index);
-        }
-        return OntologyProperty.convert(values, propertyDataType, index);
-    }
-
-    protected Graph getGraph() {
-        return graph;
-    }
-
-    protected static class QueryAndData {
-        private final Query query;
-
-        public QueryAndData(Query query) {
-            this.query = query;
-        }
-
-        public Query getQuery() {
-            return query;
-        }
     }
 }

--- a/web/web-base/src/main/java/org/visallo/web/routes/vertex/VertexSearch.java
+++ b/web/web-base/src/main/java/org/visallo/web/routes/vertex/VertexSearch.java
@@ -2,44 +2,13 @@ package org.visallo.web.routes.vertex;
 
 import com.google.inject.Inject;
 import com.v5analytics.webster.ParameterizedHandler;
-import com.v5analytics.webster.annotations.Handle;
-import org.vertexium.Authorizations;
-import org.vertexium.ElementType;
-import org.vertexium.Graph;
-import org.visallo.core.config.Configuration;
-import org.visallo.core.model.directory.DirectoryRepository;
-import org.visallo.core.model.ontology.OntologyRepository;
-import org.visallo.core.user.User;
-import org.visallo.web.clientapi.model.ClientApiElementSearchResponse;
-import org.visallo.web.parameterProviders.ActiveWorkspaceId;
+import org.visallo.core.model.search.ElementSearchRunnerBase;
+import org.visallo.core.model.search.SearchRepository;
+import org.visallo.core.model.search.VertexSearchRunner;
 
-import javax.servlet.http.HttpServletRequest;
-import java.util.EnumSet;
-
-public class VertexSearch extends ElementSearchWithRelatedBase implements ParameterizedHandler {
+public class VertexSearch extends ElementSearchBase implements ParameterizedHandler {
     @Inject
-    public VertexSearch(
-            OntologyRepository ontologyRepository,
-            Graph graph,
-            Configuration configuration,
-            DirectoryRepository directoryRepository
-    ) {
-        super(ontologyRepository, graph, configuration, directoryRepository);
-    }
-
-    @Override
-    @Handle
-    public ClientApiElementSearchResponse handle(
-            HttpServletRequest request,
-            @ActiveWorkspaceId String workspaceId,
-            User user,
-            Authorizations authorizations
-    ) throws Exception {
-        return super.handle(request, workspaceId, user, authorizations);
-    }
-
-    @Override
-    protected EnumSet<ElementType> getResultType() {
-        return EnumSet.of(ElementType.VERTEX);
+    public VertexSearch(SearchRepository searchRepository) {
+        super((ElementSearchRunnerBase) searchRepository.findSearchRunnerByUri(VertexSearchRunner.URI));
     }
 }

--- a/web/web-base/src/test/java/org/visallo/web/routes/edge/EdgeSearchTest.java
+++ b/web/web-base/src/test/java/org/visallo/web/routes/edge/EdgeSearchTest.java
@@ -1,4 +1,4 @@
-package org.visallo.web.routes.vertex;
+package org.visallo.web.routes.edge;
 
 import org.json.JSONArray;
 import org.junit.Before;
@@ -8,8 +8,8 @@ import org.mockito.ArgumentMatcher;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.vertexium.Vertex;
+import org.visallo.core.model.search.EdgeSearchRunner;
 import org.visallo.core.model.search.SearchOptions;
-import org.visallo.core.model.search.VertexSearchRunner;
 import org.visallo.web.clientapi.model.ClientApiElementSearchResponse;
 import org.visallo.web.routes.search.QueryResultsIterableSearchResultsSearchRouteTestBase;
 
@@ -21,23 +21,26 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class VertexSearchTest extends QueryResultsIterableSearchResultsSearchRouteTestBase {
-    private VertexSearch vertexSearch;
+public class EdgeSearchTest extends QueryResultsIterableSearchResultsSearchRouteTestBase {
+    private EdgeSearch edgeSearch;
 
     @Mock
-    private VertexSearchRunner vertexSearchRunner;
+    private EdgeSearchRunner edgeSearchRunner;
 
     @Before
     public void before() throws IOException {
         super.before();
 
-        when(searchRepository.findSearchRunnerByUri(VertexSearchRunner.URI)).thenReturn(vertexSearchRunner);
-        vertexSearch = new VertexSearch(searchRepository);
+        when(searchRepository.findSearchRunnerByUri(EdgeSearchRunner.URI)).thenReturn(edgeSearchRunner);
+
+        edgeSearch = new EdgeSearch(searchRepository);
     }
 
     @Test
     public void testSearch() throws Exception {
         Vertex v1 = graph.addVertex("v1", visibility, authorizations);
+        Vertex v2 = graph.addVertex("v2", visibility, authorizations);
+        graph.addEdge("e1", v1, v2, "label", visibility, authorizations);
 
         setParameter("q", "*");
         JSONArray filter = new JSONArray();
@@ -46,7 +49,7 @@ public class VertexSearchTest extends QueryResultsIterableSearchResultsSearchRou
         queryResultsIterableTotalHits = 1;
         queryResultsIterableElements.add(v1);
 
-        when(vertexSearchRunner.run(argThat(new ArgumentMatcher<SearchOptions>() {
+        when(edgeSearchRunner.run(argThat(new ArgumentMatcher<SearchOptions>() {
             @Override
             public boolean matches(Object o) {
                 SearchOptions searchOptions = (SearchOptions) o;
@@ -57,7 +60,7 @@ public class VertexSearchTest extends QueryResultsIterableSearchResultsSearchRou
             }
         }), eq(user), eq(authorizations))).thenReturn(results);
 
-        ClientApiElementSearchResponse response = vertexSearch.handle(request, WORKSPACE_ID, user, authorizations);
+        ClientApiElementSearchResponse response = edgeSearch.handle(request, WORKSPACE_ID, user, authorizations);
         assertEquals(1, response.getElements().size());
         assertEquals(1, response.getItemCount());
     }

--- a/web/web-base/src/test/java/org/visallo/web/routes/search/QueryResultsIterableSearchResultsSearchRouteTestBase.java
+++ b/web/web-base/src/test/java/org/visallo/web/routes/search/QueryResultsIterableSearchResultsSearchRouteTestBase.java
@@ -1,0 +1,74 @@
+package org.visallo.web.routes.search;
+
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.vertexium.Element;
+import org.vertexium.query.Aggregation;
+import org.vertexium.query.AggregationResult;
+import org.vertexium.query.Query;
+import org.vertexium.query.QueryResultsIterable;
+import org.visallo.core.model.search.ElementSearchRunnerBase;
+import org.visallo.core.model.search.QueryResultsIterableSearchResults;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+
+public abstract class QueryResultsIterableSearchResultsSearchRouteTestBase extends SearchRouteTestBase {
+    protected List<Aggregation> aggregations;
+    protected long queryResultsIterableTotalHits;
+    protected ArrayList<Element> queryResultsIterableElements;
+    protected ElementSearchRunnerBase.QueryAndData queryAndData;
+
+    @Mock
+    protected QueryResultsIterableSearchResults results;
+
+    @Mock
+    protected Query query;
+
+    @Override
+    protected void before() throws IOException {
+        super.before();
+
+        aggregations = new ArrayList<>();
+        queryResultsIterableTotalHits = 0L;
+        queryResultsIterableElements = new ArrayList<>();
+
+        QueryResultsIterable resultsIterable = new QueryResultsIterable<Element>() {
+            @Override
+            public <TResult extends AggregationResult> TResult getAggregationResult(String s, Class<? extends TResult> aClass) {
+                return null;
+            }
+
+            @Override
+            public void close() throws IOException {
+
+            }
+
+            @Override
+            public long getTotalHits() {
+                return queryResultsIterableTotalHits;
+            }
+
+            @Override
+            public Iterator<Element> iterator() {
+                return queryResultsIterableElements.iterator();
+            }
+        };
+        when(results.getQueryResultsIterable()).thenReturn(resultsIterable);
+
+        when(query.getAggregations()).thenReturn(aggregations);
+
+        queryAndData = createQueryAndData();
+        when(queryAndData.getQuery()).thenReturn(query);
+
+        when(results.getQueryAndData()).thenReturn(queryAndData);
+    }
+
+    protected ElementSearchRunnerBase.QueryAndData createQueryAndData() {
+        return Mockito.mock(ElementSearchRunnerBase.QueryAndData.class);
+    }
+}

--- a/web/web-base/src/test/java/org/visallo/web/routes/search/SearchRouteTestBase.java
+++ b/web/web-base/src/test/java/org/visallo/web/routes/search/SearchRouteTestBase.java
@@ -1,0 +1,29 @@
+package org.visallo.web.routes.search;
+
+import org.mockito.Mock;
+import org.vertexium.Authorizations;
+import org.vertexium.Visibility;
+import org.visallo.core.model.directory.DirectoryRepository;
+import org.visallo.core.model.search.SearchRepository;
+import org.visallo.web.RouteTestBase;
+
+import java.io.IOException;
+
+public abstract class SearchRouteTestBase extends RouteTestBase {
+    protected Authorizations authorizations;
+    protected Visibility visibility;
+
+    @Mock
+    protected DirectoryRepository directoryRepository;
+
+    @Mock
+    protected SearchRepository searchRepository;
+
+    @Override
+    protected void before() throws IOException {
+        super.before();
+
+        visibility = new Visibility("");
+        authorizations = graph.createAuthorizations("");
+    }
+}

--- a/web/web-base/src/test/java/org/visallo/web/routes/user/MeGetTest.java
+++ b/web/web-base/src/test/java/org/visallo/web/routes/user/MeGetTest.java
@@ -19,8 +19,8 @@ public class MeGetTest extends RouteTestBase {
     private MeGet meGet;
 
     @Before
-    public void setUp() throws IOException {
-        super.setUp();
+    public void before() throws IOException {
+        super.before();
         meGet = new MeGet(userRepository, workspaceRepository);
     }
 

--- a/web/web-base/src/test/java/org/visallo/web/routes/vertex/UnresolveTermEntityTest.java
+++ b/web/web-base/src/test/java/org/visallo/web/routes/vertex/UnresolveTermEntityTest.java
@@ -27,8 +27,8 @@ public class UnresolveTermEntityTest extends RouteTestBase {
     private Authorizations authorizations;
 
     @Before
-    public void setUp() throws IOException {
-        super.setUp();
+    public void before() throws IOException {
+        super.before();
 
         visibility = new Visibility("");
         termMentionVisibility = new Visibility(TermMentionRepository.VISIBILITY_STRING);

--- a/web/web-base/src/test/java/org/visallo/web/routes/vertex/VertexFindRelatedTest.java
+++ b/web/web-base/src/test/java/org/visallo/web/routes/vertex/VertexFindRelatedTest.java
@@ -1,0 +1,79 @@
+package org.visallo.web.routes.vertex;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatcher;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.vertexium.Vertex;
+import org.visallo.core.model.search.SearchOptions;
+import org.visallo.core.model.search.VertexFindRelatedSearchResults;
+import org.visallo.core.model.search.VertexFindRelatedSearchRunner;
+import org.visallo.web.clientapi.model.ClientApiElementFindRelatedResponse;
+import org.visallo.web.routes.search.SearchRouteTestBase;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class VertexFindRelatedTest extends SearchRouteTestBase {
+    private VertexFindRelated vertexFindRelated;
+
+    @Mock
+    private VertexFindRelatedSearchResults results;
+
+    @Mock
+    private VertexFindRelatedSearchRunner vertexFindRelatedSearchRunner;
+
+    @Before
+    public void before() throws IOException {
+        super.before();
+
+        when(searchRepository.findSearchRunnerByUri(VertexFindRelatedSearchRunner.URI)).thenReturn(vertexFindRelatedSearchRunner);
+
+        vertexFindRelated = new VertexFindRelated(searchRepository);
+    }
+
+    @Test
+    public void testSearchRelated() throws Exception {
+        Vertex v1 = graph.prepareVertex("v1", visibility).save(authorizations);
+        Vertex v2 = graph.prepareVertex("v2", visibility).save(authorizations);
+        Vertex v3 = graph.prepareVertex("v3", visibility).save(authorizations);
+        graph.addEdge("e1", v1, v2, "label1", visibility, authorizations);
+        graph.addEdge("e2", v1, v3, "label1", visibility, authorizations);
+        graph.flush();
+
+        List<Vertex> elements = new ArrayList<>();
+        elements.add(v2);
+        elements.add(v3);
+        when(results.getElements()).thenReturn((List) elements);
+        when(results.getCount()).thenReturn(2L);
+
+        setParameter("q", "*");
+        setArrayParameter("graphVertexIds[]", new String[]{"v1"});
+
+        when(vertexFindRelatedSearchRunner.run(argThat(new ArgumentMatcher<SearchOptions>() {
+            @Override
+            public boolean matches(Object o) {
+                SearchOptions searchOptions = (SearchOptions) o;
+                assertEquals("*", searchOptions.getRequiredParameter("q", String.class));
+                String[] graphVertexIds = searchOptions.getRequiredParameter("graphVertexIds[]", String[].class);
+                assertArrayEquals(new String[]{"v1"}, graphVertexIds);
+                assertEquals(WORKSPACE_ID, searchOptions.getWorkspaceId());
+                return true;
+            }
+        }), eq(user), eq(authorizations))).thenReturn(results);
+
+        ClientApiElementFindRelatedResponse response = vertexFindRelated.handle(request, WORKSPACE_ID, user, authorizations);
+        assertEquals(2, response.getElements().size());
+        assertEquals(2, response.getCount());
+    }
+}

--- a/web/web-base/src/test/java/org/visallo/web/routes/workspace/WorkspaceEdgesTest.java
+++ b/web/web-base/src/test/java/org/visallo/web/routes/workspace/WorkspaceEdgesTest.java
@@ -29,8 +29,8 @@ public class WorkspaceEdgesTest extends RouteTestBase {
     private Authorizations authorizations;
 
     @Before
-    public void setUp() throws IOException {
-        super.setUp();
+    public void before() throws IOException {
+        super.before();
         workspaceEdges = new WorkspaceEdges(graph, workspaceRepository) {
             @Override
             protected ClientApiWorkspaceEdges getEdges(HttpServletRequest request, String workspaceId, Iterable<String> vertexIds, Authorizations authorizations) {


### PR DESCRIPTION
- [x] @sfeng88 @rygim @jharwig 
- [x] @srfarley
- [x] @EvanOxfeld @joeybrk372
- [ ] @mwizeman @dsingley

This is a pretty large PR. Most of it consists of moving code from the search web routes to the back-end.

The biggest change is with the introduction of `SearchOptions` which is in place to decouple the code from `HttpRequest`.

@sfeng88 @rygim @jharwig Please look at https://github.com/v5analytics/visallo/compare/refactor-search-to-backend?expand=1#diff-b9711c6c54a8d174d6af7d034a70e6a2R43 I would like to move this code as well to the back-end but I know your team is relying on it so maybe you could help out with that move.