### PR TITLE
Web: Add no cache headers to JSONObject responses

### DIFF
--- a/web/web-base/src/main/java/org/visallo/web/VisalloDefaultResultWriterFactory.java
+++ b/web/web-base/src/main/java/org/visallo/web/VisalloDefaultResultWriterFactory.java
@@ -72,10 +72,12 @@ public class VisalloDefaultResultWriterFactory implements ResultWriterFactory {
                         response.addHeader("X-Content-Type-Options", "nosniff");
                     }
                     response.setCharacterEncoding("UTF-8");
-                    if (resultIsClientApiObject) {
+                    if (resultIsClientApiObject || result instanceof JSONObject) {
                         response.addHeader("Cache-Control", "no-cache, no-store, must-revalidate");
                         response.addHeader("Pragma", "no-cache");
                         response.addHeader("Expires", "0");
+                    }
+                    if (resultIsClientApiObject) {
                         ClientApiObject clientApiObject = (ClientApiObject) result;
                         User user = VisalloBaseParameterProvider.getUser(request, userRepository);
                         clientApiObject = aclProvider.appendACL(clientApiObject, user);


### PR DESCRIPTION
- [ ] @sfeng88 @rygim @jharwig 
- [x] @srfarley @joeferner
- [x] @EvanOxfeld @joeybrk372
- [x] @mwizeman @dsingley

Adds the proper headers to `JSONObject` responses in addition to `ClientApiObject` responses. Fixes a number of bugs in IE due to the browser's automatic caching of JSON endpoints.