### PR TITLE
Detail: Fix header layout in IE11

### DIFF
--- a/web/war/src/main/webapp/js/detail/item/layoutComponents/edge.js
+++ b/web/war/src/main/webapp/js/detail/item/layoutComponents/edge.js
@@ -31,7 +31,7 @@ define([
             layout: { type: 'flex', options: { direction: 'column' }},
             componentPath: 'detail/item/edge',
             children: [
-                { ref: 'org.visallo.layout.header' },
+                { ref: 'org.visallo.layout.header', style: { flex: '0 0 auto' } },
                 { ref: 'org.visallo.layout.body', style: { flex: '1 1 auto', overflow: 'auto' } }
             ]
         },

--- a/web/war/src/main/webapp/js/detail/item/layoutComponents/vertex.js
+++ b/web/war/src/main/webapp/js/detail/item/layoutComponents/vertex.js
@@ -14,7 +14,7 @@ define([
             layout: { type: 'flex', options: { direction: 'column' }},
             componentPath: 'detail/item/vertex',
             children: [
-                { ref: 'org.visallo.layout.header' },
+                { ref: 'org.visallo.layout.header', style: { flex: '0 0 auto' } },
                 { ref: 'org.visallo.layout.body', style: { flex: '1 1 auto', overflow: 'auto' } }
             ]
         },


### PR DESCRIPTION
- [x] @sfeng88 @rygim @jharwig 
- [x] @srfarley @joeferner
- [x] @EvanOxfeld @joeybrk372
- [ ] @mwizeman @dsingley

Fixes detail body spilling up into the header when a vertex or an edge has a multiline title.