### PR TITLE
Support comments on edges

### DIFF
--- a/core/core/src/main/resources/org/visallo/core/model/ontology/comment.owl
+++ b/core/core/src/main/resources/org/visallo/core/model/ontology/comment.owl
@@ -36,6 +36,7 @@
         <rdfs:label xml:lang="en">Comment</rdfs:label>
         <visallo:textIndexHints>FULL_TEXT</visallo:textIndexHints>
         <rdfs:domain rdf:resource="&owl;Thing"/>
+        <visallo:objectPropertyDomain rdf:resource="&owl;topObjectProperty"/>
         <rdfs:range rdf:resource="&xsd;string"/>
     </owl:DatatypeProperty>
     


### PR DESCRIPTION
- [x] @sfeng88 @rygim @jharwig 
- [x] @srfarley
- [x] @EvanOxfeld @joeybrk372
- [x] @mwizeman @dsingley

Introduces `topObjectProperty` which is the standard owl top level that all relationships inherit from. This allows us to attach the comment property to topObjectProperty and therefore the ACLProvider can verify.
