### PR TITLE
IE doesn't have includes, so detail pane never opens on selection

### DIFF
--- a/web/war/src/main/webapp/js/data/withObjectSelection.js
+++ b/web/war/src/main/webapp/js/data/withObjectSelection.js
@@ -507,8 +507,8 @@ define([], function() {
                         var removedEdgeIds = [];
 
                         _.each(edgesById, function(edge) {
-                            var hasOutVertex = vertexIds.includes(edge.outVertexId);
-                            var hasInVertex = vertexIds.includes(edge.inVertexId);
+                            var hasOutVertex = _.contains(vertexIds, edge.outVertexId);
+                            var hasInVertex = _.contains(vertexIds, edge.inVertexId);
 
                             if (!hasOutVertex || !hasInVertex) {
                                 removedEdgeIds.push(edge.id);


### PR DESCRIPTION
- [x] @srfarley @joeferner
- [x] @mwizeman @dsingley @EvanOxfeld 
- [x] @joeybrk372 @sfeng88 @rygim @jharwig 

Replace with underscore `contains`