### PR TITLE
Web: Add no cache headers to JSON responses

### DIFF
--- a/web/web-base/src/main/java/org/visallo/web/VisalloDefaultResultWriterFactory.java
+++ b/web/web-base/src/main/java/org/visallo/web/VisalloDefaultResultWriterFactory.java
@@ -73,6 +73,9 @@ public class VisalloDefaultResultWriterFactory implements ResultWriterFactory {
                     }
                     response.setCharacterEncoding("UTF-8");
                     if (resultIsClientApiObject) {
+                        response.addHeader("Cache-Control", "no-cache, no-store, must-revalidate");
+                        response.addHeader("Pragma", "no-cache");
+                        response.addHeader("Expires", "0");
                         ClientApiObject clientApiObject = (ClientApiObject) result;
                         User user = VisalloBaseParameterProvider.getUser(request, userRepository);
                         clientApiObject = aclProvider.appendACL(clientApiObject, user);


### PR DESCRIPTION
- [x] @sfeng88 @rygim @jharwig 
- [x] @srfarley @joeferner
- [x] @EvanOxfeld @joeybrk372
- [ ] @mwizeman @dsingley

Fixes a number of bugs in IE due to the browser's automatic caching of JSON endpoints.