### PR TITLE
Add method to directory repository for finding people in group

### DIFF
--- a/core/core/src/main/java/org/visallo/core/model/directory/DirectoryRepository.java
+++ b/core/core/src/main/java/org/visallo/core/model/directory/DirectoryRepository.java
@@ -15,4 +15,6 @@ public abstract class DirectoryRepository {
     public abstract DirectoryEntity findById(String id, User user);
 
     public abstract String getDirectoryEntityId(User user);
+
+    public abstract List<DirectoryPerson> findAllPeopleInGroup(DirectoryGroup group);
 }

--- a/core/core/src/main/java/org/visallo/core/model/directory/UserRepositoryDirectoryRepository.java
+++ b/core/core/src/main/java/org/visallo/core/model/directory/UserRepositoryDirectoryRepository.java
@@ -50,4 +50,9 @@ public class UserRepositoryDirectoryRepository extends DirectoryRepository {
     public String getDirectoryEntityId(User user) {
         return user.getUserId();
     }
+
+    @Override
+    public List<DirectoryPerson> findAllPeopleInGroup(DirectoryGroup group) {
+        return Collections.emptyList();
+    }
 }


### PR DESCRIPTION
The default implementation returns an empty set of people. Other implementations, such as LDAP, would return meaningful results.

- [x] @sfeng88 @rygim @jharwig 
- [x] @joeferner
- [x] @EvanOxfeld @joeybrk372
- [ ] @mwizeman @dsingley
