### PR TITLE
RDF: Support property keys, edge ids, and metdata names with colons and at characters escaped

### DIFF
--- a/common/rdf/src/main/java/org/visallo/common/rdf/AddEdgeVisalloRdfTriple.java
+++ b/common/rdf/src/main/java/org/visallo/common/rdf/AddEdgeVisalloRdfTriple.java
@@ -47,7 +47,7 @@ public class AddEdgeVisalloRdfTriple extends VisalloRdfTriple {
     public String toString() {
         String label = getEdgeLabel();
         if (!Strings.isNullOrEmpty(getEdgeId())) {
-            label += ":" + getEdgeId();
+            label += ":" + escape(getEdgeId(), ':');
         }
         if (!Strings.isNullOrEmpty(getEdgeVisibilitySource())) {
             label += String.format("[%s]", getEdgeVisibilitySource());

--- a/common/rdf/src/main/java/org/visallo/common/rdf/PropertyVisalloRdfTriple.java
+++ b/common/rdf/src/main/java/org/visallo/common/rdf/PropertyVisalloRdfTriple.java
@@ -55,7 +55,7 @@ public abstract class PropertyVisalloRdfTriple extends ElementVisalloRdfTriple {
     protected String getPropertyRdfString() {
         String result = getPropertyName();
         if (!Strings.isNullOrEmpty(getPropertyKey())) {
-            result += String.format(":%s", getPropertyKey());
+            result += String.format(":%s", escape(getPropertyKey(), ':'));
         }
         if (!Strings.isNullOrEmpty(getPropertyVisibilitySource())) {
             result += String.format("[%s]", getPropertyVisibilitySource());
@@ -91,7 +91,10 @@ public abstract class PropertyVisalloRdfTriple extends ElementVisalloRdfTriple {
             return getValueRdfStringWithType(val, VisalloRdfTriple.PROPERTY_TYPE_DATE_TIME);
         }
         if (getValue() instanceof DirectoryEntity) {
-            return getValueRdfStringWithType(((DirectoryEntity) getValue()).getId(), VisalloRdfTriple.PROPERTY_TYPE_DIRECTORY_ENTITY);
+            return getValueRdfStringWithType(
+                    ((DirectoryEntity) getValue()).getId(),
+                    VisalloRdfTriple.PROPERTY_TYPE_DIRECTORY_ENTITY
+            );
         }
         if (getValue() instanceof DateOnly) {
             return getValueRdfStringWithType(getValue(), VisalloRdfTriple.PROPERTY_TYPE_DATE);

--- a/common/rdf/src/main/java/org/visallo/common/rdf/SetMetadataVisalloRdfTriple.java
+++ b/common/rdf/src/main/java/org/visallo/common/rdf/SetMetadataVisalloRdfTriple.java
@@ -41,11 +41,17 @@ public class SetMetadataVisalloRdfTriple extends PropertyVisalloRdfTriple {
 
     @Override
     public String toString() {
-        return String.format("<%s> <%s%s> %s", getElementRdfString(), getPropertyRdfString(), getMetadataRdfString(), getValueRdfString());
+        return String.format(
+                "<%s> <%s%s> %s",
+                getElementRdfString(),
+                getPropertyRdfString(),
+                getMetadataRdfString(),
+                getValueRdfString()
+        );
     }
 
     protected String getMetadataRdfString() {
-        String result = String.format("@%s", getMetadataName());
+        String result = String.format("@%s", escape(getMetadataName(), '@'));
         if (!Strings.isNullOrEmpty(getMetadataVisibilitySource())) {
             result += String.format("[%s]", getMetadataVisibilitySource());
         }

--- a/common/rdf/src/test/java/org/visallo/common/rdf/AddEdgeVisalloRdfTripleTest.java
+++ b/common/rdf/src/test/java/org/visallo/common/rdf/AddEdgeVisalloRdfTripleTest.java
@@ -8,4 +8,10 @@ public class AddEdgeVisalloRdfTripleTest extends VisalloRdfTripleTestBase {
         AddEdgeVisalloRdfTriple triple = new AddEdgeVisalloRdfTriple("e1", "vout", "vin", "http://visallo.org#edgeLabel", "A");
         assertEqualsVisalloRdfTriple("<vout> <http://visallo.org#edgeLabel:e1[A]> <vin>", triple);
     }
+
+    @Test
+    public void testToStringWhenIdHasAColor() {
+        AddEdgeVisalloRdfTriple triple = new AddEdgeVisalloRdfTriple("e:1", "vout", "vin", "http://visallo.org#edgeLabel", "A");
+        assertEqualsVisalloRdfTriple("<vout> <http://visallo.org#edgeLabel:e\\:1[A]> <vin>", triple);
+    }
 }

--- a/common/rdf/src/test/java/org/visallo/common/rdf/RdfTripleImportHelperTest.java
+++ b/common/rdf/src/test/java/org/visallo/common/rdf/RdfTripleImportHelperTest.java
@@ -83,7 +83,10 @@ public class RdfTripleImportHelperTest {
         graph.flush();
 
         v1 = graph.getVertex("v1", authorizations);
-        assertEquals(new VisalloVisibility("(A)").getVisibility().getVisibilityString(), v1.getVisibility().getVisibilityString());
+        assertEquals(
+                new VisalloVisibility("(A)").getVisibility().getVisibilityString(),
+                v1.getVisibility().getVisibilityString()
+        );
         assertEquals("http://visallo.org/test#type1", VisalloProperties.CONCEPT_TYPE.getPropertyValue(v1));
         assertEquals(new VisibilityJson("A"), VisalloProperties.VISIBILITY_JSON.getPropertyValue(v1));
         assertNotNull(v1);
@@ -98,8 +101,14 @@ public class RdfTripleImportHelperTest {
         Vertex v1 = graph.getVertex("v1", authorizations);
         Property property = v1.getProperty(VisalloRdfTriple.MULTI_KEY, "http://visallo.org/test#prop1");
         assertEquals("hello world", property.getValue());
-        assertEquals(new VisalloVisibility("").getVisibility().getVisibilityString(), property.getVisibility().getVisibilityString());
-        assertEquals(new VisibilityJson(""), VisalloProperties.VISIBILITY_JSON_METADATA.getMetadataValue(property.getMetadata()));
+        assertEquals(
+                new VisalloVisibility("").getVisibility().getVisibilityString(),
+                property.getVisibility().getVisibilityString()
+        );
+        assertEquals(
+                new VisibilityJson(""),
+                VisalloProperties.VISIBILITY_JSON_METADATA.getMetadataValue(property.getMetadata())
+        );
     }
 
     @Test
@@ -112,14 +121,20 @@ public class RdfTripleImportHelperTest {
         Vertex v1 = graph.getVertex("v1", authorizations);
         Property property = v1.getProperty(VisalloRdfTriple.MULTI_KEY, "http://visallo.org/test#prop1");
         assertEquals("hello world", property.getValue());
-        assertEquals(new VisalloVisibility("(A)").getVisibility().getVisibilityString(), property.getVisibility().getVisibilityString());
-        assertEquals(new VisibilityJson("A"), VisalloProperties.VISIBILITY_JSON_METADATA.getMetadataValue(property.getMetadata()));
+        assertEquals(
+                new VisalloVisibility("(A)").getVisibility().getVisibilityString(),
+                property.getVisibility().getVisibilityString()
+        );
+        assertEquals(
+                new VisibilityJson("A"),
+                VisalloProperties.VISIBILITY_JSON_METADATA.getMetadataValue(property.getMetadata())
+        );
     }
 
     @Test
     public void testImportPropertyMetadata() {
         importRdfLine("<v1> <http://visallo.org/test#prop1> \"hello world\"");
-        importRdfLine("<v1> <http://visallo.org/test#prop1@metadata1> \"metadata value 1\"");
+        importRdfLine("<v1> <http://visallo.org/test#prop1@metadata\\@1> \"metadata value 1\"");
         importRdfLine("<v1> <http://visallo.org/test#prop1@metadata2> \"metadata value 2\"");
         importRdfLine("<v1> <http://visallo.org/test#prop1@metadata2[S]> \"metadata value 2 S\"");
         graph.flush();
@@ -127,7 +142,7 @@ public class RdfTripleImportHelperTest {
         Vertex v1 = graph.getVertex("v1", authorizations);
         Property prop1 = v1.getProperty(VisalloRdfTriple.MULTI_KEY, "http://visallo.org/test#prop1");
         assertEquals("hello world", prop1.getValue());
-        assertEquals("metadata value 1", prop1.getMetadata().getValue("metadata1"));
+        assertEquals("metadata value 1", prop1.getMetadata().getValue("metadata@1"));
         assertEquals("metadata value 2", prop1.getMetadata().getValue("metadata2", new Visibility("")));
         assertEquals("metadata value 2 S", prop1.getMetadata().getValue("metadata2", new Visibility("((S))|visallo")));
     }
@@ -151,13 +166,20 @@ public class RdfTripleImportHelperTest {
         graph.flush();
 
         Vertex v1 = graph.getVertex("v1", authorizations);
-        VisalloDateTime dateTime = VisalloDateTime.create(v1.getPropertyValue(VisalloRdfTriple.MULTI_KEY, "http://visallo.org/test#prop1"));
+        VisalloDateTime dateTime = VisalloDateTime.create(v1.getPropertyValue(
+                VisalloRdfTriple.MULTI_KEY,
+                "http://visallo.org/test#prop1"
+        ));
         assertEquals(new VisalloDateTime(2015, 5, 21, 8, 42, 22, 0, TimeZone.getDefault().getID()), dateTime);
 
         Calendar cal = Calendar.getInstance(TimeZone.getDefault());
         cal.setTimeInMillis(0);
         cal.set(2015, Calendar.MAY, 21, 8, 42, 22);
-        assertEquals("Time incorrect: " + dateTime.toDate(TimeZone.getDefault()), cal.getTimeInMillis(), dateTime.getEpoch());
+        assertEquals(
+                "Time incorrect: " + dateTime.toDate(TimeZone.getDefault()),
+                cal.getTimeInMillis(),
+                dateTime.getEpoch()
+        );
     }
 
     @Test
@@ -167,7 +189,10 @@ public class RdfTripleImportHelperTest {
         graph.flush();
 
         Vertex v1 = graph.getVertex("v1", authorizations);
-        VisalloDateTime dateTime = VisalloDateTime.create(v1.getPropertyValue(VisalloRdfTriple.MULTI_KEY, "http://visallo.org/test#prop1"));
+        VisalloDateTime dateTime = VisalloDateTime.create(v1.getPropertyValue(
+                VisalloRdfTriple.MULTI_KEY,
+                "http://visallo.org/test#prop1"
+        ));
         assertEquals(new VisalloDateTime(2015, 5, 21, 8, 42, 22, 0, "GMT"), dateTime);
         assertEquals("Time incorrect: " + dateTime.toDateGMT(), 1432197742000L, dateTime.getEpoch());
     }
@@ -175,13 +200,20 @@ public class RdfTripleImportHelperTest {
     @Test
     public void testImportDateTimeWithESTTimeZoneProperty() {
         TimeZone tz = TimeZone.getTimeZone("America/Anchorage");
-        String timeZoneOffset = "-0" + Math.abs(tz.getOffset(new VisalloDate(2015, Calendar.MAY, 21).getEpoch()) / 1000 / 60 / 60) + ":00";
+        String timeZoneOffset = "-0" + Math.abs(tz.getOffset(new VisalloDate(
+                2015,
+                Calendar.MAY,
+                21
+        ).getEpoch()) / 1000 / 60 / 60) + ":00";
         String line = "<v1> <http://visallo.org/test#prop1> \"2015-05-21T08:42:22" + timeZoneOffset + "\"^^<" + VisalloRdfTriple.PROPERTY_TYPE_DATE_TIME + ">";
         importRdfLine(line);
         graph.flush();
 
         Vertex v1 = graph.getVertex("v1", authorizations);
-        VisalloDateTime dateTime = VisalloDateTime.create(v1.getPropertyValue(VisalloRdfTriple.MULTI_KEY, "http://visallo.org/test#prop1"));
+        VisalloDateTime dateTime = VisalloDateTime.create(v1.getPropertyValue(
+                VisalloRdfTriple.MULTI_KEY,
+                "http://visallo.org/test#prop1"
+        ));
         assertEquals(new VisalloDateTime(2015, 5, 21, 8, 42, 22, 0, "America/Anchorage"), dateTime);
         assertEquals("Time incorrect: " + dateTime.toDateGMT(), 1432226542000L, dateTime.getEpoch());
     }
@@ -221,6 +253,16 @@ public class RdfTripleImportHelperTest {
     }
 
     @Test
+    public void testImportPropertyWithKeyThatHasAColon() {
+        String line = "<v1> <http://visallo.org/test#prop1:key\\:1> \"hello world\"";
+        importRdfLine(line);
+        graph.flush();
+
+        Vertex v1 = graph.getVertex("v1", authorizations);
+        assertEquals("hello world", v1.getPropertyValue("key:1", "http://visallo.org/test#prop1"));
+    }
+
+    @Test
     public void testImportPropertyVisibility() {
         String line = "<v1> <http://visallo.org/test#prop1[A]> \"hello world\"";
         importRdfLine(line);
@@ -230,8 +272,14 @@ public class RdfTripleImportHelperTest {
         Property property = v1.getProperty("http://visallo.org/test#prop1");
         assertNotNull("Could not find property", property);
         assertEquals("hello world", property.getValue());
-        assertEquals(new VisalloVisibility("(A)").getVisibility().getVisibilityString(), property.getVisibility().getVisibilityString());
-        assertEquals(new VisibilityJson("A"), VisalloProperties.VISIBILITY_JSON_METADATA.getMetadataValue(property.getMetadata()));
+        assertEquals(
+                new VisalloVisibility("(A)").getVisibility().getVisibilityString(),
+                property.getVisibility().getVisibilityString()
+        );
+        assertEquals(
+                new VisibilityJson("A"),
+                VisalloProperties.VISIBILITY_JSON_METADATA.getMetadataValue(property.getMetadata())
+        );
     }
 
     @Test
@@ -244,8 +292,14 @@ public class RdfTripleImportHelperTest {
         Property property = v1.getProperty("key1", "http://visallo.org/test#prop1");
         assertNotNull("Could not find property with key", property);
         assertEquals("hello world", property.getValue());
-        assertEquals(new VisalloVisibility("(A)").getVisibility().getVisibilityString(), property.getVisibility().getVisibilityString());
-        assertEquals(new VisibilityJson("A"), VisalloProperties.VISIBILITY_JSON_METADATA.getMetadataValue(property.getMetadata()));
+        assertEquals(
+                new VisalloVisibility("(A)").getVisibility().getVisibilityString(),
+                property.getVisibility().getVisibilityString()
+        );
+        assertEquals(
+                new VisibilityJson("A"),
+                VisalloProperties.VISIBILITY_JSON_METADATA.getMetadataValue(property.getMetadata())
+        );
     }
 
     @Test
@@ -301,7 +355,10 @@ public class RdfTripleImportHelperTest {
         assertEquals(1, v1.getEdgeCount(Direction.OUT, authorizations));
         List<Edge> edges = toList(v1.getEdges(Direction.OUT, authorizations));
         assertEquals(1, edges.size());
-        assertEquals(new VisalloVisibility("(A)").getVisibility().getVisibilityString(), edges.get(0).getVisibility().getVisibilityString());
+        assertEquals(
+                new VisalloVisibility("(A)").getVisibility().getVisibilityString(),
+                edges.get(0).getVisibility().getVisibilityString()
+        );
         assertEquals("http://visallo.org/test#edgeLabel1", edges.get(0).getLabel());
         assertEquals("v2", edges.get(0).getOtherVertex("v1", authorizations).getId());
     }
@@ -322,6 +379,21 @@ public class RdfTripleImportHelperTest {
     }
 
     @Test
+    public void testImportEdgeWithIdWithAColon() {
+        String line = "<v1> <http://visallo.org/test#edgeLabel1:edge\\:1> <v2>";
+        importRdfLine(line);
+        graph.flush();
+
+        Vertex v1 = graph.getVertex("v1", authorizations);
+        assertEquals(1, v1.getEdgeCount(Direction.OUT, authorizations));
+        List<Edge> edges = toList(v1.getEdges(Direction.OUT, authorizations));
+        assertEquals(1, edges.size());
+        assertEquals("http://visallo.org/test#edgeLabel1", edges.get(0).getLabel());
+        assertEquals("v2", edges.get(0).getOtherVertex("v1", authorizations).getId());
+        assertEquals("edge:1", edges.get(0).getId());
+    }
+
+    @Test
     public void testImportEdgeProperty() {
         graph.addEdge("edge1", "v1", "v2", "label1", new Visibility(""), authorizations);
 
@@ -332,12 +404,27 @@ public class RdfTripleImportHelperTest {
         Edge edge1 = graph.getEdge("edge1", authorizations);
         Property property = edge1.getProperty(VisalloRdfTriple.MULTI_KEY, "http://visallo.org/test#prop1");
         assertEquals("hello world", property.getValue());
-        assertEquals(new VisalloVisibility("").getVisibility().getVisibilityString(), property.getVisibility().getVisibilityString());
-        assertEquals(new VisibilityJson(""), VisalloProperties.VISIBILITY_JSON_METADATA.getMetadataValue(property.getMetadata()));
+        assertEquals(
+                new VisalloVisibility("").getVisibility().getVisibilityString(),
+                property.getVisibility().getVisibilityString()
+        );
+        assertEquals(
+                new VisibilityJson(""),
+                VisalloProperties.VISIBILITY_JSON_METADATA.getMetadataValue(property.getMetadata())
+        );
     }
 
     private void importRdfLine(String line) {
         Set<Element> elements = new HashSet<>();
-        rdfTripleImportHelper.importRdfLine(elements, sourceFileName, line, workingDir, timeZone, defaultVisibilitySource, user, authorizations);
+        rdfTripleImportHelper.importRdfLine(
+                elements,
+                sourceFileName,
+                line,
+                workingDir,
+                timeZone,
+                defaultVisibilitySource,
+                user,
+                authorizations
+        );
     }
 }

--- a/common/rdf/src/test/java/org/visallo/common/rdf/SetPropertyVisalloRdfTripleTest.java
+++ b/common/rdf/src/test/java/org/visallo/common/rdf/SetPropertyVisalloRdfTripleTest.java
@@ -23,6 +23,17 @@ public class SetPropertyVisalloRdfTripleTest extends VisalloRdfTripleTestBase {
     }
 
     @Test
+    public void testToStringVertexWithPropertyKeyThatHasAColon() {
+        SetPropertyVisalloRdfTriple triple = new SetPropertyVisalloRdfTriple(
+                ElementType.VERTEX,
+                "v1", "A",
+                "pkey:1", "http://visallo.org#pname", "B",
+                "value1"
+        );
+        assertEqualsVisalloRdfTriple("<v1[A]> <http://visallo.org#pname:pkey\\:1[B]> \"value1\"", triple);
+    }
+
+    @Test
     public void testToStringEdge() {
         SetPropertyVisalloRdfTriple triple = new SetPropertyVisalloRdfTriple(
                 ElementType.EDGE,


### PR DESCRIPTION
- [x] @srfarley
- [x] @mwizeman @dsingley @EvanOxfeld 
- [x] @joeybrk372 @sfeng88 @rygim @jharwig 

Currently RDF import does not support importing property keys with `:` (colons) this is a problem when trying to import/export comments which represent their key in `yyyy-MM-ddHH:mm:ss` format.

This PR addresses this issue by allowing you to escape `:` with a slash. This also fixes edge id and metadata names with `:` and `@` respectively.