### PR TITLE
Add detected objects to split detail

### DIFF
--- a/web/war/src/main/webapp/js/detail/item/layoutComponents/vertex.js
+++ b/web/war/src/main/webapp/js/detail/item/layoutComponents/vertex.js
@@ -93,6 +93,7 @@ define([
             identifier: 'org.visallo.layout.body.split',
             children: [
                 { componentPath: 'detail/image/image', className: 'org-visallo-image' },
+                { componentPath: 'detail/detectedObjects/detectedObjects' },
                 { ref: 'org.visallo.layout.body.split.artifact' }
             ]
         },

--- a/web/war/src/main/webapp/less/util/underneath.less
+++ b/web/war/src/main/webapp/less/util/underneath.less
@@ -4,7 +4,6 @@
   margin: 0;
   padding: 0 1em;
   color: #666;
-  float: left;
   width: 100%;
   .transition(~"height ease-in 0.3s");
   .box-sizing(border-box);


### PR DESCRIPTION
- [x] @sfeng88 @rygim @jharwig 
- [x] @srfarley @joeferner
- [x] @EvanOxfeld @joeybrk372
- [x] @mwizeman @dsingley

Also fix detected objects form layout in Firefox.