### PR TITLE
Allow sort to be passed as string array or json array

### DIFF
--- a/core/core-test/src/test/java/org/visallo/core/model/search/ElementSearchRunnerTest.java
+++ b/core/core-test/src/test/java/org/visallo/core/model/search/ElementSearchRunnerTest.java
@@ -5,9 +5,11 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.vertexium.Element;
 import org.vertexium.Vertex;
 
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 
 import static com.google.common.collect.Iterables.size;
@@ -55,5 +57,58 @@ public class ElementSearchRunnerTest extends SearchRunnerTestBase {
 
         QueryResultsIterableSearchResults results = elementSearchRunner.run(searchOptions, user, authorizations);
         assertEquals(5, size(results.getElements()));
+    }
+
+    @Test
+    public void testSortWithStringArray() throws Exception {
+        Vertex v1 = graph.prepareVertex("v1", visibility)
+                .addPropertyValue("k1", "name", "B", visibility)
+                .save(authorizations);
+        Vertex v2 = graph.prepareVertex("v2", visibility)
+                .addPropertyValue("k1", "name", "A", visibility)
+                .save(authorizations);
+        graph.flush();
+
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("q", "*");
+        parameters.put("filter", new JSONArray());
+        parameters.put("sort[]", new String[] { "name:ASCENDING" });
+        SearchOptions searchOptions = new SearchOptions(parameters, "workspace1");
+
+        QueryResultsIterableSearchResults results = elementSearchRunner.run(searchOptions, user, authorizations);
+        assertEquals(2, size(results.getElements()));
+        Iterator<? extends Element> elements = results.getElements().iterator();
+
+        Element first = elements.next();
+        assertEquals("A", first.getProperty("name").getValue());
+        Element second = elements.next();
+        assertEquals("B", second.getProperty("name").getValue());
+    }
+
+    @Test
+    public void testSortWithJsonArray() throws Exception {
+        Vertex v1 = graph.prepareVertex("v1", visibility)
+                .addPropertyValue("k1", "name", "A", visibility)
+                .save(authorizations);
+        Vertex v2 = graph.prepareVertex("v2", visibility)
+                .addPropertyValue("k1", "name", "B", visibility)
+                .save(authorizations);
+        graph.flush();
+
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("q", "*");
+        parameters.put("filter", new JSONArray());
+        JSONArray sorts = new JSONArray(new String[] { "name:DESCENDING"});
+        parameters.put("sort", sorts);
+        SearchOptions searchOptions = new SearchOptions(parameters, "workspace1");
+
+        QueryResultsIterableSearchResults results = elementSearchRunner.run(searchOptions, user, authorizations);
+        assertEquals(2, size(results.getElements()));
+        Iterator<? extends Element> elements = results.getElements().iterator();
+
+        Element first = elements.next();
+        assertEquals("B", first.getProperty("name").getValue());
+        Element second = elements.next();
+        assertEquals("A", second.getProperty("name").getValue());
     }
 }

--- a/core/core/src/main/java/org/visallo/core/model/search/ElementSearchRunnerBase.java
+++ b/core/core/src/main/java/org/visallo/core/model/search/ElementSearchRunnerBase.java
@@ -173,6 +173,12 @@ public abstract class ElementSearchRunnerBase extends SearchRunner {
     protected void applySortToQuery(QueryAndData queryAndData, SearchOptions searchOptions) {
         String[] sorts = searchOptions.getOptionalParameter("sort[]", String[].class);
         if (sorts == null) {
+            JSONArray sortsJson = searchOptions.getOptionalParameter("sort", JSONArray.class);
+            if (sortsJson != null) {
+                sorts = JSONUtil.toStringList(sortsJson).toArray(new String[sortsJson.length()]);
+            }
+        }
+        if (sorts == null) {
             return;
         }
         for (String sort : sorts) {


### PR DESCRIPTION
- [x] @sfeng88 @rygim @jharwig 
- [x] @srfarley @joeferner
- [x] @EvanOxfeld @joeybrk372
- [x] @mwizeman @dsingley

Convenience for the front-end from having to JSON.encode sort parameters. Allow both legacy `sort[]` with string array, and `sort` that accepts `JsonArray`. Fixes some issues with plugins that call search services.