### PR TITLE
RDF: Treat 'http://visallo.org#conceptType' the same as OWL 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type'

### DIFF
--- a/common/rdf/src/main/java/org/visallo/common/rdf/RdfImportHelper.java
+++ b/common/rdf/src/main/java/org/visallo/common/rdf/RdfImportHelper.java
@@ -17,7 +17,6 @@ import java.util.TimeZone;
 public class RdfImportHelper {
     private static final VisalloLogger LOGGER = VisalloLoggerFactory.getLogger(RdfImportHelper.class);
     private final Graph graph;
-    private final UserRepository userRepository;
     private final RdfXmlImportHelper rdfXmlImportHelper;
     private final RdfTripleImportHelper rdfTripleImportHelper;
 
@@ -30,12 +29,10 @@ public class RdfImportHelper {
     @Inject
     public RdfImportHelper(
             Graph graph,
-            UserRepository userRepository,
             RdfXmlImportHelper rdfXmlImportHelper,
             RdfTripleImportHelper rdfTripleImportHelper
     ) {
         this.graph = graph;
-        this.userRepository = userRepository;
         this.rdfXmlImportHelper = rdfXmlImportHelper;
         this.rdfTripleImportHelper = rdfTripleImportHelper;
     }

--- a/common/rdf/src/main/java/org/visallo/common/rdf/VisalloRdfTriple.java
+++ b/common/rdf/src/main/java/org/visallo/common/rdf/VisalloRdfTriple.java
@@ -5,6 +5,7 @@ import org.vertexium.ElementType;
 import org.vertexium.property.StreamingPropertyValue;
 import org.vertexium.type.GeoPoint;
 import org.visallo.core.exception.VisalloException;
+import org.visallo.core.model.properties.VisalloProperties;
 import org.visallo.core.util.VisalloDate;
 import org.visallo.core.util.VisalloDateTime;
 
@@ -64,7 +65,7 @@ public abstract class VisalloRdfTriple {
             elementVisibilitySource = defaultVisibilitySource;
         }
 
-        if (label.equals(LABEL_CONCEPT_TYPE)) {
+        if (label.equals(LABEL_CONCEPT_TYPE) || label.equals(VisalloProperties.CONCEPT_TYPE.getPropertyName())) {
             return parseConceptTypeTriple(elementId, elementVisibilitySource, third);
         }
 


### PR DESCRIPTION
- [x] @srfarley @joeferner
- [x] @mwizeman @dsingley @EvanOxfeld 
- [x] @joeybrk372 @sfeng88 @rygim @jharwig 

Using `http://visallo.org#conceptType` instead of `http://www.w3.org/1999/02/22-rdf-syntax-ns#type` might be a common error users might make when creating RDF to import into Visallo. This treats them the same.