### PR TITLE
Better Comment sort behavior hints 

### DIFF
--- a/core/messages/src/main/resources/MessageBundle.properties
+++ b/core/messages/src/main/resources/MessageBundle.properties
@@ -133,8 +133,8 @@ detail.comments.user.loading=Loading...
 detail.comment.form.button.cancel=Cancel
 detail.comment.form.button=Comment
 detail.comment.field.placeholder=Comment
-detail.comments.date.edited={0} (edited)
-detail.comments.date.hover.edited=Created: {0}  Edited: {1}
+detail.comments.date.edited=edited {0}
+detail.comments.date.hover.edited=Created: {0}&#xa;Edited: {1}
 
 detail.resolve.form.entity_search.placeholder=Resolve to Entity
 detail.resolve.form.entity_search.help=Click to show existing matches

--- a/core/messages/src/main/resources/MessageBundle.properties
+++ b/core/messages/src/main/resources/MessageBundle.properties
@@ -134,7 +134,7 @@ detail.comment.form.button.cancel=Cancel
 detail.comment.form.button=Comment
 detail.comment.field.placeholder=Comment
 detail.comments.date.edited=edited {0}
-detail.comments.date.hover.edited=Created: {0}&#xa;Edited: {1}
+detail.comments.date.hover.edited=Created: {0}\nEdited: {1}
 
 detail.resolve.form.entity_search.placeholder=Resolve to Entity
 detail.resolve.form.entity_search.help=Click to show existing matches


### PR DESCRIPTION
- [x] @sfeng88 @rygim @jharwig 
- [x] @srfarley @joeferner
- [x] @EvanOxfeld @joeybrk372
- [x] @mwizeman @dsingley

Comment sorting is based on creation date for the stability of the tree, but the date displayed is the last modified. Make it clear that the date was edited and put the created date in hover.

Prevents the list from looking out of order

<img width="270" alt="comment order" src="https://cloud.githubusercontent.com/assets/7098/15235467/1a242570-1881-11e6-93ca-d236dea06ef1.png">