### PR TITLE
Add a shutdown service to provide more consistent shutdown between web and cli

### DIFF
--- a/core/core-test/src/main/java/org/visallo/core/model/lock/LockRepositoryTestBase.java
+++ b/core/core-test/src/main/java/org/visallo/core/model/lock/LockRepositoryTestBase.java
@@ -2,6 +2,8 @@ package org.visallo.core.model.lock;
 
 import org.junit.After;
 import org.junit.Before;
+import org.visallo.core.util.ShutdownListener;
+import org.visallo.core.util.ShutdownService;
 import org.visallo.core.util.VisalloLogger;
 import org.visallo.core.util.VisalloLoggerFactory;
 
@@ -13,6 +15,7 @@ import static org.junit.Assert.assertEquals;
 public abstract class LockRepositoryTestBase {
     private static final VisalloLogger LOGGER = VisalloLoggerFactory.getLogger(LockRepositoryTestBase.class);
     protected LockRepository lockRepository;
+    protected ShutdownService shutdownService = new ShutdownService();
 
     protected abstract LockRepository createLockRepository();
 
@@ -23,7 +26,7 @@ public abstract class LockRepositoryTestBase {
 
     @After
     public void after() throws Exception {
-        lockRepository.shutdown();
+        shutdownService.shutdown();
     }
 
     protected Thread createLockExercisingThread(

--- a/core/core-test/src/main/java/org/visallo/core/util/ShutdownServiceTest.java
+++ b/core/core-test/src/main/java/org/visallo/core/util/ShutdownServiceTest.java
@@ -1,0 +1,66 @@
+package org.visallo.core.util;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class ShutdownServiceTest {
+    private ShutdownService shutdownService;
+    private List<Class> shutdownList;
+
+    @Before
+    public void before() {
+        shutdownService = new ShutdownService();
+        shutdownList = new ArrayList<>();
+    }
+
+    @Test
+    public void testShutdown() {
+        A a = new A();
+        B b = new B(a);
+        shutdownService.register(a);
+        shutdownService.register(b);
+
+        shutdownService.shutdown();
+
+        assertEquals(2, shutdownList.size());
+
+        // B should shutdown first because B depends on A
+        assertEquals(B.class, shutdownList.get(0));
+        assertEquals(A.class, shutdownList.get(1));
+    }
+
+    private class A implements ShutdownListener {
+        public boolean hasShutdown = false;
+
+        public A() {
+            shutdownService.register(this);
+        }
+
+        @Override
+        public void shutdown() {
+            hasShutdown = true;
+            shutdownList.add(A.class);
+        }
+    }
+
+    private class B implements ShutdownListener {
+        private final A a;
+
+        public B(A a) {
+            this.a = a;
+            shutdownService.register(this);
+        }
+
+        @Override
+        public void shutdown() {
+            assertFalse("A should shutdown after B", a.hasShutdown);
+            shutdownList.add(B.class);
+        }
+    }
+}

--- a/core/core/src/main/java/org/visallo/core/bootstrap/GraphShutdownListener.java
+++ b/core/core/src/main/java/org/visallo/core/bootstrap/GraphShutdownListener.java
@@ -1,0 +1,17 @@
+package org.visallo.core.bootstrap;
+
+import org.vertexium.Graph;
+import org.visallo.core.util.ShutdownListener;
+
+public class GraphShutdownListener implements ShutdownListener {
+    private final Graph graph;
+
+    public GraphShutdownListener(Graph graph) {
+        this.graph = graph;
+    }
+
+    @Override
+    public void shutdown() {
+        this.graph.shutdown();
+    }
+}

--- a/core/core/src/main/java/org/visallo/core/bootstrap/SimpleOrmSessionShutdownListener.java
+++ b/core/core/src/main/java/org/visallo/core/bootstrap/SimpleOrmSessionShutdownListener.java
@@ -1,0 +1,17 @@
+package org.visallo.core.bootstrap;
+
+import com.v5analytics.simpleorm.SimpleOrmSession;
+import org.visallo.core.util.ShutdownListener;
+
+public class SimpleOrmSessionShutdownListener implements ShutdownListener {
+    private final SimpleOrmSession simpleOrmSession;
+
+    public SimpleOrmSessionShutdownListener(SimpleOrmSession simpleOrmSession) {
+        this.simpleOrmSession = simpleOrmSession;
+    }
+
+    @Override
+    public void shutdown() {
+        simpleOrmSession.close();
+    }
+}

--- a/core/core/src/main/java/org/visallo/core/bootstrap/VisalloBootstrap.java
+++ b/core/core/src/main/java/org/visallo/core/bootstrap/VisalloBootstrap.java
@@ -12,11 +12,11 @@ import org.visallo.core.email.EmailRepository;
 import org.visallo.core.exception.VisalloException;
 import org.visallo.core.geocoding.GeocoderRepository;
 import org.visallo.core.http.HttpRepository;
+import org.visallo.core.model.directory.DirectoryRepository;
 import org.visallo.core.model.file.FileSystemRepository;
 import org.visallo.core.model.lock.LockRepository;
 import org.visallo.core.model.longRunningProcess.LongRunningProcessRepository;
 import org.visallo.core.model.ontology.OntologyRepository;
-import org.visallo.core.model.directory.DirectoryRepository;
 import org.visallo.core.model.search.SearchRepository;
 import org.visallo.core.model.user.AuthorizationMapper;
 import org.visallo.core.model.user.AuthorizationRepository;
@@ -35,6 +35,7 @@ import org.visallo.core.trace.Traced;
 import org.visallo.core.trace.TracedMethodInterceptor;
 import org.visallo.core.user.User;
 import org.visallo.core.util.ServiceLoaderUtil;
+import org.visallo.core.util.ShutdownService;
 import org.visallo.core.util.VisalloLogger;
 import org.visallo.core.util.VisalloLoggerFactory;
 
@@ -118,71 +119,86 @@ public class VisalloBootstrap extends AbstractModule {
         bindInterceptor(Matchers.any(), Matchers.annotatedWith(Traced.class), new TracedMethodInterceptor());
 
         bind(TraceRepository.class)
-                .toProvider(VisalloBootstrap.<TraceRepository>getConfigurableProvider(configuration, Configuration.TRACE_REPOSITORY))
+                .toProvider(VisalloBootstrap.getConfigurableProvider(configuration, Configuration.TRACE_REPOSITORY))
                 .in(Scopes.SINGLETON);
         bind(Graph.class)
                 .toProvider(getGraphProvider(configuration, Configuration.GRAPH_PROVIDER))
                 .in(Scopes.SINGLETON);
         bind(LockRepository.class)
-                .toProvider(VisalloBootstrap.<LockRepository>getConfigurableProvider(configuration, Configuration.LOCK_REPOSITORY))
+                .toProvider(VisalloBootstrap.getConfigurableProvider(configuration, Configuration.LOCK_REPOSITORY))
                 .in(Scopes.SINGLETON);
         bind(WorkQueueRepository.class)
-                .toProvider(VisalloBootstrap.<WorkQueueRepository>getConfigurableProvider(configuration, Configuration.WORK_QUEUE_REPOSITORY))
+                .toProvider(VisalloBootstrap.getConfigurableProvider(configuration, Configuration.WORK_QUEUE_REPOSITORY))
                 .in(Scopes.SINGLETON);
         bind(LongRunningProcessRepository.class)
-                .toProvider(VisalloBootstrap.<LongRunningProcessRepository>getConfigurableProvider(configuration, Configuration.LONG_RUNNING_PROCESS_REPOSITORY))
+                .toProvider(VisalloBootstrap.getConfigurableProvider(configuration, Configuration.LONG_RUNNING_PROCESS_REPOSITORY))
                 .in(Scopes.SINGLETON);
         bind(DirectoryRepository.class)
-                .toProvider(VisalloBootstrap.<DirectoryRepository>getConfigurableProvider(configuration, Configuration.DIRECTORY_REPOSITORY))
+                .toProvider(VisalloBootstrap.getConfigurableProvider(configuration, Configuration.DIRECTORY_REPOSITORY))
                 .in(Scopes.SINGLETON);
         bind(VisibilityTranslator.class)
-                .toProvider(VisalloBootstrap.<VisibilityTranslator>getConfigurableProvider(configuration, Configuration.VISIBILITY_TRANSLATOR))
+                .toProvider(VisalloBootstrap.getConfigurableProvider(configuration, Configuration.VISIBILITY_TRANSLATOR))
                 .in(Scopes.SINGLETON);
         bind(UserRepository.class)
-                .toProvider(VisalloBootstrap.<UserRepository>getConfigurableProvider(configuration, Configuration.USER_REPOSITORY))
+                .toProvider(VisalloBootstrap.getConfigurableProvider(configuration, Configuration.USER_REPOSITORY))
                 .in(Scopes.SINGLETON);
         bind(UserSessionCounterRepository.class)
-                .toProvider(VisalloBootstrap.<UserSessionCounterRepository>getConfigurableProvider(configuration, Configuration.USER_SESSION_COUNTER_REPOSITORY))
+                .toProvider(VisalloBootstrap.getConfigurableProvider(configuration, Configuration.USER_SESSION_COUNTER_REPOSITORY))
                 .in(Scopes.SINGLETON);
         bind(SearchRepository.class)
-                .toProvider(VisalloBootstrap.<SearchRepository>getConfigurableProvider(configuration, Configuration.SEARCH_REPOSITORY))
+                .toProvider(VisalloBootstrap.getConfigurableProvider(configuration, Configuration.SEARCH_REPOSITORY))
                 .in(Scopes.SINGLETON);
         bind(WorkspaceRepository.class)
-                .toProvider(VisalloBootstrap.<WorkspaceRepository>getConfigurableProvider(configuration, Configuration.WORKSPACE_REPOSITORY))
+                .toProvider(VisalloBootstrap.getConfigurableProvider(configuration, Configuration.WORKSPACE_REPOSITORY))
                 .in(Scopes.SINGLETON);
         bind(AuthorizationRepository.class)
-                .toProvider(VisalloBootstrap.<AuthorizationRepository>getConfigurableProvider(configuration, Configuration.AUTHORIZATION_REPOSITORY))
+                .toProvider(VisalloBootstrap.getConfigurableProvider(configuration, Configuration.AUTHORIZATION_REPOSITORY))
                 .in(Scopes.SINGLETON);
         bind(OntologyRepository.class)
-                .toProvider(VisalloBootstrap.<OntologyRepository>getConfigurableProvider(configuration, Configuration.ONTOLOGY_REPOSITORY))
+                .toProvider(VisalloBootstrap.getConfigurableProvider(configuration, Configuration.ONTOLOGY_REPOSITORY))
                 .in(Scopes.SINGLETON);
         bind(SimpleOrmSession.class)
-                .toProvider(VisalloBootstrap.<SimpleOrmSession>getConfigurableProvider(configuration, Configuration.SIMPLE_ORM_SESSION))
+                .toProvider(getSimpleOrmSessionProvider(configuration, Configuration.SIMPLE_ORM_SESSION))
                 .in(Scopes.SINGLETON);
         bind(HttpRepository.class)
-                .toProvider(VisalloBootstrap.<HttpRepository>getConfigurableProvider(configuration, Configuration.HTTP_REPOSITORY))
+                .toProvider(VisalloBootstrap.getConfigurableProvider(configuration, Configuration.HTTP_REPOSITORY))
                 .in(Scopes.SINGLETON);
         bind(GeocoderRepository.class)
-                .toProvider(VisalloBootstrap.<GeocoderRepository>getConfigurableProvider(configuration, Configuration.GEOCODER_REPOSITORY))
+                .toProvider(VisalloBootstrap.getConfigurableProvider(configuration, Configuration.GEOCODER_REPOSITORY))
                 .in(Scopes.SINGLETON);
         bind(EmailRepository.class)
-                .toProvider(VisalloBootstrap.<EmailRepository>getConfigurableProvider(configuration, Configuration.EMAIL_REPOSITORY))
+                .toProvider(VisalloBootstrap.getConfigurableProvider(configuration, Configuration.EMAIL_REPOSITORY))
                 .in(Scopes.SINGLETON);
         bind(StatusRepository.class)
-                .toProvider(VisalloBootstrap.<StatusRepository>getConfigurableProvider(configuration, Configuration.STATUS_REPOSITORY))
+                .toProvider(VisalloBootstrap.getConfigurableProvider(configuration, Configuration.STATUS_REPOSITORY))
                 .in(Scopes.SINGLETON);
         bind(ACLProvider.class)
-                .toProvider(VisalloBootstrap.<ACLProvider>getConfigurableProvider(configuration, Configuration.ACL_PROVIDER_REPOSITORY))
+                .toProvider(VisalloBootstrap.getConfigurableProvider(configuration, Configuration.ACL_PROVIDER_REPOSITORY))
                 .in(Scopes.SINGLETON);
         bind(FileSystemRepository.class)
-                .toProvider(VisalloBootstrap.<FileSystemRepository>getConfigurableProvider(configuration, Configuration.FILE_SYSTEM_REPOSITORY))
+                .toProvider(VisalloBootstrap.getConfigurableProvider(configuration, Configuration.FILE_SYSTEM_REPOSITORY))
                 .in(Scopes.SINGLETON);
         bind(AuthorizationMapper.class)
-                .toProvider(VisalloBootstrap.<AuthorizationMapper>getConfigurableProvider(configuration, Configuration.AUTHORIZATION_MAPPER))
+                .toProvider(VisalloBootstrap.getConfigurableProvider(configuration, Configuration.AUTHORIZATION_MAPPER))
                 .in(Scopes.SINGLETON);
         bind(TimeRepository.class)
                 .toInstance(new TimeRepository());
         injectProviders();
+    }
+
+    private Provider<? extends SimpleOrmSession> getSimpleOrmSessionProvider(
+            Configuration configuration,
+            String simpleOrmSessionConfigurationName
+    ) {
+        return (Provider<SimpleOrmSession>) () -> {
+            Provider<? extends SimpleOrmSession> provider = VisalloBootstrap.getConfigurableProvider(
+                    configuration,
+                    simpleOrmSessionConfigurationName
+            );
+            SimpleOrmSession simpleOrmSession = provider.get();
+            getShutdownService().register(new SimpleOrmSessionShutdownListener(simpleOrmSession));
+            return simpleOrmSession;
+        };
     }
 
     private Provider<? extends Graph> getGraphProvider(Configuration configuration, String configurationPrefix) {
@@ -208,22 +224,25 @@ public class VisalloBootstrap extends AbstractModule {
             throw new RuntimeException("Could not find create(Map) method on class: " + graphClass.getName(), e);
         }
 
-        return new Provider<Graph>() {
-            @Override
-            public Graph get() {
-                Graph g;
-                try {
-                    LOGGER.debug("creating graph");
-                    g = (Graph) createMethod.invoke(null, configurationSubset);
-                } catch (Exception e) {
-                    throw new RuntimeException("Could not create graph " + graphClass.getName(), e);
-                }
-
-                checkVisalloGraphVersion(g);
-
-                return g;
+        return (Provider<Graph>) () -> {
+            Graph g;
+            try {
+                LOGGER.debug("creating graph");
+                g = (Graph) createMethod.invoke(null, configurationSubset);
+            } catch (Exception e) {
+                throw new RuntimeException("Could not create graph " + graphClass.getName(), e);
             }
+
+            checkVisalloGraphVersion(g);
+
+            getShutdownService().register(new GraphShutdownListener(g));
+
+            return g;
         };
+    }
+
+    private ShutdownService getShutdownService() {
+        return InjectHelper.getInstance(ShutdownService.class);
     }
 
     public void checkVisalloGraphVersion(Graph g) {
@@ -255,7 +274,7 @@ public class VisalloBootstrap extends AbstractModule {
 
     public static <T> Provider<? extends T> getConfigurableProvider(final Configuration config, final String key) {
         Class<? extends T> configuredClass = config.getClass(key);
-        return configuredClass != null ? new ConfigurableProvider<>(configuredClass, config, key, null) : new NullProvider<T>();
+        return configuredClass != null ? new ConfigurableProvider<>(configuredClass, config, key, null) : new NullProvider<>();
     }
 
     private static class NullProvider<T> implements Provider<T> {

--- a/core/core/src/main/java/org/visallo/core/cmdline/CommandLineTool.java
+++ b/core/core/src/main/java/org/visallo/core/cmdline/CommandLineTool.java
@@ -17,6 +17,7 @@ import org.visallo.core.model.user.UserRepository;
 import org.visallo.core.model.workQueue.WorkQueueRepository;
 import org.visallo.core.security.VisibilityTranslator;
 import org.visallo.core.user.User;
+import org.visallo.core.util.ShutdownService;
 import org.visallo.core.util.VersionUtil;
 import org.visallo.core.util.VisalloLogger;
 import org.visallo.core.util.VisalloLoggerFactory;
@@ -36,6 +37,7 @@ public abstract class CommandLineTool {
     private OntologyRepository ontologyRepository;
     private VisibilityTranslator visibilityTranslator;
     private SimpleOrmSession simpleOrmSession;
+    private ShutdownService shutdownService;
 
     @Parameter(names = {"--help", "-h"}, description = "Print help", help = true)
     private boolean help;
@@ -105,22 +107,7 @@ public abstract class CommandLineTool {
     }
 
     protected void shutdown() {
-        if (this.lockRepository != null) {
-            LOGGER.debug("shutting down %s", this.lockRepository.getClass().getName());
-            this.lockRepository.shutdown();
-        }
-        if (graph != null) {
-            LOGGER.debug("shutting down %s", this.graph.getClass().getName());
-            this.graph.shutdown();
-        }
-        if (this.workQueueRepository != null) {
-            LOGGER.debug("shutting down %s", this.workQueueRepository.getClass().getName());
-            this.workQueueRepository.shutdown();
-        }
-        if (this.simpleOrmSession != null) {
-            LOGGER.debug("shutting down %s", this.simpleOrmSession.getClass().getName());
-            this.simpleOrmSession.close();
-        }
+        getShutdownService().shutdown();
     }
 
     protected abstract int run() throws Exception;
@@ -180,6 +167,11 @@ public abstract class CommandLineTool {
         this.simpleOrmSession = simpleOrmSession;
     }
 
+    @Inject
+    public void setShutdownService(ShutdownService shutdownService) {
+        this.shutdownService = shutdownService;
+    }
+
     public SimpleOrmSession getSimpleOrmSession() {
         return simpleOrmSession;
     }
@@ -202,6 +194,10 @@ public abstract class CommandLineTool {
 
     public VisibilityTranslator getVisibilityTranslator() {
         return visibilityTranslator;
+    }
+
+    public ShutdownService getShutdownService() {
+        return shutdownService;
     }
 
     @Inject

--- a/core/core/src/main/java/org/visallo/core/model/WorkerBase.java
+++ b/core/core/src/main/java/org/visallo/core/model/WorkerBase.java
@@ -2,6 +2,7 @@ package org.visallo.core.model;
 
 import org.json.JSONObject;
 import org.visallo.core.config.Configuration;
+import org.visallo.core.exception.VisalloException;
 import org.visallo.core.ingest.WorkerSpout;
 import org.visallo.core.ingest.WorkerTuple;
 import org.visallo.core.model.workQueue.WorkQueueRepository;
@@ -17,7 +18,10 @@ public abstract class WorkerBase {
 
     protected WorkerBase(WorkQueueRepository workQueueRepository, Configuration configuration) {
         this.workQueueRepository = workQueueRepository;
-        this.statusEnabled = configuration.getBoolean(Configuration.STATUS_ENABLED, Configuration.STATUS_ENABLED_DEFAULT);
+        this.statusEnabled = configuration.getBoolean(
+                Configuration.STATUS_ENABLED,
+                Configuration.STATUS_ENABLED_DEFAULT
+        );
     }
 
     public void run() throws Exception {
@@ -30,7 +34,12 @@ public abstract class WorkerBase {
             statusServer = createStatusServer();
         }
         while (shouldRun) {
-            WorkerTuple tuple = workerSpout.nextTuple();
+            WorkerTuple tuple;
+            try {
+                tuple = workerSpout.nextTuple();
+            } catch (Exception ex) {
+                throw new VisalloException("Failed to get next tuple", ex);
+            }
             if (tuple == null) {
                 Thread.sleep(100);
                 continue;
@@ -72,7 +81,7 @@ public abstract class WorkerBase {
         return workQueueRepository;
     }
 
-    public boolean shouldRun(){
+    public boolean shouldRun() {
         return shouldRun;
     }
 }

--- a/core/core/src/main/java/org/visallo/core/model/lock/LockRepository.java
+++ b/core/core/src/main/java/org/visallo/core/model/lock/LockRepository.java
@@ -51,6 +51,4 @@ public abstract class LockRepository {
     public abstract Lock createLock(String lockName);
 
     public abstract void leaderElection(String lockName, LeaderListener listener);
-
-    public abstract void shutdown();
 }

--- a/core/core/src/main/java/org/visallo/core/model/lock/NonLockingLockRepository.java
+++ b/core/core/src/main/java/org/visallo/core/model/lock/NonLockingLockRepository.java
@@ -1,10 +1,26 @@
 package org.visallo.core.model.lock;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.inject.Inject;
+import org.visallo.core.util.ShutdownListener;
+import org.visallo.core.util.ShutdownService;
+
 import java.util.WeakHashMap;
 import java.util.concurrent.Callable;
 
-public class NonLockingLockRepository extends LockRepository {
+public class NonLockingLockRepository extends LockRepository implements ShutdownListener {
     private WeakHashMap<Long, Thread> threads = new WeakHashMap<>();
+
+    // available for testing when you don't need perfect shutdown behavior
+    @VisibleForTesting
+    public NonLockingLockRepository() {
+
+    }
+
+    @Inject
+    public NonLockingLockRepository(ShutdownService shutdownService) {
+        shutdownService.register(this);
+    }
 
     @Override
     public Lock createLock(String lockName) {

--- a/core/core/src/main/java/org/visallo/core/model/lock/SingleJvmLockRepository.java
+++ b/core/core/src/main/java/org/visallo/core/model/lock/SingleJvmLockRepository.java
@@ -1,12 +1,27 @@
 package org.visallo.core.model.lock;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.inject.Inject;
 import org.visallo.core.exception.VisalloException;
+import org.visallo.core.util.ShutdownListener;
+import org.visallo.core.util.ShutdownService;
 
 import java.util.WeakHashMap;
 import java.util.concurrent.Callable;
 
-public class SingleJvmLockRepository extends LockRepository {
+public class SingleJvmLockRepository extends LockRepository implements ShutdownListener {
     private WeakHashMap<Long, Thread> threads = new WeakHashMap<>();
+
+    // available for testing when you don't need perfect shutdown behavior
+    @VisibleForTesting
+    public SingleJvmLockRepository() {
+
+    }
+
+    @Inject
+    public SingleJvmLockRepository(ShutdownService shutdownService) {
+        shutdownService.register(this);
+    }
 
     @Override
     public Lock createLock(String lockName) {

--- a/core/core/src/main/java/org/visallo/core/model/workQueue/WorkQueueRepository.java
+++ b/core/core/src/main/java/org/visallo/core/model/workQueue/WorkQueueRepository.java
@@ -52,12 +52,22 @@ public abstract class WorkQueueRepository {
         pushGraphPropertyQueue(element, property.getKey(), property.getName(), priority);
     }
 
-    public void pushGraphPropertyQueue(final Element element, final Property property, ElementOrPropertyStatus status, Long beforeActionTimestamp, Priority priority) {
+    public void pushGraphPropertyQueue(
+            final Element element,
+            final Property property,
+            ElementOrPropertyStatus status,
+            Long beforeActionTimestamp,
+            Priority priority
+    ) {
         checkNotNull(property, "property cannot be null");
         pushGraphPropertyQueue(element, property.getKey(), property.getName(), status, beforeActionTimestamp, priority);
     }
 
-    public void pushGraphVisalloPropertyQueue(final Element element, final Iterable<VisalloPropertyUpdate> properties, Priority priority) {
+    public void pushGraphVisalloPropertyQueue(
+            final Element element,
+            final Iterable<VisalloPropertyUpdate> properties,
+            Priority priority
+    ) {
         pushGraphVisalloPropertyQueue(element, properties, null, null, priority);
     }
 
@@ -87,30 +97,79 @@ public abstract class WorkQueueRepository {
         }
     }
 
-    public void pushGraphPropertyQueue(final Element element, final Property property, String workspaceId, String visibilitySource, Priority priority) {
-        pushGraphPropertyQueue(element, property.getKey(), property.getName(), workspaceId, visibilitySource, ElementOrPropertyStatus.UPDATE, null, priority);
+    public void pushGraphPropertyQueue(
+            final Element element,
+            final Property property,
+            String workspaceId,
+            String visibilitySource,
+            Priority priority
+    ) {
+        pushGraphPropertyQueue(
+                element,
+                property.getKey(),
+                property.getName(),
+                workspaceId,
+                visibilitySource,
+                ElementOrPropertyStatus.UPDATE,
+                null,
+                priority
+        );
     }
 
-    public void pushGraphPropertyQueue(final Element element, final Property property, String workspaceId, String visibilitySource, Priority priority, FlushFlag flushFlag) {
-        pushGraphPropertyQueue(element, property.getKey(), property.getName(), workspaceId, visibilitySource, priority, ElementOrPropertyStatus.UPDATE, null, flushFlag);
+    public void pushGraphPropertyQueue(
+            final Element element,
+            final Property property,
+            String workspaceId,
+            String visibilitySource,
+            Priority priority,
+            FlushFlag flushFlag
+    ) {
+        pushGraphPropertyQueue(
+                element,
+                property.getKey(),
+                property.getName(),
+                workspaceId,
+                visibilitySource,
+                priority,
+                ElementOrPropertyStatus.UPDATE,
+                null,
+                flushFlag
+        );
     }
 
-    public void pushGraphPropertyQueue(final Element element,
-                                       final Property property,
-                                       String workspaceId,
-                                       String visibilitySource,
-                                       Priority priority,
-                                       ElementOrPropertyStatus status,
-                                       Long beforeActionTimestamp,
-                                       FlushFlag flushFlag) {
-        pushGraphPropertyQueue(element, property.getKey(), property.getName(), workspaceId, visibilitySource, priority, status, beforeActionTimestamp, flushFlag);
+    public void pushGraphPropertyQueue(
+            final Element element,
+            final Property property,
+            String workspaceId,
+            String visibilitySource,
+            Priority priority,
+            ElementOrPropertyStatus status,
+            Long beforeActionTimestamp,
+            FlushFlag flushFlag
+    ) {
+        pushGraphPropertyQueue(
+                element,
+                property.getKey(),
+                property.getName(),
+                workspaceId,
+                visibilitySource,
+                priority,
+                status,
+                beforeActionTimestamp,
+                flushFlag
+        );
     }
 
     public void pushElementImageQueue(final Element element, final Property property, Priority priority) {
         pushElementImageQueue(element, property.getKey(), property.getName(), priority);
     }
 
-    public void pushElementImageQueue(final Element element, String propertyKey, final String propertyName, Priority priority) {
+    public void pushElementImageQueue(
+            final Element element,
+            String propertyKey,
+            final String propertyName,
+            Priority priority
+    ) {
         getGraph().flush();
         checkNotNull(element);
         JSONObject data = new JSONObject();
@@ -132,7 +191,8 @@ public abstract class WorkQueueRepository {
             final Element element,
             String propertyKey,
             final String propertyName,
-            Priority priority) {
+            Priority priority
+    ) {
         pushGraphPropertyQueue(element, propertyKey, propertyName, ElementOrPropertyStatus.UPDATE, null, priority);
     }
 
@@ -141,7 +201,8 @@ public abstract class WorkQueueRepository {
             String propertyKey,
             final String propertyName,
             Long beforeActionTimestamp,
-            Priority priority) {
+            Priority priority
+    ) {
         pushGraphPropertyQueue(
                 element, propertyKey, propertyName, ElementOrPropertyStatus.UPDATE, beforeActionTimestamp, priority);
     }
@@ -152,7 +213,8 @@ public abstract class WorkQueueRepository {
             final String propertyName,
             ElementOrPropertyStatus status,
             Long beforeActionTimestamp,
-            Priority priority) {
+            Priority priority
+    ) {
         pushGraphPropertyQueue(
                 element,
                 propertyKey,
@@ -173,7 +235,17 @@ public abstract class WorkQueueRepository {
             String visibilitySource,
             Priority priority
     ) {
-        pushGraphPropertyQueue(element, propertyKey, propertyName, workspaceId, visibilitySource, priority, ElementOrPropertyStatus.UPDATE, null, FlushFlag.DEFAULT);
+        pushGraphPropertyQueue(
+                element,
+                propertyKey,
+                propertyName,
+                workspaceId,
+                visibilitySource,
+                priority,
+                ElementOrPropertyStatus.UPDATE,
+                null,
+                FlushFlag.DEFAULT
+        );
     }
 
     public void pushGraphPropertyQueue(
@@ -200,15 +272,17 @@ public abstract class WorkQueueRepository {
     }
 
 
-    public void pushMultipleGraphPropertyQueue(final Iterable<? extends Element> elements,
-                                               String propertyKey,
-                                               final String propertyName,
-                                               String workspaceId,
-                                               String visibilitySource,
-                                               Priority priority,
-                                               ElementOrPropertyStatus status,
-                                               Long beforeActionTimestamp,
-                                               FlushFlag flushFlag) {
+    public void pushMultipleGraphPropertyQueue(
+            final Iterable<? extends Element> elements,
+            String propertyKey,
+            final String propertyName,
+            String workspaceId,
+            String visibilitySource,
+            Priority priority,
+            ElementOrPropertyStatus status,
+            Long beforeActionTimestamp,
+            FlushFlag flushFlag
+    ) {
 
         checkNotNull(elements);
         if (!elements.iterator().hasNext()) {
@@ -217,7 +291,14 @@ public abstract class WorkQueueRepository {
 
         getGraph().flush();
 
-        JSONObject data = createPropertySpecificJSON(propertyKey, propertyName, workspaceId, visibilitySource, status, beforeActionTimestamp);
+        JSONObject data = createPropertySpecificJSON(
+                propertyKey,
+                propertyName,
+                workspaceId,
+                visibilitySource,
+                status,
+                beforeActionTimestamp
+        );
         JSONArray vertices = new JSONArray();
         JSONArray edges = new JSONArray();
 
@@ -262,7 +343,14 @@ public abstract class WorkQueueRepository {
         getGraph().flush();
         checkNotNull(element);
 
-        JSONObject data = createPropertySpecificJSON(propertyKey, propertyName, workspaceId, visibilitySource, status, beforeDeleteTimestamp);
+        JSONObject data = createPropertySpecificJSON(
+                propertyKey,
+                propertyName,
+                workspaceId,
+                visibilitySource,
+                status,
+                beforeDeleteTimestamp
+        );
 
         if (element instanceof Vertex) {
             data.put(GraphPropertyMessage.GRAPH_VERTEX_ID, element.getId());
@@ -299,7 +387,8 @@ public abstract class WorkQueueRepository {
             String workspaceId,
             String visibilitySource,
             ElementOrPropertyStatus status,
-            Long beforeActionTimestamp) {
+            Long beforeActionTimestamp
+    ) {
         JSONObject data = new JSONObject();
 
         if (workspaceId != null && !workspaceId.equals("")) {
@@ -360,7 +449,13 @@ public abstract class WorkQueueRepository {
         pushOnQueue(workQueueNames.getGraphPropertyQueueName(), flushFlag, data, priority);
     }
 
-    protected boolean shouldBroadcastGraphPropertyChange(Element element, String propertyKey, String propertyName, String workspaceId, Priority priority) {
+    protected boolean shouldBroadcastGraphPropertyChange(
+            Element element,
+            String propertyKey,
+            String propertyName,
+            String workspaceId,
+            Priority priority
+    ) {
         return shouldBroadcast(priority);
     }
 
@@ -444,7 +539,17 @@ public abstract class WorkQueueRepository {
     }
 
     public void pushElements(Iterable<? extends Element> elements, Priority priority) {
-        pushMultipleGraphPropertyQueue(elements, null, null, null, null, priority, ElementOrPropertyStatus.UPDATE, null, FlushFlag.DEFAULT);
+        pushMultipleGraphPropertyQueue(
+                elements,
+                null,
+                null,
+                null,
+                null,
+                priority,
+                ElementOrPropertyStatus.UPDATE,
+                null,
+                FlushFlag.DEFAULT
+        );
     }
 
     public void pushElement(Element element) {
@@ -466,7 +571,13 @@ public abstract class WorkQueueRepository {
         pushGraphPropertyQueue(vertex, null, null, ElementOrPropertyStatus.DELETION, beforeDeletionTimestamp, priority);
     }
 
-    public void pushPublishedPropertyDeletion(Element element, String key, String name, long beforeDeletionTimestamp, Priority priority) {
+    public void pushPublishedPropertyDeletion(
+            Element element,
+            String key,
+            String name,
+            long beforeDeletionTimestamp,
+            Priority priority
+    ) {
         broadcastPublishPropertyDelete(element, key, name);
         pushGraphPropertyQueue(element, key, name, ElementOrPropertyStatus.DELETION, beforeDeletionTimestamp, priority);
     }
@@ -476,7 +587,13 @@ public abstract class WorkQueueRepository {
         pushGraphPropertyQueue(element, key, name, ElementOrPropertyStatus.UNHIDDEN, null, priority);
     }
 
-    public void pushUndoSandboxProperty(Element element, String key, String name, long beforeDeletionTimestamp, Priority priority) {
+    public void pushUndoSandboxProperty(
+            Element element,
+            String key,
+            String name,
+            long beforeDeletionTimestamp,
+            Priority priority
+    ) {
         broadcastUndoPropertyDelete(element, key, name);
         pushGraphPropertyQueue(element, key, name, ElementOrPropertyStatus.DELETION, beforeDeletionTimestamp, priority);
     }
@@ -581,7 +698,12 @@ public abstract class WorkQueueRepository {
         broadcastUserWorkspaceChange(user, workspaceId);
     }
 
-    public void pushWorkspaceChange(ClientApiWorkspace workspace, List<ClientApiWorkspace.User> previousUsers, String changedByUserId, String changedBySourceGuid) {
+    public void pushWorkspaceChange(
+            ClientApiWorkspace workspace,
+            List<ClientApiWorkspace.User> previousUsers,
+            String changedByUserId,
+            String changedBySourceGuid
+    ) {
         broadcastWorkspace(workspace, previousUsers, changedByUserId, changedBySourceGuid);
     }
 
@@ -594,7 +716,12 @@ public abstract class WorkQueueRepository {
         broadcastJson(json);
     }
 
-    protected void broadcastWorkspace(ClientApiWorkspace workspace, List<ClientApiWorkspace.User> previousUsers, String changedByUserId, String changedBySourceGuid) {
+    protected void broadcastWorkspace(
+            ClientApiWorkspace workspace,
+            List<ClientApiWorkspace.User> previousUsers,
+            String changedByUserId,
+            String changedBySourceGuid
+    ) {
         JSONObject json = new JSONObject();
         json.put("type", "workspaceChange");
         json.put("modifiedBy", changedByUserId);
@@ -624,7 +751,10 @@ public abstract class WorkQueueRepository {
         broadcastJson(json);
     }
 
-    private JSONObject getPermissionsWithUsers(ClientApiWorkspace workspace, List<ClientApiWorkspace.User> previousUsers) {
+    private JSONObject getPermissionsWithUsers(
+            ClientApiWorkspace workspace,
+            List<ClientApiWorkspace.User> previousUsers
+    ) {
         JSONObject permissions = new JSONObject();
         JSONArray users = new JSONArray();
         if (previousUsers != null) {
@@ -698,7 +828,12 @@ public abstract class WorkQueueRepository {
         broadcastJson(json);
     }
 
-    protected void broadcastPropertyChange(Element element, String propertyKey, String propertyName, String workspaceId) {
+    protected void broadcastPropertyChange(
+            Element element,
+            String propertyKey,
+            String propertyName,
+            String workspaceId
+    ) {
         try {
             JSONObject json;
             if (element instanceof Vertex) {
@@ -737,7 +872,12 @@ public abstract class WorkQueueRepository {
         return json;
     }
 
-    protected JSONObject getBroadcastPropertyChangeJson(Vertex graphVertex, String propertyKey, String propertyName, String workspaceId) {
+    protected JSONObject getBroadcastPropertyChangeJson(
+            Vertex graphVertex,
+            String propertyKey,
+            String propertyName,
+            String workspaceId
+    ) {
         // TODO: only broadcast to workspace users if sandboxStatus is PRIVATE
         JSONObject json = new JSONObject();
         json.put("type", "propertyChange");
@@ -751,7 +891,12 @@ public abstract class WorkQueueRepository {
         return json;
     }
 
-    protected JSONObject getBroadcastPropertyChangeJson(Edge edge, String propertyKey, String propertyName, String workspaceId) {
+    protected JSONObject getBroadcastPropertyChangeJson(
+            Edge edge,
+            String propertyKey,
+            String propertyName,
+            String workspaceId
+    ) {
         // TODO: only broadcast to workspace users if sandboxStatus is PRIVATE
         JSONObject json = new JSONObject();
         json.put("type", "propertyChange");
@@ -765,7 +910,12 @@ public abstract class WorkQueueRepository {
         return json;
     }
 
-    public abstract void pushOnQueue(String queueName, @Deprecated FlushFlag flushFlag, JSONObject json, Priority priority);
+    public abstract void pushOnQueue(
+            String queueName,
+            @Deprecated FlushFlag flushFlag,
+            JSONObject json,
+            Priority priority
+    );
 
     public void init(Map map) {
 
@@ -806,10 +956,6 @@ public abstract class WorkQueueRepository {
     public abstract void subscribeToBroadcastMessages(BroadcastConsumer broadcastConsumer);
 
     public abstract WorkerSpout createWorkerSpout(String queueName);
-
-    public void shutdown() {
-
-    }
 
     public void broadcastPublishVertexDelete(Vertex vertex) {
         broadcastPublish(vertex, PublishType.DELETE);
@@ -879,7 +1025,12 @@ public abstract class WorkQueueRepository {
         }
     }
 
-    protected JSONObject getBroadcastPublishJson(Vertex graphVertex, String propertyKey, String propertyName, PublishType publishType) {
+    protected JSONObject getBroadcastPublishJson(
+            Vertex graphVertex,
+            String propertyKey,
+            String propertyName,
+            PublishType publishType
+    ) {
         JSONObject json = new JSONObject();
         json.put("type", "publish");
 
@@ -896,7 +1047,12 @@ public abstract class WorkQueueRepository {
         return json;
     }
 
-    protected JSONObject getBroadcastPublishJson(Edge edge, String propertyKey, String propertyName, PublishType publishType) {
+    protected JSONObject getBroadcastPublishJson(
+            Edge edge,
+            String propertyKey,
+            String propertyName,
+            PublishType publishType
+    ) {
         JSONObject json = new JSONObject();
         json.put("type", "publish");
 

--- a/core/core/src/main/java/org/visallo/core/util/ShutdownListener.java
+++ b/core/core/src/main/java/org/visallo/core/util/ShutdownListener.java
@@ -1,0 +1,8 @@
+package org.visallo.core.util;
+
+/**
+ * Implementors of this class must call {@link ShutdownService#register(ShutdownListener)} to be notified of shutdown
+ */
+public interface ShutdownListener {
+    void shutdown();
+}

--- a/core/core/src/main/java/org/visallo/core/util/ShutdownService.java
+++ b/core/core/src/main/java/org/visallo/core/util/ShutdownService.java
@@ -1,0 +1,46 @@
+package org.visallo.core.util;
+
+import com.google.common.collect.Lists;
+import com.google.inject.Singleton;
+import com.v5analytics.simpleorm.SimpleOrmSession;
+import org.vertexium.Graph;
+import org.visallo.core.bootstrap.InjectHelper;
+import org.visallo.core.bootstrap.VisalloBootstrap;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+
+@Singleton
+public class ShutdownService {
+    private static final VisalloLogger LOGGER = VisalloLoggerFactory.getLogger(ShutdownService.class);
+    private LinkedHashSet<ShutdownListener> shutdownListeners = new LinkedHashSet<>();
+
+    public void shutdown() {
+        // shutdown in reverse order to better handle dependencies
+        List<ShutdownListener> shutdownListenersList = Lists.reverse(new ArrayList<>(shutdownListeners));
+        for (ShutdownListener shutdownListener : shutdownListenersList) {
+            try {
+                LOGGER.info("Shutdown: " + shutdownListener.getClass().getName());
+                shutdownListener.shutdown();
+            } catch (Exception e) {
+                LOGGER.error("Unable to shutdown: " + shutdownListener.getClass().getName(), e);
+            }
+        }
+
+        LOGGER.info("Shutdown: InjectHelper");
+        InjectHelper.shutdown();
+
+        LOGGER.info("Shutdown: VisalloBootstrap");
+        VisalloBootstrap.shutdown();
+    }
+
+    /**
+     * Classes that implement {@link ShutdownListener} call this method to be notified of
+     * a Visallo shutdown. We can not use the service locator pattern to find shutdown listeners because that
+     * may cause an inadvertent initialization of that class.
+     */
+    public void register(ShutdownListener shutdownListener) {
+        this.shutdownListeners.add(shutdownListener);
+    }
+}

--- a/web/web-base/src/main/java/org/visallo/web/initializers/ApplicationBootstrapInitializer.java
+++ b/web/web-base/src/main/java/org/visallo/web/initializers/ApplicationBootstrapInitializer.java
@@ -1,13 +1,7 @@
 package org.visallo.web.initializers;
 
 import javax.servlet.ServletContext;
-import java.io.Closeable;
-import java.io.IOException;
 
-public abstract class ApplicationBootstrapInitializer implements Closeable {
+public abstract class ApplicationBootstrapInitializer {
     public abstract void initialize(ServletContext context);
-
-    @Override
-    public void close() throws IOException {
-    }
 }

--- a/web/web-base/src/main/java/org/visallo/web/initializers/ExternalResourceWorkersInitializer.java
+++ b/web/web-base/src/main/java/org/visallo/web/initializers/ExternalResourceWorkersInitializer.java
@@ -6,14 +6,14 @@ import org.visallo.core.externalResource.ExternalResourceRunner;
 import org.visallo.core.model.user.UserRepository;
 import org.visallo.core.status.StatusRepository;
 import org.visallo.core.user.User;
+import org.visallo.core.util.ShutdownListener;
+import org.visallo.core.util.ShutdownService;
 import org.visallo.core.util.VisalloLogger;
 import org.visallo.core.util.VisalloLoggerFactory;
 
 import javax.servlet.ServletContext;
-import java.io.IOException;
-import java.util.Collection;
 
-public class ExternalResourceWorkersInitializer extends ApplicationBootstrapInitializer {
+public class ExternalResourceWorkersInitializer extends ApplicationBootstrapInitializer implements ShutdownListener {
     private static final VisalloLogger LOGGER = VisalloLoggerFactory.getLogger(ExternalResourceWorkersInitializer.class);
     private final Configuration config;
     private final UserRepository userRepository;
@@ -24,11 +24,13 @@ public class ExternalResourceWorkersInitializer extends ApplicationBootstrapInit
     public ExternalResourceWorkersInitializer(
             Configuration config,
             UserRepository userRepository,
-            StatusRepository statusRepository
+            StatusRepository statusRepository,
+            ShutdownService shutdownService
     ) {
         this.config = config;
         this.userRepository = userRepository;
         this.statusRepository = statusRepository;
+        shutdownService.register(this);
     }
 
     @Override
@@ -41,7 +43,7 @@ public class ExternalResourceWorkersInitializer extends ApplicationBootstrapInit
     }
 
     @Override
-    public void close() throws IOException {
+    public void shutdown() {
         if (resourceRunner != null) {
             resourceRunner.shutdown();
         }

--- a/web/web-base/src/main/java/org/visallo/web/initializers/GraphPropertyWorkerRunnerInitializer.java
+++ b/web/web-base/src/main/java/org/visallo/web/initializers/GraphPropertyWorkerRunnerInitializer.java
@@ -6,15 +6,13 @@ import org.visallo.core.config.Configuration;
 import org.visallo.core.ingest.graphProperty.GraphPropertyRunner;
 import org.visallo.core.model.user.UserRepository;
 import org.visallo.core.user.User;
-import org.visallo.core.util.StoppableRunnable;
-import org.visallo.core.util.VisalloLogger;
-import org.visallo.core.util.VisalloLoggerFactory;
+import org.visallo.core.util.*;
 
 import javax.servlet.ServletContext;
 import java.util.ArrayList;
 import java.util.List;
 
-public class GraphPropertyWorkerRunnerInitializer extends ApplicationBootstrapInitializer {
+public class GraphPropertyWorkerRunnerInitializer extends ApplicationBootstrapInitializer implements ShutdownListener {
     private static final String CONFIG_THREAD_COUNT = GraphPropertyWorkerRunnerInitializer.class.getName() + ".threadCount";
     private static final int DEFAULT_THREAD_COUNT = 1;
     private static final VisalloLogger LOGGER = VisalloLoggerFactory.getLogger(GraphPropertyWorkerRunnerInitializer.class);
@@ -26,10 +24,12 @@ public class GraphPropertyWorkerRunnerInitializer extends ApplicationBootstrapIn
     @Inject
     public GraphPropertyWorkerRunnerInitializer(
             Configuration config,
-            UserRepository userRepository
+            UserRepository userRepository,
+            ShutdownService shutdownService
     ) {
         this.config = config;
         this.userRepository = userRepository;
+        shutdownService.register(this);
     }
 
     @Override
@@ -77,7 +77,7 @@ public class GraphPropertyWorkerRunnerInitializer extends ApplicationBootstrapIn
     }
 
     @Override
-    public void close() {
+    public void shutdown() {
         stoppables.forEach(StoppableRunnable::stop);
     }
 }

--- a/web/web-base/src/main/java/org/visallo/web/initializers/LongRunningProcessRunnerInitializer.java
+++ b/web/web-base/src/main/java/org/visallo/web/initializers/LongRunningProcessRunnerInitializer.java
@@ -4,15 +4,13 @@ import com.google.inject.Inject;
 import org.visallo.core.bootstrap.InjectHelper;
 import org.visallo.core.config.Configuration;
 import org.visallo.core.model.longRunningProcess.LongRunningProcessRunner;
-import org.visallo.core.util.StoppableRunnable;
-import org.visallo.core.util.VisalloLogger;
-import org.visallo.core.util.VisalloLoggerFactory;
+import org.visallo.core.util.*;
 
 import javax.servlet.ServletContext;
 import java.util.ArrayList;
 import java.util.List;
 
-public class LongRunningProcessRunnerInitializer extends ApplicationBootstrapInitializer {
+public class LongRunningProcessRunnerInitializer extends ApplicationBootstrapInitializer implements ShutdownListener {
     private static final String CONFIG_THREAD_COUNT = LongRunningProcessRunnerInitializer.class.getName() + ".threadCount";
     private static final int DEFAULT_THREAD_COUNT = 1;
     private static final VisalloLogger LOGGER = VisalloLoggerFactory.getLogger(LongRunningProcessRunnerInitializer.class);
@@ -21,8 +19,9 @@ public class LongRunningProcessRunnerInitializer extends ApplicationBootstrapIni
     private final List<StoppableRunnable> stoppables = new ArrayList<>();
 
     @Inject
-    public LongRunningProcessRunnerInitializer(Configuration config) {
+    public LongRunningProcessRunnerInitializer(Configuration config, ShutdownService shutdownService) {
         this.config = config;
+        shutdownService.register(this);
     }
 
     @Override
@@ -69,7 +68,7 @@ public class LongRunningProcessRunnerInitializer extends ApplicationBootstrapIni
     }
 
     @Override
-    public void close() {
+    public void shutdown() {
         stoppables.forEach(StoppableRunnable::stop);
     }
 }


### PR DESCRIPTION
- [x] @srfarley 
- [x] @mwizeman @dsingley @EvanOxfeld 
- [x] @joeybrk372 @sfeng88 @rygim @jharwig 

Features
- Any plugin can now register to be shutdown via `ShutdownService#register` method. I didn't want to use the service discovery pattern here because that could prematurely initialize plugins/classes during the shutdown phase.
- In `VisalloBootstrap` I register both `Graph` and `SimpleOrmSession` for shutdown so not more special handling of those classes.
- Shutdown order is in reverse order from startup order. So this should create a cleaner shutdown.