### PR TITLE
Add AuthorizationMapper to allow applications to override user's authorization and privileges

### DIFF
--- a/config/visallo.properties
+++ b/config/visallo.properties
@@ -14,6 +14,7 @@ repository.trace=org.visallo.core.trace.DefaultTraceRepository
 repository.fileSystem=org.visallo.core.model.file.LocalFileSystemRepository
 repository.acl=org.visallo.core.security.AllowAllAclProvider
 repository.geocoder=org.visallo.core.geocoding.DefaultGeocoderRepository
+authorizationMapper=org.visallo.core.model.user.DefaultAuthorizationMapper
 
 repository.workQueue=org.visallo.model.queue.inmemory.InMemoryWorkQueueRepository
 #repository.workQueue=org.visallo.model.rabbitmq.RabbitMQWorkQueueRepository

--- a/core/core-test/src/main/java/org/visallo/core/model/user/DefaultAuthorizationMapperTest.java
+++ b/core/core-test/src/main/java/org/visallo/core/model/user/DefaultAuthorizationMapperTest.java
@@ -1,0 +1,75 @@
+package org.visallo.core.model.user;
+
+import com.google.common.collect.Sets;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.vertexium.Authorizations;
+import org.vertexium.inmemory.InMemoryAuthorizations;
+import org.visallo.core.user.User;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DefaultAuthorizationMapperTest {
+    private DefaultAuthorizationMapper defaultAuthorizationMapper;
+
+    @Mock
+    private User user;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Before
+    public void before() {
+        defaultAuthorizationMapper = new DefaultAuthorizationMapper(userRepository);
+    }
+
+    @Test
+    public void testGetPrivilegesForNewUser() {
+        HashSet<String> expected = Sets.newHashSet("userRepositoryPrivilege1", "userRepositoryPrivilege2");
+        when(userRepository.getDefaultPrivileges()).thenReturn(expected);
+
+        AuthorizationContext authorizationContext = new AuthorizationContext(null);
+        Set<String> privileges = defaultAuthorizationMapper.getPrivileges(authorizationContext);
+        assertEquals(expected, privileges);
+    }
+
+    @Test
+    public void testGetPrivilegesForExisting() {
+        HashSet<String> expected = Sets.newHashSet("userPrivilege1", "userPrivilege2");
+        when(user.getPrivileges()).thenReturn(expected);
+
+        AuthorizationContext authorizationContext = new AuthorizationContext(user);
+        Set<String> privileges = defaultAuthorizationMapper.getPrivileges(authorizationContext);
+        assertEquals(expected, privileges);
+    }
+
+    @Test
+    public void testGetAuthorizationsForNewUser() {
+        HashSet<String> expected = Sets.newHashSet("userRepositoryAuthorization1", "userRepositoryAuthorization2");
+        when(userRepository.getDefaultAuthorizations()).thenReturn(expected);
+
+        AuthorizationContext authorizationContext = new AuthorizationContext(null);
+        Set<String> privileges = defaultAuthorizationMapper.getAuthorizations(authorizationContext);
+        assertEquals(expected, privileges);
+    }
+
+    @Test
+    public void testGetAuthorizationsForExisting() {
+        String[] authorizationsArray = {"userAuthorization1", "userAuthorization2"};
+        Authorizations authorizations = new InMemoryAuthorizations(authorizationsArray);
+        when(userRepository.getAuthorizations(eq(user))).thenReturn(authorizations);
+
+        AuthorizationContext authorizationContext = new AuthorizationContext(user);
+        Set<String> privileges = defaultAuthorizationMapper.getAuthorizations(authorizationContext);
+        assertEquals(Sets.newHashSet(authorizationsArray), privileges);
+    }
+}

--- a/core/core/src/main/java/org/visallo/core/bootstrap/VisalloBootstrap.java
+++ b/core/core/src/main/java/org/visallo/core/bootstrap/VisalloBootstrap.java
@@ -18,6 +18,7 @@ import org.visallo.core.model.longRunningProcess.LongRunningProcessRepository;
 import org.visallo.core.model.ontology.OntologyRepository;
 import org.visallo.core.model.directory.DirectoryRepository;
 import org.visallo.core.model.search.SearchRepository;
+import org.visallo.core.model.user.AuthorizationMapper;
 import org.visallo.core.model.user.AuthorizationRepository;
 import org.visallo.core.model.user.UserRepository;
 import org.visallo.core.model.user.UserSessionCounterRepository;
@@ -175,6 +176,9 @@ public class VisalloBootstrap extends AbstractModule {
                 .in(Scopes.SINGLETON);
         bind(FileSystemRepository.class)
                 .toProvider(VisalloBootstrap.<FileSystemRepository>getConfigurableProvider(configuration, Configuration.FILE_SYSTEM_REPOSITORY))
+                .in(Scopes.SINGLETON);
+        bind(AuthorizationMapper.class)
+                .toProvider(VisalloBootstrap.<AuthorizationMapper>getConfigurableProvider(configuration, Configuration.AUTHORIZATION_MAPPER))
                 .in(Scopes.SINGLETON);
         bind(TimeRepository.class)
                 .toInstance(new TimeRepository());

--- a/core/core/src/main/java/org/visallo/core/config/Configuration.java
+++ b/core/core/src/main/java/org/visallo/core/config/Configuration.java
@@ -54,6 +54,7 @@ public class Configuration {
     public static final String ONTOLOGY_REPOSITORY_OWL = "repository.ontology.owl";
     public static final String ACL_PROVIDER_REPOSITORY = "repository.acl";
     public static final String FILE_SYSTEM_REPOSITORY = "repository.fileSystem";
+    public static final String AUTHORIZATION_MAPPER = "authorizationMapper";
     public static final String GRAPH_PROVIDER = "graph";
     public static final String VISIBILITY_TRANSLATOR = "security.visibilityTranslator";
     public static final String DEFAULT_PRIVILEGES = "newuser.privileges";

--- a/core/core/src/main/java/org/visallo/core/model/user/AuthorizationContext.java
+++ b/core/core/src/main/java/org/visallo/core/model/user/AuthorizationContext.java
@@ -1,0 +1,19 @@
+package org.visallo.core.model.user;
+
+import org.visallo.core.user.User;
+
+public class AuthorizationContext {
+    private final User existingUser;
+
+    public AuthorizationContext(User existingUser) {
+        this.existingUser = existingUser;
+    }
+
+    public User getExistingUser() {
+        return existingUser;
+    }
+
+    public boolean isNewUser() {
+        return getExistingUser() == null;
+    }
+}

--- a/core/core/src/main/java/org/visallo/core/model/user/AuthorizationMapper.java
+++ b/core/core/src/main/java/org/visallo/core/model/user/AuthorizationMapper.java
@@ -1,0 +1,9 @@
+package org.visallo.core.model.user;
+
+import java.util.Set;
+
+public abstract class AuthorizationMapper {
+    public abstract Set<String> getPrivileges(AuthorizationContext authorizationContext);
+
+    public abstract Set<String> getAuthorizations(AuthorizationContext authorizationContext);
+}

--- a/core/core/src/main/java/org/visallo/core/model/user/DefaultAuthorizationMapper.java
+++ b/core/core/src/main/java/org/visallo/core/model/user/DefaultAuthorizationMapper.java
@@ -1,0 +1,37 @@
+package org.visallo.core.model.user;
+
+import com.google.common.collect.Sets;
+import com.google.inject.Inject;
+
+import java.util.Set;
+
+public class DefaultAuthorizationMapper extends AuthorizationMapper {
+    private final UserRepository userRepository;
+
+    @Inject
+    public DefaultAuthorizationMapper(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public Set<String> getPrivileges(AuthorizationContext authorizationContext) {
+        if (authorizationContext.isNewUser()) {
+            return this.userRepository.getDefaultPrivileges();
+        }
+        return authorizationContext.getExistingUser().getPrivileges();
+    }
+
+    @Override
+    public Set<String> getAuthorizations(AuthorizationContext authorizationContext) {
+        if (authorizationContext.isNewUser()) {
+            return this.userRepository.getDefaultAuthorizations();
+        }
+        return Sets.newHashSet(
+                userRepository.getAuthorizations(authorizationContext.getExistingUser()).getAuthorizations()
+        );
+    }
+
+    public UserRepository getUserRepository() {
+        return userRepository;
+    }
+}

--- a/core/core/src/main/java/org/visallo/core/model/user/UserNameAuthorizationContext.java
+++ b/core/core/src/main/java/org/visallo/core/model/user/UserNameAuthorizationContext.java
@@ -1,0 +1,16 @@
+package org.visallo.core.model.user;
+
+import org.visallo.core.user.User;
+
+public class UserNameAuthorizationContext extends AuthorizationContext {
+    private final String username;
+
+    public UserNameAuthorizationContext(User existingUser, String username) {
+        super(existingUser);
+        this.username = username;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+}

--- a/graph-property-worker/graph-property-worker-plugin-test/src/main/resources/org/visallo/test/visallo.properties
+++ b/graph-property-worker/graph-property-worker-plugin-test/src/main/resources/org/visallo/test/visallo.properties
@@ -42,6 +42,7 @@ repository.ontology=org.visallo.vertexium.model.ontology.VertexiumOntologyReposi
 repository.audit=org.visallo.core.model.audit.SimpleOrmAuditRepository
 repository.workQueue=org.visallo.model.queue.inmemory.InMemoryWorkQueueRepository
 repository.email=org.visallo.core.email.NopEmailRepository
+authorizationMapper=org.visallo.core.model.user.DefaultAuthorizationMapper
 
 # Clavin
 clavin.disabled=false

--- a/web/plugins/auth-username-password/src/main/java/org/visallo/web/auth/usernamepassword/routes/Login.java
+++ b/web/plugins/auth-username-password/src/main/java/org/visallo/web/auth/usernamepassword/routes/Login.java
@@ -6,20 +6,26 @@ import com.v5analytics.webster.annotations.Handle;
 import com.v5analytics.webster.annotations.Required;
 import org.json.JSONObject;
 import org.visallo.core.exception.VisalloAccessDeniedException;
+import org.visallo.core.model.user.AuthorizationContext;
+import org.visallo.core.model.user.AuthorizationMapper;
+import org.visallo.core.model.user.UserNameAuthorizationContext;
 import org.visallo.core.model.user.UserRepository;
 import org.visallo.core.user.User;
 import org.visallo.web.AuthenticationHandler;
 import org.visallo.web.CurrentUser;
 
 import javax.servlet.http.HttpServletRequest;
+import java.util.Set;
 
 public class Login implements ParameterizedHandler {
 
     private final UserRepository userRepository;
+    private final AuthorizationMapper authorizationMapper;
 
     @Inject
-    public Login(UserRepository userRepository) {
+    public Login(UserRepository userRepository, AuthorizationMapper authorizationMapper) {
         this.userRepository = userRepository;
+        this.authorizationMapper = authorizationMapper;
     }
 
     @Handle
@@ -33,6 +39,12 @@ public class Login implements ParameterizedHandler {
 
         User user = userRepository.findByUsername(username);
         if (user != null && userRepository.isPasswordValid(user, password)) {
+            AuthorizationContext authorizationContext = new UserNameAuthorizationContext(user, username);
+            Set<String> privileges = authorizationMapper.getPrivileges(authorizationContext);
+            Set<String> authorizations = authorizationMapper.getAuthorizations(authorizationContext);
+            userRepository.setPrivileges(user, privileges, userRepository.getSystemUser());
+            userRepository.setAuthorizations(user, authorizations, userRepository.getSystemUser());
+
             userRepository.recordLogin(user, AuthenticationHandler.getRemoteAddr(request));
             CurrentUser.set(request, user.getUserId(), user.getUsername());
             JSONObject json = new JSONObject();


### PR DESCRIPTION
- [x] @sfeng88 @rygim @jharwig 
- [x] @srfarley
- [ ] @EvanOxfeld @joeybrk372
- [x] @mwizeman @dsingley

This PR introduces two new classes AuthorizationMapper and AuthorizationContext. AuthorizationMapper maps AuthorizationContext into authorizations and privileges. AuthorizationContext contains what is to be mapped (existing user, user name, ldap info, etc).