### PR TITLE
Handle bad comment property keys in javascript

### DIFF
--- a/web/war/src/main/webapp/js/comments/comments.js
+++ b/web/war/src/main/webapp/js/comments/comments.js
@@ -88,7 +88,11 @@ define([
         var isLegacyKeyInServerTimezone = !(/Z$/).test(p.key),
             date = null;
         if (isLegacyKeyInServerTimezone) {
-            date = F.date.utc(new Date(p.key + 'Z').getTime());
+            var time = new Date(p.key + 'Z').getTime();
+            if (isNaN(time)) {
+                return undefined;
+            }
+            date = F.date.utc(time);
         } else {
             date = F.date.local(p.key);
         }
@@ -96,6 +100,7 @@ define([
         if (millis && !isNaN(millis)) {
             return millis;
         }
+        return undefined;
     }
 
     function isEdited(created, modified) {


### PR DESCRIPTION
- [x] @srfarley
- [x] @mwizeman @dsingley @EvanOxfeld 
- [x] @joeybrk372 @sfeng88 @rygim @jharwig 

If a comment is created via RDF or entered by an external process the key may not always be constructed correctly (Should be timestamp). This fix allows the UI to still function under these circumstances. Without it the details pane becomes completely unresponsive in Firefox and IE.