### PR TITLE
Support loading configuration from a string containing properties

### DIFF
--- a/core/core-test/src/test/java/org/visallo/core/config/HashMapConfigurationLoaderTest.java
+++ b/core/core-test/src/test/java/org/visallo/core/config/HashMapConfigurationLoaderTest.java
@@ -1,0 +1,27 @@
+package org.visallo.core.config;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class HashMapConfigurationLoaderTest {
+    @Test
+    public void testLoadFromString() {
+        Configuration config = new HashMapConfigurationLoader("prop1=test1\nprop2=${prop1}").createConfiguration();
+        assertEquals("test1", config.get("prop1", "not found"));
+        assertEquals("test1", config.get("prop2", "not found"));
+    }
+
+    @Test
+    public void testLoadFromMap() {
+        Map map = new HashMap<>();
+        map.put("prop1", "test1");
+        map.put("prop2", "${prop1}");
+        Configuration config = new HashMapConfigurationLoader(map).createConfiguration();
+        assertEquals("test1", config.get("prop1", "not found"));
+        assertEquals("test1", config.get("prop2", "not found"));
+    }
+}

--- a/core/core/src/main/java/org/visallo/core/config/HashMapConfigurationLoader.java
+++ b/core/core/src/main/java/org/visallo/core/config/HashMapConfigurationLoader.java
@@ -1,9 +1,19 @@
 package org.visallo.core.config;
 
+import org.visallo.core.exception.VisalloException;
+
 import java.io.File;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
 import java.util.Map;
+import java.util.Properties;
 
 public class HashMapConfigurationLoader extends ConfigurationLoader {
+    public HashMapConfigurationLoader(String propertiesString) {
+        this(parseStringToProperties(propertiesString));
+    }
+
     public HashMapConfigurationLoader(Map initParameters) {
         super(initParameters);
     }
@@ -16,5 +26,16 @@ public class HashMapConfigurationLoader extends ConfigurationLoader {
     @Override
     public File resolveFileName(String fileName) {
         return FileConfigurationLoader.resolveLocalFileName(fileName);
+    }
+
+    private static Properties parseStringToProperties(String propertiesString) {
+        Properties properties = new Properties();
+        Reader reader = new StringReader(propertiesString);
+        try {
+            properties.load(reader);
+        } catch (IOException ex) {
+            throw new VisalloException("Could not load properties string", ex);
+        }
+        return properties;
     }
 }


### PR DESCRIPTION
- [x] @sfeng88 @rygim @jharwig 
- [x] @srfarley
- [x] @EvanOxfeld @joeybrk372
- [x] @mwizeman @dsingley

This allows code like this in scala: 

```scala
new HashMapConfigurationLoader("""
prop1=test1
prop2=${prop1}
""")
```