### PR TITLE
Upgrade vertexium to 2.4.0 and simple-orm to 1.2.0

### DIFF
--- a/root/pom.xml
+++ b/root/pom.xml
@@ -78,8 +78,8 @@
         <lesscss.version>1.3.3</lesscss.version>
         <log4j.version>1.2.17</log4j.version>
         <metrics.version>3.0.2</metrics.version>
-        <vertexium.version>2.3.1</vertexium.version>
-        <simple-orm.version>1.1.1</simple-orm.version>
+        <vertexium.version>2.4.0</vertexium.version>
+        <simple-orm.version>1.2.0</simple-orm.version>
         <groovy.version>2.4.5</groovy.version>
         <zip4j.version>1.3.1</zip4j.version>
         <zookeeper.version>3.4.7</zookeeper.version>


### PR DESCRIPTION
- [x] @sfeng88 @rygim @jharwig 
- [x] @srfarley
- [x] @EvanOxfeld @joeybrk372
- [x] @mwizeman @dsingley

**NOTE: This requires a reindex of your data**

Vertexium
* ACCUMULO: iterator locations in accumulo config are now stored per table name
* Elasticsearch: fix: sort by strings with tokens should not effect sort order 
* SQL: Switch to HikariCP connection pool

SimpleORM
* SQL: Use HikariCP for SQL connection pooling
