### PR TITLE
OntologyRepositoryBase: add a null check for text index hints

### DIFF
--- a/core/core/src/main/java/org/visallo/core/model/ontology/OntologyRepositoryBase.java
+++ b/core/core/src/main/java/org/visallo/core/model/ontology/OntologyRepositoryBase.java
@@ -1395,6 +1395,7 @@ public abstract class OntologyRepositoryBase implements OntologyRepository {
 
     protected boolean determineSearchable(String propertyIri, PropertyType dataType, Collection<TextIndexHint> textIndexHints, boolean searchable) {
         if (dataType == PropertyType.STRING) {
+            checkNotNull(textIndexHints, "textIndexHints are required for string properties");
             if (searchable && (textIndexHints.isEmpty() || textIndexHints.equals(TextIndexHint.NONE))) {
                 searchable = false;
             } else if (!searchable && (!textIndexHints.isEmpty() || !textIndexHints.equals(TextIndexHint.NONE))) {


### PR DESCRIPTION
- [x] @sfeng88 @rygim @jharwig 
- [x] @srfarley
- [x] @EvanOxfeld @joeybrk372
- [x] @mwizeman @dsingley

Simple addition to check for nulls ahead of time. The NPE without this isn't very nice