### PR TITLE
upgrade guice to 4.1.0

### DIFF
--- a/root/pom.xml
+++ b/root/pom.xml
@@ -62,7 +62,7 @@
         <curator.version>2.8.0</curator.version>
         <elasticsearch.version>1.4.4</elasticsearch.version>
         <evo.inflector.version>1.0.1</evo.inflector.version>
-        <guice.version>3.0</guice.version>
+        <guice.version>4.1.0</guice.version>
         <visallo.closure.compiler.version>1.0.0</visallo.closure.compiler.version>
         <hadoop.version>2.6.0-cdh5.4.2</hadoop.version>
         <twill.version>0.4.0-incubating</twill.version>
@@ -291,6 +291,12 @@
                 <groupId>com.google.inject</groupId>
                 <artifactId>guice</artifactId>
                 <version>${guice.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.google.guava</groupId>
+                        <artifactId>guava</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>com.google.inject.extensions</groupId>


### PR DESCRIPTION
- [x] @sfeng88 @rygim @jharwig 
- [x] @srfarley
- [x] @EvanOxfeld @joeybrk372
- [x] @mwizeman @dsingley

Upgrading guava appears to fix the issue of getting `ArrayIndexOutOfBoundsException`s if injecting fails.

I excluded guava because guice wants v19 for some reason even though it doesn't appear to be used in their code anywhere https://github.com/google/guice/search?utf8=%E2%9C%93&q=guava