### PR TITLE
Set text property visibility

### DIFF
--- a/core/core-test/src/test/java/org/visallo/core/model/graph/GraphRepositoryTest.java
+++ b/core/core-test/src/test/java/org/visallo/core/model/graph/GraphRepositoryTest.java
@@ -11,10 +11,10 @@ import org.vertexium.id.QueueIdGenerator;
 import org.vertexium.inmemory.InMemoryGraph;
 import org.vertexium.inmemory.InMemoryGraphConfiguration;
 import org.vertexium.search.DefaultSearchIndex;
+import org.visallo.core.exception.VisalloResourceNotFoundException;
 import org.visallo.core.model.termMention.TermMentionRepository;
 import org.visallo.core.security.DirectVisibilityTranslator;
 import org.visallo.core.security.VisalloVisibility;
-import org.visallo.core.security.VisibilityTranslator;
 import org.visallo.core.user.User;
 import org.visallo.web.clientapi.model.ClientApiSourceInfo;
 
@@ -22,9 +22,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import static org.vertexium.util.IterableUtils.toList;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -47,12 +45,13 @@ public class GraphRepositoryTest {
     private TermMentionRepository termMentionRepository;
 
     private Authorizations defaultAuthorizations;
+    private DirectVisibilityTranslator visibilityTranslator;
 
     @Before
     public void setup() throws Exception {
-        InMemoryGraphConfiguration config = new InMemoryGraphConfiguration(new HashMap<String, Object>());
+        InMemoryGraphConfiguration config = new InMemoryGraphConfiguration(new HashMap<>());
         QueueIdGenerator idGenerator = new QueueIdGenerator();
-        VisibilityTranslator visibilityTranslator = new DirectVisibilityTranslator();
+        visibilityTranslator = new DirectVisibilityTranslator();
         graph = InMemoryGraph.create(config, idGenerator, new DefaultSearchIndex(config));
         defaultAuthorizations = graph.createAuthorizations();
 
@@ -61,6 +60,57 @@ public class GraphRepositoryTest {
                 visibilityTranslator,
                 termMentionRepository
         );
+    }
+
+    @Test
+    public void testUpdatePropertyVisibilitySource() {
+        Authorizations authorizations = graph.createAuthorizations("A");
+        Visibility newVisibility = visibilityTranslator.toVisibility("A").getVisibility();
+
+        Vertex v1 = graph.prepareVertex(ENTITY_1_VERTEX_ID, new VisalloVisibility().getVisibility())
+                .addPropertyValue("k1", "p1", "value1", new Visibility(""))
+                .save(authorizations);
+
+        Property p1 = graphRepository.updatePropertyVisibilitySource(
+                v1,
+                "k1",
+                "p1",
+                "",
+                "A",
+                user1,
+                defaultAuthorizations
+        );
+        assertEquals(newVisibility, p1.getVisibility());
+        graph.flush();
+
+        v1 = graph.getVertex(ENTITY_1_VERTEX_ID, authorizations);
+        p1 = v1.getProperty("k1", "p1", newVisibility);
+        assertNotNull("could not find p1", p1);
+        assertEquals(newVisibility, p1.getVisibility());
+    }
+
+    @Test
+    public void testUpdatePropertyVisibilitySourceMissingProperty() {
+        Authorizations authorizations = graph.createAuthorizations("A");
+
+        Vertex v1 = graph.prepareVertex(ENTITY_1_VERTEX_ID, new VisalloVisibility().getVisibility())
+                .addPropertyValue("k1", "p1", "value1", new Visibility(""))
+                .save(authorizations);
+
+        try {
+            graphRepository.updatePropertyVisibilitySource(
+                    v1,
+                    "k1",
+                    "pNotFound",
+                    "",
+                    "A",
+                    user1,
+                    defaultAuthorizations
+            );
+            fail("expected exception");
+        } catch (VisalloResourceNotFoundException ex) {
+            // OK
+        }
     }
 
     @Test
@@ -227,8 +277,10 @@ public class GraphRepositoryTest {
         setProperty(vertex, value, "", "", workspaceId, workspaceAuthorizations);
     }
 
-    private void setProperty(Vertex vertex, String value, String oldVisibility, String newVisibility,
-                             String workspaceId, Authorizations workspaceAuthorizations) {
+    private void setProperty(
+            Vertex vertex, String value, String oldVisibility, String newVisibility,
+            String workspaceId, Authorizations workspaceAuthorizations
+    ) {
         VisibilityAndElementMutation<Vertex> setPropertyResult = graphRepository.setProperty(
                 vertex,
                 "prop1",

--- a/core/core-test/src/test/java/org/visallo/core/model/graph/GraphRepositoryTest.java
+++ b/core/core-test/src/test/java/org/visallo/core/model/graph/GraphRepositoryTest.java
@@ -12,11 +12,13 @@ import org.vertexium.inmemory.InMemoryGraph;
 import org.vertexium.inmemory.InMemoryGraphConfiguration;
 import org.vertexium.search.DefaultSearchIndex;
 import org.visallo.core.exception.VisalloResourceNotFoundException;
+import org.visallo.core.model.properties.VisalloProperties;
 import org.visallo.core.model.termMention.TermMentionRepository;
 import org.visallo.core.security.DirectVisibilityTranslator;
 import org.visallo.core.security.VisalloVisibility;
 import org.visallo.core.user.User;
 import org.visallo.web.clientapi.model.ClientApiSourceInfo;
+import org.visallo.web.clientapi.model.VisibilityJson;
 
 import java.util.HashMap;
 import java.util.Iterator;
@@ -87,6 +89,9 @@ public class GraphRepositoryTest {
         p1 = v1.getProperty("k1", "p1", newVisibility);
         assertNotNull("could not find p1", p1);
         assertEquals(newVisibility, p1.getVisibility());
+        VisibilityJson visibilityJson = VisalloProperties.VISIBILITY_JSON_METADATA
+                .getMetadataValue(p1.getMetadata());
+        assertEquals("A", visibilityJson.getSource());
     }
 
     @Test

--- a/core/core-test/src/test/java/org/visallo/core/model/graph/GraphRepositoryTest.java
+++ b/core/core-test/src/test/java/org/visallo/core/model/graph/GraphRepositoryTest.java
@@ -79,6 +79,7 @@ public class GraphRepositoryTest {
                 "p1",
                 "",
                 "A",
+                WORKSPACE_ID,
                 user1,
                 defaultAuthorizations
         );
@@ -109,6 +110,7 @@ public class GraphRepositoryTest {
                     "pNotFound",
                     "",
                     "A",
+                    WORKSPACE_ID,
                     user1,
                     defaultAuthorizations
             );

--- a/core/core/src/main/java/org/visallo/core/model/graph/GraphRepository.java
+++ b/core/core/src/main/java/org/visallo/core/model/graph/GraphRepository.java
@@ -196,7 +196,8 @@ public class GraphRepository {
     ) {
         Visibility defaultVisibility = visibilityTranslator.getDefaultVisibility();
 
-        Property oldProperty = getProperty(element, propertyKey, propertyName, oldVisibilitySource, workspaceId);
+        Visibility oldPropertyVisibility = getVisibilityWithWorkspace(oldVisibilitySource, workspaceId);
+        Property oldProperty = element.getProperty(propertyKey, propertyName, oldPropertyVisibility);
         boolean isUpdate = oldProperty != null;
 
         Metadata propertyMetadata = isUpdate ? oldProperty.getMetadata() : new Metadata();

--- a/web/war/src/main/webapp/js/data/web-worker/services/edge.js
+++ b/web/war/src/main/webapp/js/data/web-worker/services/edge.js
@@ -29,6 +29,16 @@ define([
             });
         },
 
+        setPropertyVisibility: function(edgeId, property) {
+            return ajax('POST', '/edge/property/visibility', {
+                graphEdgeId: edgeId,
+                newVisibilitySource: property.visibilitySource,
+                oldVisibilitySource: property.oldVisibilitySource,
+                propertyKey: property.key,
+                propertyName: property.name
+            })
+        },
+
         setProperty: function(edgeId, property, optionalWorkspaceId) {
             var url = storeHelper.edgePropertyUrl(property);
             return ajax('POST', url, _.tap({

--- a/web/war/src/main/webapp/js/data/web-worker/services/vertex.js
+++ b/web/war/src/main/webapp/js/data/web-worker/services/vertex.js
@@ -247,6 +247,16 @@ define([
             });
         },
 
+        setPropertyVisibility: function(vertexId, property) {
+            return ajax('POST', '/vertex/property/visibility', {
+                graphVertexId: vertexId,
+                newVisibilitySource: property.visibilitySource,
+                oldVisibilitySource: property.oldVisibilitySource,
+                propertyKey: property.key,
+                propertyName: property.name
+            })
+        },
+
         setProperty: function(vertexId, property, optionalWorkspaceId) {
             var url = storeHelper.vertexPropertyUrl(property);
             return ajax('POST', url, _.tap({

--- a/web/war/src/main/webapp/js/util/popovers/propertyInfo/propertyInfo.js
+++ b/web/war/src/main/webapp/js/util/popovers/propertyInfo/propertyInfo.js
@@ -5,6 +5,7 @@ define([
     'util/vertex/formatters',
     'util/withDataRequest',
     'util/privileges',
+    'util/visibility/view',
     'd3'
 ], function(
     defineComponent,
@@ -12,6 +13,7 @@ define([
     F,
     withDataRequest,
     Privileges,
+    VisibilityViewer,
     d3) {
     'use strict';
 
@@ -53,6 +55,10 @@ define([
                 config.canSearch = config.ontologyProperty &&
                     (config.ontologyProperty.searchable || isCompoundField) &&
                     !config.isFullscreen;
+
+                if (config.property.streamingPropertyValue) {
+                    config.canAdd = config.canDelete = config.canSearch = false;
+                }
             }
             config.hideDialog = true;
         });
@@ -135,6 +141,14 @@ define([
                         }
                         return true;
                     })
+                    .tap(function(metadata) {
+                        if (property.streamingPropertyValue) {
+                            var key = 'http://visallo.org#visibilityJson';
+                            metadata.push([key, property.metadata && property.metadata[key]]);
+                            displayNames[key] = i18n('visibility.label');
+                            displayTypes[key] = 'visibility';
+                        }
+                    })
                     .value(),
                 row = this.contentRoot.select('table')
                     .selectAll('tr')
@@ -174,6 +188,10 @@ define([
                                     })
                                     .finally(positionDialog);
                                 d3.select(this).text(i18n('popovers.property_info.loading'));
+                            } else if (typeName === 'visibility') {
+                                VisibilityViewer.attachTo(this, {
+                                    value: value && value.source
+                                });
                             } else {
                                 console.warn('No metadata type formatter: ' + typeName);
                                 d3.select(this).text(value);

--- a/web/war/src/main/webapp/less/detail/detail.less
+++ b/web/war/src/main/webapp/less/detail/detail.less
@@ -286,6 +286,23 @@
     .text-section {
       margin: 1px 0;
       padding: 0;
+
+      & > h1 {
+        @import (multiple) "../util/info-button";
+        button.info {
+          float: right;
+          position: absolute;
+          right: 1.7ex;
+          left: auto;
+          top: 0.4ex;
+          &:hover {
+            left: auto;
+          }
+          &:active {
+            top: 0.5ex;
+          }
+        }
+      }
       
       & > .text {
         margin: 0;

--- a/web/web-base-test/src/test/java/org/visallo/web/routes/SetPropertyVisibilityTestBase.java
+++ b/web/web-base-test/src/test/java/org/visallo/web/routes/SetPropertyVisibilityTestBase.java
@@ -1,0 +1,116 @@
+package org.visallo.web.routes;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.vertexium.Authorizations;
+import org.vertexium.Element;
+import org.visallo.core.exception.VisalloResourceNotFoundException;
+import org.visallo.core.user.ProxyUser;
+import org.visallo.web.BadRequestException;
+import org.visallo.web.clientapi.model.VisibilityJson;
+
+import java.io.IOException;
+import java.util.ResourceBundle;
+
+import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+
+public abstract class SetPropertyVisibilityTestBase extends RouteTestBase {
+    protected Authorizations authorizations;
+
+    @Before
+    public void before() throws IOException {
+        super.before();
+        authorizations = graph.createAuthorizations("A");
+    }
+
+    public abstract void testValid() throws Exception;
+
+    protected void testValid(Element element) throws Exception {
+        String newVisibilitySource = new VisibilityJson("A").getSource();
+        String oldVisibilitySource = new VisibilityJson("").getSource();
+        handle(
+                element.getId(),
+                newVisibilitySource,
+                oldVisibilitySource,
+                "k1",
+                "p1",
+                WORKSPACE_ID,
+                resourceBundle,
+                user,
+                authorizations
+        );
+
+        verify(graphRepository).updatePropertyVisibilitySource(
+                eq(element),
+                eq("k1"),
+                eq("p1"),
+                eq(""),
+                eq("A"),
+                eq(user),
+                eq(authorizations)
+        );
+    }
+
+    @Test
+    public void testNotFound() throws Exception {
+        String newVisibilitySource = new VisibilityJson("A").getSource();
+        String oldVisibilitySource = new VisibilityJson("").getSource();
+        Authorizations authorizations = graph.createAuthorizations();
+
+        try {
+            handle(
+                    "badElementId",
+                    newVisibilitySource,
+                    oldVisibilitySource,
+                    "k1",
+                    "p1",
+                    WORKSPACE_ID,
+                    resourceBundle,
+                    user,
+                    authorizations
+            );
+            fail("expected exception");
+        } catch (VisalloResourceNotFoundException ex) {
+            assertEquals("badElementId", ex.getResourceId());
+        }
+    }
+
+    public abstract void testBadVisibility() throws Exception;
+
+    protected void testBadVisibility(Element element) throws Exception {
+        String newVisibilitySource = new VisibilityJson("bad").getSource();
+        String oldVisibilitySource = new VisibilityJson("").getSource();
+
+        try {
+            handle(
+                    element.getId(),
+                    newVisibilitySource,
+                    oldVisibilitySource,
+                    "k1",
+                    "p1",
+                    WORKSPACE_ID,
+                    resourceBundle,
+                    user,
+                    authorizations
+            );
+            fail("expected exception");
+        } catch (BadRequestException ex) {
+            assertEquals("newVisibilitySource", ex.getParameterName());
+        }
+    }
+
+    protected abstract void handle(
+            String elementId,
+            String newVisibilitySource,
+            String oldVisibilitySource,
+            String propertyKey,
+            String propertyName,
+            String workspaceId,
+            ResourceBundle resourceBundle,
+            ProxyUser user,
+            Authorizations authorizations
+    ) throws Exception;
+}

--- a/web/web-base-test/src/test/java/org/visallo/web/routes/SetPropertyVisibilityTestBase.java
+++ b/web/web-base-test/src/test/java/org/visallo/web/routes/SetPropertyVisibilityTestBase.java
@@ -49,6 +49,7 @@ public abstract class SetPropertyVisibilityTestBase extends RouteTestBase {
                 eq("p1"),
                 eq(""),
                 eq("A"),
+                eq(WORKSPACE_ID),
                 eq(user),
                 eq(authorizations)
         );

--- a/web/web-base-test/src/test/java/org/visallo/web/routes/edge/EdgeSetPropertyVisibilityTest.java
+++ b/web/web-base-test/src/test/java/org/visallo/web/routes/edge/EdgeSetPropertyVisibilityTest.java
@@ -1,0 +1,77 @@
+package org.visallo.web.routes.edge;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.vertexium.Authorizations;
+import org.vertexium.Edge;
+import org.vertexium.Vertex;
+import org.vertexium.Visibility;
+import org.visallo.core.user.ProxyUser;
+import org.visallo.web.routes.SetPropertyVisibilityTestBase;
+
+import java.io.IOException;
+import java.util.ResourceBundle;
+
+@RunWith(MockitoJUnitRunner.class)
+public class EdgeSetPropertyVisibilityTest extends SetPropertyVisibilityTestBase {
+    private EdgeSetPropertyVisibility edgeSetPropertyVisibility;
+    private Edge e1;
+
+    @Before
+    public void before() throws IOException {
+        super.before();
+
+        edgeSetPropertyVisibility = new EdgeSetPropertyVisibility(
+                graph,
+                workspaceRepository,
+                visibilityTranslator,
+                graphRepository,
+                workQueueRepository
+        );
+
+        Visibility visibility = new Visibility("");
+        authorizations = graph.createAuthorizations("A");
+        Vertex v1 = graph.addVertex("v1", visibility, authorizations);
+        Vertex v2 = graph.addVertex("v2", visibility, authorizations);
+        e1 = graph.prepareEdge("e1", v1, v2, "edgeLabel", visibility)
+                .addPropertyValue("k1", "p1", "value1", visibility)
+                .save(authorizations);
+    }
+
+    @Test
+    public void testValid() throws Exception {
+        super.testValid(e1);
+    }
+
+    @Override
+    public void testBadVisibility() throws Exception {
+        super.testBadVisibility(e1);
+    }
+
+    @Override
+    protected void handle(
+            String elementId,
+            String newVisibilitySource,
+            String oldVisibilitySource,
+            String propertyKey,
+            String propertyName,
+            String workspaceId,
+            ResourceBundle resourceBundle,
+            ProxyUser user,
+            Authorizations authorizations
+    ) throws Exception {
+        edgeSetPropertyVisibility.handle(
+                elementId,
+                newVisibilitySource,
+                oldVisibilitySource,
+                propertyKey,
+                propertyName,
+                workspaceId,
+                resourceBundle,
+                user,
+                authorizations
+        );
+    }
+}

--- a/web/web-base-test/src/test/java/org/visallo/web/routes/vertex/VertexSetPropertyVisibilityTest.java
+++ b/web/web-base-test/src/test/java/org/visallo/web/routes/vertex/VertexSetPropertyVisibilityTest.java
@@ -1,0 +1,73 @@
+package org.visallo.web.routes.vertex;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.vertexium.Authorizations;
+import org.vertexium.Vertex;
+import org.vertexium.Visibility;
+import org.visallo.core.user.ProxyUser;
+import org.visallo.web.routes.SetPropertyVisibilityTestBase;
+
+import java.io.IOException;
+import java.util.ResourceBundle;
+
+@RunWith(MockitoJUnitRunner.class)
+public class VertexSetPropertyVisibilityTest extends SetPropertyVisibilityTestBase {
+    private VertexSetPropertyVisibility vertexSetPropertyVisibility;
+    private Vertex v1;
+
+    @Before
+    public void before() throws IOException {
+        super.before();
+
+        vertexSetPropertyVisibility = new VertexSetPropertyVisibility(
+                graph,
+                workspaceRepository,
+                visibilityTranslator,
+                graphRepository,
+                workQueueRepository
+        );
+
+        Visibility visibility = new Visibility("");
+        v1 = graph.prepareVertex("v1", visibility)
+                .addPropertyValue("k1", "p1", "value1", visibility)
+                .save(authorizations);
+    }
+
+    @Test
+    public void testValid() throws Exception {
+        super.testValid(v1);
+    }
+
+    @Override
+    public void testBadVisibility() throws Exception {
+        super.testBadVisibility(v1);
+    }
+
+    @Override
+    protected void handle(
+            String elementId,
+            String newVisibilitySource,
+            String oldVisibilitySource,
+            String propertyKey,
+            String propertyName,
+            String workspaceId,
+            ResourceBundle resourceBundle,
+            ProxyUser user,
+            Authorizations authorizations
+    ) throws Exception {
+        vertexSetPropertyVisibility.handle(
+                elementId,
+                newVisibilitySource,
+                oldVisibilitySource,
+                propertyKey,
+                propertyName,
+                workspaceId,
+                resourceBundle,
+                user,
+                authorizations
+        );
+    }
+}

--- a/web/web-base/src/main/java/org/visallo/web/Router.java
+++ b/web/web-base/src/main/java/org/visallo/web/Router.java
@@ -146,6 +146,7 @@ public class Router extends HttpServlet {
             app.get("/vertex/property", authenticator, csrfProtector, ReadPrivilegeFilter.class, VertexGetPropertyValue.class);
             app.get("/vertex/property/history", authenticator, csrfProtector, ReadPrivilegeFilter.class, VertexGetPropertyHistory.class);
             app.post("/vertex/property", authenticator, csrfProtector, EditPrivilegeFilter.class, VertexSetProperty.class);
+            app.post("/vertex/property/visibility", authenticator, csrfProtector, EditPrivilegeFilter.class, VertexSetPropertyVisibility.class);
             app.post("/vertex/comment", authenticator, csrfProtector, CommentPrivilegeFilter.class, VertexSetProperty.class);
             app.delete("/vertex/property", authenticator, csrfProtector, EditPrivilegeFilter.class, VertexDeleteProperty.class);
             app.delete("/vertex/comment", authenticator, csrfProtector, CommentPrivilegeFilter.class, VertexDeleteProperty.class);
@@ -166,6 +167,7 @@ public class Router extends HttpServlet {
             app.get("/vertex/count", authenticator, csrfProtector, ReadPrivilegeFilter.class, VertexGetCount.class);
 
             app.post("/edge/property", authenticator, csrfProtector, EditPrivilegeFilter.class, EdgeSetProperty.class);
+            app.post("/edge/property/visibility", authenticator, csrfProtector, EditPrivilegeFilter.class, EdgeSetPropertyVisibility.class);
             app.post("/edge/comment", authenticator, csrfProtector, CommentPrivilegeFilter.class, EdgeSetProperty.class);
             app.delete("/edge", authenticator, csrfProtector, EditPrivilegeFilter.class, EdgeDelete.class);
             app.delete("/edge/property", authenticator, csrfProtector, EditPrivilegeFilter.class, EdgeDeleteProperty.class);

--- a/web/web-base/src/main/java/org/visallo/web/routes/edge/EdgeSetPropertyVisibility.java
+++ b/web/web-base/src/main/java/org/visallo/web/routes/edge/EdgeSetPropertyVisibility.java
@@ -1,0 +1,98 @@
+package org.visallo.web.routes.edge;
+
+import com.google.inject.Inject;
+import com.v5analytics.webster.ParameterizedHandler;
+import com.v5analytics.webster.annotations.Handle;
+import com.v5analytics.webster.annotations.Optional;
+import com.v5analytics.webster.annotations.Required;
+import org.vertexium.*;
+import org.visallo.core.exception.VisalloResourceNotFoundException;
+import org.visallo.core.model.graph.GraphRepository;
+import org.visallo.core.model.workQueue.Priority;
+import org.visallo.core.model.workQueue.WorkQueueRepository;
+import org.visallo.core.model.workspace.WorkspaceRepository;
+import org.visallo.core.security.VisibilityTranslator;
+import org.visallo.core.user.User;
+import org.visallo.core.util.VisalloLogger;
+import org.visallo.core.util.VisalloLoggerFactory;
+import org.visallo.web.BadRequestException;
+import org.visallo.web.VisalloResponse;
+import org.visallo.web.clientapi.model.ClientApiSuccess;
+import org.visallo.web.parameterProviders.ActiveWorkspaceId;
+
+import java.util.ResourceBundle;
+
+public class EdgeSetPropertyVisibility implements ParameterizedHandler {
+    private static final VisalloLogger LOGGER = VisalloLoggerFactory.getLogger(EdgeSetPropertyVisibility.class);
+    private final Graph graph;
+    private final WorkspaceRepository workspaceRepository;
+    private final VisibilityTranslator visibilityTranslator;
+    private final GraphRepository graphRepository;
+    private final WorkQueueRepository workQueueRepository;
+
+    @Inject
+    public EdgeSetPropertyVisibility(
+            Graph graph,
+            WorkspaceRepository workspaceRepository,
+            VisibilityTranslator visibilityTranslator,
+            GraphRepository graphRepository,
+            WorkQueueRepository workQueueRepository
+    ) {
+        this.graph = graph;
+        this.workspaceRepository = workspaceRepository;
+        this.visibilityTranslator = visibilityTranslator;
+        this.graphRepository = graphRepository;
+        this.workQueueRepository = workQueueRepository;
+    }
+
+    @Handle
+    public ClientApiSuccess handle(
+            @Required(name = "graphEdgeId") String graphEdgeId,
+            @Required(name = "newVisibilitySource") String newVisibilitySource,
+            @Optional(name = "oldVisibilitySource") String oldVisibilitySource,
+            @Optional(name = "propertyKey") String propertyKey,
+            @Required(name = "propertyName") String propertyName,
+            @ActiveWorkspaceId String workspaceId,
+            ResourceBundle resourceBundle,
+            User user,
+            Authorizations authorizations
+    ) throws Exception {
+        Edge edge = graph.getEdge(graphEdgeId, authorizations);
+        if (edge == null) {
+            throw new VisalloResourceNotFoundException("Could not find edge: " + graphEdgeId, graphEdgeId);
+        }
+
+        if (!graph.isVisibilityValid(
+                visibilityTranslator.toVisibility(newVisibilitySource).getVisibility(),
+                authorizations
+        )) {
+            LOGGER.warn("%s is not a valid visibility for %s user", newVisibilitySource, user.getDisplayName());
+            throw new BadRequestException("visibilitySource", resourceBundle.getString("visibility.invalid"));
+        }
+
+        // add the vertex to the workspace so that the changes show up in the diff panel
+        workspaceRepository.updateEntityOnWorkspace(workspaceId, edge.getVertexId(Direction.IN), null, null, user);
+        workspaceRepository.updateEntityOnWorkspace(workspaceId, edge.getVertexId(Direction.OUT), null, null, user);
+
+        Property property = graphRepository.updatePropertyVisibilitySource(
+                edge,
+                propertyKey,
+                propertyName,
+                oldVisibilitySource,
+                newVisibilitySource,
+                user,
+                authorizations
+        );
+        this.graph.flush();
+
+        workQueueRepository.pushGraphPropertyQueue(
+                edge,
+                property,
+                workspaceId,
+                newVisibilitySource,
+                Priority.HIGH
+        );
+
+        return VisalloResponse.SUCCESS;
+    }
+}

--- a/web/web-base/src/main/java/org/visallo/web/routes/edge/EdgeSetPropertyVisibility.java
+++ b/web/web-base/src/main/java/org/visallo/web/routes/edge/EdgeSetPropertyVisibility.java
@@ -80,6 +80,7 @@ public class EdgeSetPropertyVisibility implements ParameterizedHandler {
                 propertyName,
                 oldVisibilitySource,
                 newVisibilitySource,
+                workspaceId,
                 user,
                 authorizations
         );

--- a/web/web-base/src/main/java/org/visallo/web/routes/vertex/VertexSetPropertyVisibility.java
+++ b/web/web-base/src/main/java/org/visallo/web/routes/vertex/VertexSetPropertyVisibility.java
@@ -82,6 +82,7 @@ public class VertexSetPropertyVisibility implements ParameterizedHandler {
                 propertyName,
                 oldVisibilitySource,
                 newVisibilitySource,
+                workspaceId,
                 user,
                 authorizations
         );

--- a/web/web-base/src/main/java/org/visallo/web/routes/vertex/VertexSetPropertyVisibility.java
+++ b/web/web-base/src/main/java/org/visallo/web/routes/vertex/VertexSetPropertyVisibility.java
@@ -1,0 +1,100 @@
+package org.visallo.web.routes.vertex;
+
+import com.google.inject.Inject;
+import com.v5analytics.webster.ParameterizedHandler;
+import com.v5analytics.webster.annotations.Handle;
+import com.v5analytics.webster.annotations.Optional;
+import com.v5analytics.webster.annotations.Required;
+import org.vertexium.Authorizations;
+import org.vertexium.Graph;
+import org.vertexium.Property;
+import org.vertexium.Vertex;
+import org.visallo.core.exception.VisalloResourceNotFoundException;
+import org.visallo.core.model.graph.GraphRepository;
+import org.visallo.core.model.workQueue.Priority;
+import org.visallo.core.model.workQueue.WorkQueueRepository;
+import org.visallo.core.model.workspace.WorkspaceRepository;
+import org.visallo.core.security.VisibilityTranslator;
+import org.visallo.core.user.User;
+import org.visallo.core.util.VisalloLogger;
+import org.visallo.core.util.VisalloLoggerFactory;
+import org.visallo.web.BadRequestException;
+import org.visallo.web.VisalloResponse;
+import org.visallo.web.clientapi.model.ClientApiSuccess;
+import org.visallo.web.parameterProviders.ActiveWorkspaceId;
+
+import java.util.ResourceBundle;
+
+public class VertexSetPropertyVisibility implements ParameterizedHandler {
+    private static final VisalloLogger LOGGER = VisalloLoggerFactory.getLogger(VertexSetPropertyVisibility.class);
+    private final Graph graph;
+    private final WorkspaceRepository workspaceRepository;
+    private final VisibilityTranslator visibilityTranslator;
+    private final GraphRepository graphRepository;
+    private final WorkQueueRepository workQueueRepository;
+
+    @Inject
+    public VertexSetPropertyVisibility(
+            Graph graph,
+            WorkspaceRepository workspaceRepository,
+            VisibilityTranslator visibilityTranslator,
+            GraphRepository graphRepository,
+            WorkQueueRepository workQueueRepository
+    ) {
+        this.graph = graph;
+        this.workspaceRepository = workspaceRepository;
+        this.visibilityTranslator = visibilityTranslator;
+        this.graphRepository = graphRepository;
+        this.workQueueRepository = workQueueRepository;
+    }
+
+    @Handle
+    public ClientApiSuccess handle(
+            @Required(name = "graphVertexId") String graphVertexId,
+            @Required(name = "newVisibilitySource") String newVisibilitySource,
+            @Optional(name = "oldVisibilitySource") String oldVisibilitySource,
+            @Optional(name = "propertyKey") String propertyKey,
+            @Required(name = "propertyName") String propertyName,
+            @ActiveWorkspaceId String workspaceId,
+            ResourceBundle resourceBundle,
+            User user,
+            Authorizations authorizations
+    ) throws Exception {
+        Vertex vertex = graph.getVertex(graphVertexId, authorizations);
+        if (vertex == null) {
+            throw new VisalloResourceNotFoundException("Could not find vertex: " + graphVertexId, graphVertexId);
+        }
+
+        if (!graph.isVisibilityValid(
+                visibilityTranslator.toVisibility(newVisibilitySource).getVisibility(),
+                authorizations
+        )) {
+            LOGGER.warn("%s is not a valid visibility for %s user", newVisibilitySource, user.getDisplayName());
+            throw new BadRequestException("newVisibilitySource", resourceBundle.getString("visibility.invalid"));
+        }
+
+        // add the vertex to the workspace so that the changes show up in the diff panel
+        workspaceRepository.updateEntityOnWorkspace(workspaceId, graphVertexId, null, null, user);
+
+        Property property = graphRepository.updatePropertyVisibilitySource(
+                vertex,
+                propertyKey,
+                propertyName,
+                oldVisibilitySource,
+                newVisibilitySource,
+                user,
+                authorizations
+        );
+        this.graph.flush();
+
+        workQueueRepository.pushGraphPropertyQueue(
+                vertex,
+                property,
+                workspaceId,
+                newVisibilitySource,
+                Priority.HIGH
+        );
+
+        return VisalloResponse.SUCCESS;
+    }
+}

--- a/web/web-base/src/main/java/org/visallo/web/routes/vertex/VertexSetVisibility.java
+++ b/web/web-base/src/main/java/org/visallo/web/routes/vertex/VertexSetVisibility.java
@@ -62,13 +62,13 @@ public class VertexSetVisibility implements ParameterizedHandler {
             throw new BadRequestException("visibilitySource", resourceBundle.getString("visibility.invalid"));
         }
 
-        // add the vertex to the workspace so that the changes show up in the diff panel
-        workspaceRepository.updateEntityOnWorkspace(workspaceId, graphVertexId, null, null, user);
-
         Vertex graphVertex = graph.getVertex(graphVertexId, authorizations);
         if (graphVertex == null) {
             throw new VisalloResourceNotFoundException("Could not find vertex: " + graphVertexId);
         }
+
+        // add the vertex to the workspace so that the changes show up in the diff panel
+        workspaceRepository.updateEntityOnWorkspace(workspaceId, graphVertexId, null, null, user);
 
         LOGGER.info("changing vertex (%s) visibility source to %s", graphVertex.getId(), visibilitySource);
 


### PR DESCRIPTION
- [x] @srfarley @joeferner
- [x] @mwizeman @dsingley @EvanOxfeld 
- [x] @joeybrk372 @sfeng88 @rygim @jharwig 

Since text properties aren't editable, there was no way to know or edit the visibility. This adds a button to view and edit visibility. Along with showing any other metadata.

<img width="300" src="https://cloud.githubusercontent.com/assets/7098/16597198/432282c6-42bd-11e6-976f-a91427424413.png"/>
