### PR TITLE
Fix bug with rendering edge comments, and factor out common code between vertex and edge set property routes into a helper class

### DIFF
--- a/web/web-base/src/main/java/org/visallo/web/SetPropertyRouteHelper.java
+++ b/web/web-base/src/main/java/org/visallo/web/SetPropertyRouteHelper.java
@@ -1,0 +1,61 @@
+package org.visallo.web;
+
+import com.google.inject.Inject;
+import org.vertexium.Authorizations;
+import org.vertexium.Graph;
+import org.visallo.core.exception.VisalloException;
+import org.visallo.core.model.properties.VisalloProperties;
+import org.visallo.core.security.VisibilityTranslator;
+import org.visallo.core.user.User;
+import org.visallo.core.util.VisalloLogger;
+import org.visallo.core.util.VisalloLoggerFactory;
+
+import javax.servlet.http.HttpServletRequest;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.ResourceBundle;
+import java.util.TimeZone;
+
+public class SetPropertyRouteHelper {
+    private static final VisalloLogger LOGGER = VisalloLoggerFactory.getLogger(SetPropertyRouteHelper.class);
+
+    private Graph graph;
+    private VisibilityTranslator visibilityTranslator;
+
+    @Inject
+    public SetPropertyRouteHelper(Graph graph, VisibilityTranslator visibilityTranslator) {
+        this.graph = graph;
+        this.visibilityTranslator = visibilityTranslator;
+    }
+
+    public boolean isCommentProperty(String propertyName) {
+        return VisalloProperties.COMMENT.isSameName(propertyName);
+    }
+
+    public String createPropertyKey(String propertyName, Graph graph) {
+        return isCommentProperty(propertyName) ? createCommentPropertyKey() : graph.getIdGenerator().nextId();
+    }
+
+    public void checkVisibilityParameter(
+            String visibilitySource, Authorizations authorizations, User user, ResourceBundle resourceBundle) {
+        if (!graph.isVisibilityValid(visibilityTranslator.toVisibility(visibilitySource).getVisibility(), authorizations)) {
+            LOGGER.warn("%s is not a valid visibility for %s user", visibilitySource, user.getDisplayName());
+            throw new BadRequestException("visibilitySource", resourceBundle.getString("visibility.invalid"));
+        }
+    }
+
+    public void checkRoutePath(String entityType, String propertyName, HttpServletRequest request) {
+        boolean isComment = isCommentProperty(propertyName);
+        if (isComment && request.getPathInfo().equals(String.format("/%s/property", entityType))) {
+            throw new VisalloException(String.format("Use /%s/comment to save comment properties", entityType));
+        } else if (!isComment && request.getPathInfo().equals(String.format("/%s/comment", entityType))) {
+            throw new VisalloException(String.format("Use /%s/property to save non-comment properties", entityType));
+        }
+    }
+
+    private static String createCommentPropertyKey() {
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+        dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+        return dateFormat.format(new Date());
+    }
+}

--- a/web/web-base/src/main/java/org/visallo/web/routes/SetPropertyBase.java
+++ b/web/web-base/src/main/java/org/visallo/web/routes/SetPropertyBase.java
@@ -1,6 +1,5 @@
-package org.visallo.web;
+package org.visallo.web.routes;
 
-import com.google.inject.Inject;
 import org.vertexium.Authorizations;
 import org.vertexium.Graph;
 import org.visallo.core.exception.VisalloException;
@@ -9,6 +8,7 @@ import org.visallo.core.security.VisibilityTranslator;
 import org.visallo.core.user.User;
 import org.visallo.core.util.VisalloLogger;
 import org.visallo.core.util.VisalloLoggerFactory;
+import org.visallo.web.BadRequestException;
 
 import javax.servlet.http.HttpServletRequest;
 import java.text.SimpleDateFormat;
@@ -16,27 +16,26 @@ import java.util.Date;
 import java.util.ResourceBundle;
 import java.util.TimeZone;
 
-public class SetPropertyRouteHelper {
-    private static final VisalloLogger LOGGER = VisalloLoggerFactory.getLogger(SetPropertyRouteHelper.class);
+public abstract class SetPropertyBase {
+    private static final VisalloLogger LOGGER = VisalloLoggerFactory.getLogger(SetPropertyBase.class);
 
-    private Graph graph;
-    private VisibilityTranslator visibilityTranslator;
+    protected final Graph graph;
+    protected final VisibilityTranslator visibilityTranslator;
 
-    @Inject
-    public SetPropertyRouteHelper(Graph graph, VisibilityTranslator visibilityTranslator) {
+    protected SetPropertyBase(Graph graph, VisibilityTranslator visibilityTranslator) {
         this.graph = graph;
         this.visibilityTranslator = visibilityTranslator;
     }
 
-    public boolean isCommentProperty(String propertyName) {
+    protected boolean isCommentProperty(String propertyName) {
         return VisalloProperties.COMMENT.isSameName(propertyName);
     }
 
-    public String createPropertyKey(String propertyName, Graph graph) {
+    protected String createPropertyKey(String propertyName, Graph graph) {
         return isCommentProperty(propertyName) ? createCommentPropertyKey() : graph.getIdGenerator().nextId();
     }
 
-    public void checkVisibilityParameter(
+    protected void checkVisibilityParameter(
             String visibilitySource, Authorizations authorizations, User user, ResourceBundle resourceBundle) {
         if (!graph.isVisibilityValid(visibilityTranslator.toVisibility(visibilitySource).getVisibility(), authorizations)) {
             LOGGER.warn("%s is not a valid visibility for %s user", visibilitySource, user.getDisplayName());
@@ -44,7 +43,7 @@ public class SetPropertyRouteHelper {
         }
     }
 
-    public void checkRoutePath(String entityType, String propertyName, HttpServletRequest request) {
+    protected void checkRoutePath(String entityType, String propertyName, HttpServletRequest request) {
         boolean isComment = isCommentProperty(propertyName);
         if (isComment && request.getPathInfo().equals(String.format("/%s/property", entityType))) {
             throw new VisalloException(String.format("Use /%s/comment to save comment properties", entityType));

--- a/web/web-base/src/main/java/org/visallo/web/routes/edge/EdgeSetProperty.java
+++ b/web/web-base/src/main/java/org/visallo/web/routes/edge/EdgeSetProperty.java
@@ -21,7 +21,7 @@ import org.visallo.core.util.VertexiumMetadataUtil;
 import org.visallo.core.util.VisalloLogger;
 import org.visallo.core.util.VisalloLoggerFactory;
 import org.visallo.web.BadRequestException;
-import org.visallo.web.SetPropertyRouteHelper;
+import org.visallo.web.routes.SetPropertyBase;
 import org.visallo.web.VisalloResponse;
 import org.visallo.web.clientapi.model.ClientApiSourceInfo;
 import org.visallo.web.clientapi.model.ClientApiSuccess;
@@ -31,17 +31,14 @@ import org.visallo.web.parameterProviders.JustificationText;
 import javax.servlet.http.HttpServletRequest;
 import java.util.ResourceBundle;
 
-public class EdgeSetProperty implements ParameterizedHandler {
+public class EdgeSetProperty extends SetPropertyBase implements ParameterizedHandler {
     private static final VisalloLogger LOGGER = VisalloLoggerFactory.getLogger(EdgeSetProperty.class);
 
-    private final Graph graph;
     private final OntologyRepository ontologyRepository;
-    private VisibilityTranslator visibilityTranslator;
     private final WorkQueueRepository workQueueRepository;
     private final WorkspaceRepository workspaceRepository;
     private final GraphRepository graphRepository;
     private final ACLProvider aclProvider;
-    private final SetPropertyRouteHelper routeHelper;
     private final boolean autoPublishComments;
 
     @Inject
@@ -53,17 +50,14 @@ public class EdgeSetProperty implements ParameterizedHandler {
             final WorkspaceRepository workspaceRepository,
             final GraphRepository graphRepository,
             final ACLProvider aclProvider,
-            final SetPropertyRouteHelper routeHelper,
             final Configuration configuration
     ) {
+        super(graph, visibilityTranslator);
         this.ontologyRepository = ontologyRepository;
-        this.graph = graph;
-        this.visibilityTranslator = visibilityTranslator;
         this.workQueueRepository = workQueueRepository;
         this.workspaceRepository = workspaceRepository;
         this.graphRepository = graphRepository;
         this.aclProvider = aclProvider;
-        this.routeHelper = routeHelper;
         this.autoPublishComments = configuration.getBoolean(Configuration.COMMENTS_AUTO_PUBLISH,
                 Configuration.DEFAULT_COMMENTS_AUTO_PUBLISH);
     }
@@ -84,17 +78,17 @@ public class EdgeSetProperty implements ParameterizedHandler {
             User user,
             Authorizations authorizations
     ) throws Exception {
-        routeHelper.checkVisibilityParameter(visibilitySource, authorizations, user, resourceBundle);
-        routeHelper.checkRoutePath("edge", propertyName, request);
+        checkVisibilityParameter(visibilitySource, authorizations, user, resourceBundle);
+        checkRoutePath("edge", propertyName, request);
 
-        boolean isComment = routeHelper.isCommentProperty(propertyName);
+        boolean isComment = isCommentProperty(propertyName);
         boolean autoPublish = isComment && autoPublishComments;
         if (autoPublish) {
             workspaceId = null;
         }
 
         if (propertyKey == null) {
-            propertyKey = routeHelper.createPropertyKey(propertyName, graph);
+            propertyKey = createPropertyKey(propertyName, graph);
         }
 
         Edge edge = graph.getEdge(edgeId, authorizations);

--- a/web/web-base/src/main/java/org/visallo/web/routes/edge/EdgeSetProperty.java
+++ b/web/web-base/src/main/java/org/visallo/web/routes/edge/EdgeSetProperty.java
@@ -7,12 +7,10 @@ import com.v5analytics.webster.annotations.Optional;
 import com.v5analytics.webster.annotations.Required;
 import org.vertexium.*;
 import org.visallo.core.config.Configuration;
-import org.visallo.core.exception.VisalloException;
 import org.visallo.core.model.graph.GraphRepository;
 import org.visallo.core.model.graph.VisibilityAndElementMutation;
 import org.visallo.core.model.ontology.OntologyProperty;
 import org.visallo.core.model.ontology.OntologyRepository;
-import org.visallo.core.model.properties.VisalloProperties;
 import org.visallo.core.model.workQueue.Priority;
 import org.visallo.core.model.workQueue.WorkQueueRepository;
 import org.visallo.core.model.workspace.WorkspaceRepository;
@@ -23,6 +21,7 @@ import org.visallo.core.util.VertexiumMetadataUtil;
 import org.visallo.core.util.VisalloLogger;
 import org.visallo.core.util.VisalloLoggerFactory;
 import org.visallo.web.BadRequestException;
+import org.visallo.web.SetPropertyRouteHelper;
 import org.visallo.web.VisalloResponse;
 import org.visallo.web.clientapi.model.ClientApiSourceInfo;
 import org.visallo.web.clientapi.model.ClientApiSuccess;
@@ -42,6 +41,7 @@ public class EdgeSetProperty implements ParameterizedHandler {
     private final WorkspaceRepository workspaceRepository;
     private final GraphRepository graphRepository;
     private final ACLProvider aclProvider;
+    private final SetPropertyRouteHelper routeHelper;
     private final boolean autoPublishComments;
 
     @Inject
@@ -53,6 +53,7 @@ public class EdgeSetProperty implements ParameterizedHandler {
             final WorkspaceRepository workspaceRepository,
             final GraphRepository graphRepository,
             final ACLProvider aclProvider,
+            final SetPropertyRouteHelper routeHelper,
             final Configuration configuration
     ) {
         this.ontologyRepository = ontologyRepository;
@@ -62,6 +63,7 @@ public class EdgeSetProperty implements ParameterizedHandler {
         this.workspaceRepository = workspaceRepository;
         this.graphRepository = graphRepository;
         this.aclProvider = aclProvider;
+        this.routeHelper = routeHelper;
         this.autoPublishComments = configuration.getBoolean(Configuration.COMMENTS_AUTO_PUBLISH,
                 Configuration.DEFAULT_COMMENTS_AUTO_PUBLISH);
     }
@@ -82,33 +84,24 @@ public class EdgeSetProperty implements ParameterizedHandler {
             User user,
             Authorizations authorizations
     ) throws Exception {
-        if (!graph.isVisibilityValid(visibilityTranslator.toVisibility(visibilitySource).getVisibility(), authorizations)) {
-            LOGGER.warn("%s is not a valid visibility for %s user", visibilitySource, user.getDisplayName());
-            throw new BadRequestException("visibilitySource", resourceBundle.getString("visibility.invalid"));
-        }
+        routeHelper.checkVisibilityParameter(visibilitySource, authorizations, user, resourceBundle);
+        routeHelper.checkRoutePath("edge", propertyName, request);
 
-        boolean isComment = VisalloProperties.COMMENT.isSameName(propertyName);
-
-        if (isComment && request.getPathInfo().equals("/edge/property")) {
-            throw new VisalloException("Use /edge/comment to save comment properties");
-        } else if (!isComment && request.getPathInfo().equals("/edge/comment")) {
-            throw new VisalloException("Use /edge/property to save non-comment properties");
-        }
-
+        boolean isComment = routeHelper.isCommentProperty(propertyName);
         boolean autoPublish = isComment && autoPublishComments;
         if (autoPublish) {
             workspaceId = null;
         }
 
-        OntologyProperty property = ontologyRepository.getRequiredPropertyByIRI(propertyName);
+        if (propertyKey == null) {
+            propertyKey = routeHelper.createPropertyKey(propertyName, graph);
+        }
 
         Edge edge = graph.getEdge(edgeId, authorizations);
 
-        if (propertyKey == null) {
-            propertyKey = graph.getIdGenerator().nextId();
-        }
-
         aclProvider.checkCanAddOrUpdateProperty(edge, propertyKey, propertyName, user);
+
+        OntologyProperty property = ontologyRepository.getRequiredPropertyByIRI(propertyName);
 
         Object value;
         try {


### PR DESCRIPTION
- [x] @joeferner
- [x] @mwizeman @dsingley @EvanOxfeld 
- [x] @joeybrk372 @sfeng88 @rygim @jharwig 

The comment key is now consistent (a timestamp) between vertices and edges.