### PR TITLE
Make loading spinner show next to buttons in IE

### DIFF
--- a/web/war/src/main/webapp/less/util/button-loading.less
+++ b/web/war/src/main/webapp/less/util/button-loading.less
@@ -8,6 +8,7 @@ button, .btn {
   &.loading {
     position: relative;
     margin-left: 24px;    
+    overflow: visible;
 
     &:before {
       background-image: url('../img/loading.gif');


### PR DESCRIPTION
- [x] @srfarley @joeferner
- [x] @mwizeman @dsingley @EvanOxfeld 
- [x] @joeybrk372 @sfeng88 @rygim @jharwig 

Buttons with psuedoelements require the element to have visible overflow.