### PR TITLE
Support external url for all notification types

### DIFF
--- a/core/core/src/main/java/org/visallo/core/model/notification/Notification.java
+++ b/core/core/src/main/java/org/visallo/core/model/notification/Notification.java
@@ -10,7 +10,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
 public abstract class Notification {
-    public static final String ACTION_EVENT_EXTERNAL_URL = "EXTERNAL_URL";
+    static final String ACTION_EVENT_EXTERNAL_URL = "EXTERNAL_URL";
 
     @Id
     private String id;
@@ -36,7 +36,6 @@ public abstract class Notification {
     }
 
     protected Notification() {
-
     }
 
     public String getId() {
@@ -75,6 +74,16 @@ public abstract class Notification {
         this.actionPayload = actionPayload;
     }
 
+    public void setExternalUrl(String externalUrl) {
+        if (getActionPayload() != null || getActionEvent() != null) {
+            throw new IllegalStateException("actionPayload or actionEvent is already assigned");
+        }
+        setActionEvent(ACTION_EVENT_EXTERNAL_URL);
+        JSONObject payload = new JSONObject();
+        payload.put("url", externalUrl);
+        this.setActionPayload(payload);
+    }
+
     public final JSONObject toJSONObject() {
         JSONObject json = new JSONObject();
         json.put("id", getId());
@@ -89,6 +98,8 @@ public abstract class Notification {
     }
 
     protected abstract void populateJSONObject(JSONObject json);
+
+
 
     protected abstract String getType();
 

--- a/core/core/src/main/java/org/visallo/core/model/notification/SystemNotification.java
+++ b/core/core/src/main/java/org/visallo/core/model/notification/SystemNotification.java
@@ -24,7 +24,7 @@ public class SystemNotification extends Notification {
         super();
     }
 
-    public SystemNotification(Date startDate, String title, String message, String actionEvent, JSONObject actionPayload) {
+    SystemNotification(Date startDate, String title, String message, String actionEvent, JSONObject actionPayload) {
         super(createId(startDate), title, message, actionEvent, actionPayload);
     }
 
@@ -57,13 +57,6 @@ public class SystemNotification extends Notification {
 
     public void setEndDate(Date endDate) {
         this.endDate = endDate;
-    }
-
-    public void setExternalUrl(String externalUrl) {
-        this.setActionEvent(ACTION_EVENT_EXTERNAL_URL);
-        JSONObject payload = new JSONObject();
-        payload.put("url", externalUrl);
-        this.setActionPayload(payload);
     }
 
     public boolean isActive() {

--- a/core/core/src/main/java/org/visallo/core/model/notification/UserNotification.java
+++ b/core/core/src/main/java/org/visallo/core/model/notification/UserNotification.java
@@ -37,9 +37,6 @@ public class UserNotification extends Notification {
         if (expirationAge != null) {
             this.expirationAgeAmount = expirationAge.getAmount();
             this.expirationAgeUnit = expirationAge.getExpirationAgeUnit();
-        } else {
-            this.expirationAgeAmount = null;
-            this.expirationAgeUnit = null;
         }
     }
 

--- a/core/core/src/main/java/org/visallo/core/model/notification/UserNotificationRepository.java
+++ b/core/core/src/main/java/org/visallo/core/model/notification/UserNotificationRepository.java
@@ -56,12 +56,28 @@ public class UserNotificationRepository extends NotificationRepository {
             ExpirationAge expirationAge,
             User authUser
     ) {
-        UserNotification notification = new UserNotification(userId, title, message, actionEvent, actionPayload, expirationAge);
+        UserNotification notification = new UserNotification(
+                userId, title, message, actionEvent, actionPayload, expirationAge);
+        saveNotification(notification, authUser);
+        return notification;
+    }
 
-        notification.setMarkedRead(false);
+    public UserNotification createNotification(
+            String userId,
+            String title,
+            String message,
+            String externalUrl,
+            ExpirationAge expirationAge,
+            User authUser) {
+        UserNotification notification = new UserNotification(userId, title, message, null, null, expirationAge);
+        notification.setExternalUrl(externalUrl);
+        saveNotification(notification, authUser);
+        return notification;
+    }
+
+    private void saveNotification(UserNotification notification, User authUser) {
         getSimpleOrmSession().save(notification, VISIBILITY_STRING, getUserRepository().getSimpleOrmContext(authUser));
         workQueueRepository.pushUserNotification(notification);
-        return notification;
     }
 
     public UserNotification getNotification(String notificationId, User user) {


### PR DESCRIPTION
When a notification with an external URL is clicked, the URL opens in a new browser tab.

- [x] @sfeng88 @rygim @jharwig 
- [x] @joeferner
- [x] @EvanOxfeld @joeybrk372
- [x] @mwizeman @dsingley

