### PR TITLE
Move visibility json, modified date, and modified by from metadata values off of concept type to top level properties to be in line with edges

### DIFF
--- a/common/rdf/src/main/java/org/visallo/common/rdf/RdfImportHelper.java
+++ b/common/rdf/src/main/java/org/visallo/common/rdf/RdfImportHelper.java
@@ -17,7 +17,6 @@ import java.util.TimeZone;
 public class RdfImportHelper {
     private static final VisalloLogger LOGGER = VisalloLoggerFactory.getLogger(RdfImportHelper.class);
     private final Graph graph;
-    private final UserRepository userRepository;
     private final RdfXmlImportHelper rdfXmlImportHelper;
     private final RdfTripleImportHelper rdfTripleImportHelper;
 
@@ -30,12 +29,10 @@ public class RdfImportHelper {
     @Inject
     public RdfImportHelper(
             Graph graph,
-            UserRepository userRepository,
             RdfXmlImportHelper rdfXmlImportHelper,
             RdfTripleImportHelper rdfTripleImportHelper
     ) {
         this.graph = graph;
-        this.userRepository = userRepository;
         this.rdfXmlImportHelper = rdfXmlImportHelper;
         this.rdfTripleImportHelper = rdfTripleImportHelper;
     }

--- a/common/rdf/src/main/java/org/visallo/common/rdf/RdfTripleImportHelper.java
+++ b/common/rdf/src/main/java/org/visallo/common/rdf/RdfTripleImportHelper.java
@@ -22,6 +22,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 public class RdfTripleImportHelper {
     private static final VisalloLogger LOGGER = VisalloLoggerFactory.getLogger(RdfTripleImportHelper.class);
+    private static final String MULTIVALUE_KEY = RdfTripleImportHelper.class.getName();
     private final Graph graph;
     private final VisibilityTranslator visibilityTranslator;
     private WorkQueueRepository workQueueRepository;
@@ -284,21 +285,16 @@ public class RdfTripleImportHelper {
             Authorizations authorizations
     ) {
         Date now = new Date();
-        Metadata metadata = new Metadata();
         Visibility defaultVisibility = visibilityTranslator.getDefaultVisibility();
-        if (sourceFileName != null) {
-            VisalloProperties.SOURCE_FILE_NAME_METADATA.setMetadata(metadata, sourceFileName, defaultVisibility);
-        }
         VisibilityJson visibilityJson = new VisibilityJson(triple.getElementVisibilitySource());
-        VisalloProperties.VISIBILITY_JSON_METADATA.setMetadata(metadata, visibilityJson, defaultVisibility);
-        VisalloProperties.MODIFIED_DATE_METADATA.setMetadata(metadata, now, defaultVisibility);
-        VisalloProperties.MODIFIED_BY_METADATA.setMetadata(metadata, user.getUserId(), defaultVisibility);
-        VisalloProperties.CONFIDENCE_METADATA.setMetadata(metadata, GraphRepository.SET_PROPERTY_CONFIDENCE, defaultVisibility);
 
         Visibility elementVisibility = getVisibility(triple.getElementVisibilitySource());
         VertexBuilder m = graph.prepareVertex(triple.getElementId(), elementVisibility);
-        VisalloProperties.CONCEPT_TYPE.setProperty(m, triple.getConceptType(), metadata, elementVisibility);
-        VisalloProperties.VISIBILITY_JSON.setProperty(m, visibilityJson, metadata, elementVisibility);
+        VisalloProperties.CONCEPT_TYPE.setProperty(m, triple.getConceptType(), defaultVisibility);
+        VisalloProperties.VISIBILITY_JSON.setProperty(m, visibilityJson, defaultVisibility);
+        VisalloProperties.MODIFIED_BY.setProperty(m, user.getUserId(), defaultVisibility);
+        VisalloProperties.MODIFIED_DATE.setProperty(m, now, defaultVisibility);
+        VisalloProperties.SOURCE.addPropertyValue(m, MULTIVALUE_KEY, sourceFileName, elementVisibility);
         Vertex vertex = m.save(authorizations);
         elements.add(vertex);
     }

--- a/common/rdf/src/main/java/org/visallo/common/rdf/RdfXmlImportHelper.java
+++ b/common/rdf/src/main/java/org/visallo/common/rdf/RdfXmlImportHelper.java
@@ -90,7 +90,7 @@ public class RdfXmlImportHelper {
             workspaceId = data.getWorkspaceId();
         }
         if (rdfConceptTypeIri != null && data != null) {
-            VisalloProperties.CONCEPT_TYPE.setProperty(data.getElement(), rdfConceptTypeIri, data.createPropertyMetadata(), visibility, authorizations);
+            VisalloProperties.CONCEPT_TYPE.setProperty(data.getElement(), rdfConceptTypeIri, visibilityTranslator.getDefaultVisibility(), authorizations);
         }
 
         Model model = ModelFactory.createDefaultModel();
@@ -141,11 +141,7 @@ public class RdfXmlImportHelper {
             if (obj instanceof Resource) {
                 if (isConceptTypeResource(statement)) {
                     String value = statement.getResource().toString();
-                    Metadata metadata = null;
-                    if (data != null) {
-                        metadata = data.createPropertyMetadata();
-                    }
-                    VisalloProperties.CONCEPT_TYPE.setProperty(vertexBuilder, value, metadata, visibility);
+                    VisalloProperties.CONCEPT_TYPE.setProperty(vertexBuilder, value, visibilityTranslator.getDefaultVisibility());
                 }
             } else if (obj instanceof Literal) {
                 LOGGER.info("set property on %s to %s", subject.toString(), statement.toString());

--- a/common/rdf/src/main/java/org/visallo/common/rdf/VisalloRdfTriple.java
+++ b/common/rdf/src/main/java/org/visallo/common/rdf/VisalloRdfTriple.java
@@ -5,6 +5,7 @@ import org.vertexium.ElementType;
 import org.vertexium.property.StreamingPropertyValue;
 import org.vertexium.type.GeoPoint;
 import org.visallo.core.exception.VisalloException;
+import org.visallo.core.model.properties.VisalloProperties;
 import org.visallo.core.util.VisalloDate;
 import org.visallo.core.util.VisalloDateTime;
 
@@ -64,7 +65,7 @@ public abstract class VisalloRdfTriple {
             elementVisibilitySource = defaultVisibilitySource;
         }
 
-        if (label.equals(LABEL_CONCEPT_TYPE)) {
+        if (label.equals(LABEL_CONCEPT_TYPE) || label.equals(VisalloProperties.CONCEPT_TYPE.getPropertyName())) {
             return parseConceptTypeTriple(elementId, elementVisibilitySource, third);
         }
 

--- a/common/rdf/src/test/java/org/visallo/common/rdf/RdfTripleImportHelperTest.java
+++ b/common/rdf/src/test/java/org/visallo/common/rdf/RdfTripleImportHelperTest.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.util.*;
 
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.when;
 import static org.vertexium.util.IterableUtils.toList;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -52,6 +53,8 @@ public class RdfTripleImportHelperTest {
         authorizations = graph.createAuthorizations("A");
         timeZone = TimeZone.getDefault();
         visibilityTranslator = new DirectVisibilityTranslator();
+
+        when(user.getUserId()).thenReturn("user1");
 
         rdfTripleImportHelper = new RdfTripleImportHelper(graph, visibilityTranslator, workQueueRepository);
         defaultVisibilitySource = "";

--- a/core/core-test/src/test/java/org/visallo/core/model/search/VertexSearchRunnerTest.java
+++ b/core/core-test/src/test/java/org/visallo/core/model/search/VertexSearchRunnerTest.java
@@ -7,6 +7,7 @@ import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.vertexium.ElementBuilder;
 import org.vertexium.Vertex;
+import org.vertexium.Visibility;
 import org.visallo.core.model.properties.VisalloProperties;
 
 import java.util.HashMap;
@@ -36,9 +37,9 @@ public class VertexSearchRunnerTest extends SearchRunnerTestBase {
         ElementBuilder<Vertex> v1Mutation = graph.prepareVertex("v1", visibility);
         ElementBuilder<Vertex> v2Mutation = graph.prepareVertex("v2", visibility);
         ElementBuilder<Vertex> v3Mutation = graph.prepareVertex("v3", visibility);
-        VisalloProperties.CONCEPT_TYPE.setProperty(v1Mutation, "testConcept", visibility);
-        VisalloProperties.CONCEPT_TYPE.setProperty(v2Mutation, "testConcept", visibility);
-        VisalloProperties.CONCEPT_TYPE.setProperty(v3Mutation, "testConcept", visibility);
+        VisalloProperties.CONCEPT_TYPE.setProperty(v1Mutation, "testConcept", new Visibility(""));
+        VisalloProperties.CONCEPT_TYPE.setProperty(v2Mutation, "testConcept", new Visibility(""));
+        VisalloProperties.CONCEPT_TYPE.setProperty(v3Mutation, "testConcept", new Visibility(""));
         Vertex v1 = v1Mutation.save(authorizations);
         Vertex v2 = v2Mutation.save(authorizations);
         Vertex v3 = v3Mutation.save(authorizations);

--- a/core/core-test/src/test/java/org/visallo/core/model/termMention/TermMentionRepositoryTest.java
+++ b/core/core-test/src/test/java/org/visallo/core/model/termMention/TermMentionRepositoryTest.java
@@ -51,7 +51,7 @@ public class TermMentionRepositoryTest {
         Edge e = graph.addEdge("v1_to_v2", v1, v2, "link", visibility, authorizations);
         VisibilityJson visibilityJson = new VisibilityJson();
         visibilityJson.addWorkspace(WORKSPACE_ID);
-        VisalloProperties.VISIBILITY_JSON.setProperty(e, visibilityJson, visibility, authorizations);
+        VisalloProperties.VISIBILITY_JSON.setProperty(e, visibilityJson, new Visibility(""), authorizations);
         graph.flush();
 
         termMentionRepository.delete(v1tm1, authorizations);

--- a/core/core-test/src/test/java/org/visallo/core/model/workspace/WorkspaceHelperTest.java
+++ b/core/core-test/src/test/java/org/visallo/core/model/workspace/WorkspaceHelperTest.java
@@ -79,7 +79,7 @@ public class WorkspaceHelperTest {
         Edge e = graph.addEdge("v1_to_v2", v1, v2, "link", visibility, authorizations);
         VisibilityJson visibilityJson = new VisibilityJson();
         visibilityJson.addWorkspace(WORKSPACE_ID);
-        VisalloProperties.VISIBILITY_JSON.setProperty(e, visibilityJson, visibility, authorizations);
+        VisalloProperties.VISIBILITY_JSON.setProperty(e, visibilityJson, new Visibility(""), authorizations);
         graph.flush();
 
         workspaceHelper.unresolveTerm(v1tm1, authorizations);
@@ -98,7 +98,7 @@ public class WorkspaceHelperTest {
         graph.addEdge("v1_to_tm", tm, v1, VisalloProperties.TERM_MENTION_LABEL_RESOLVED_TO, termMentionVisibility, authorizations);
         Edge e = graph.addEdge("doc_to_v1", doc, v1, "link", visibility, authorizations);
         VisibilityJson visibilityJson = new VisibilityJson();
-        VisalloProperties.VISIBILITY_JSON.setProperty(e, visibilityJson, visibility, authorizations);
+        VisalloProperties.VISIBILITY_JSON.setProperty(e, visibilityJson, new Visibility(""), authorizations);
         graph.flush();
         workspaceHelper.deleteVertex(v1, WORKSPACE_ID, true, Priority.HIGH, authorizations, user);
 

--- a/core/core/src/main/java/org/visallo/core/ingest/FileImport.java
+++ b/core/core/src/main/java/org/visallo/core/ingest/FileImport.java
@@ -242,6 +242,7 @@ public class FileImport {
             VisibilityJson visibilityJson = VisibilityJson.updateVisibilitySourceAndAddWorkspaceId(null, visibilitySource, workspace == null ? null : workspace.getWorkspaceId());
             VisalloVisibility visalloVisibility = this.visibilityTranslator.toVisibility(visibilityJson);
             Visibility visibility = visalloVisibility.getVisibility();
+            Visibility defaultVisibility = visibilityTranslator.getDefaultVisibility();
             PropertyMetadata propertyMetadata = new PropertyMetadata(user, visibilityJson, visibilityTranslator.getDefaultVisibility());
             VisalloProperties.CONFIDENCE_METADATA.setMetadata(propertyMetadata, 0.1, visibilityTranslator.getDefaultVisibility());
 
@@ -252,14 +253,42 @@ public class FileImport {
                 vertexBuilder = this.graph.prepareVertex(predefinedId, visibility);
             }
             List<VisalloPropertyUpdate> changedProperties = new ArrayList<>();
-            VisalloProperties.VISIBILITY_JSON.updateProperty(changedProperties, null, vertexBuilder, visibilityJson, propertyMetadata, visibility);
             VisalloProperties.RAW.updateProperty(changedProperties, null, vertexBuilder, rawValue, propertyMetadata, visibility);
             VisalloProperties.CONTENT_HASH.updateProperty(changedProperties, null, vertexBuilder, MULTI_VALUE_KEY, hash, propertyMetadata, visibility);
             VisalloProperties.FILE_NAME.updateProperty(changedProperties, null, vertexBuilder, MULTI_VALUE_KEY, f.getName(), propertyMetadata, visibility);
-            VisalloProperties.MODIFIED_DATE.updateProperty(changedProperties, null, vertexBuilder, new Date(f.lastModified()), propertyMetadata, visibility);
-            VisalloProperties.MODIFIED_BY.updateProperty(changedProperties, null, vertexBuilder, user.getUserId(), propertyMetadata, visibility);
+            VisalloProperties.MODIFIED_DATE.updateProperty(
+                    changedProperties,
+                    null,
+                    vertexBuilder,
+                    new Date(f.lastModified()),
+                    (Metadata) null,
+                    defaultVisibility
+            );
+            VisalloProperties.MODIFIED_BY.updateProperty(
+                    changedProperties,
+                    null,
+                    vertexBuilder,
+                    user.getUserId(),
+                    (Metadata) null,
+                    defaultVisibility
+            );
+            VisalloProperties.VISIBILITY_JSON.updateProperty(
+                    changedProperties,
+                    null,
+                    vertexBuilder,
+                    visibilityJson,
+                    (Metadata) null,
+                    defaultVisibility
+            );
             if (conceptId != null) {
-                VisalloProperties.CONCEPT_TYPE.updateProperty(changedProperties, null, vertexBuilder, conceptId, propertyMetadata, visibility);
+                VisalloProperties.CONCEPT_TYPE.updateProperty(
+                        changedProperties,
+                        null,
+                        vertexBuilder,
+                        conceptId,
+                        (Metadata) null,
+                        defaultVisibility
+                );
             }
             if (properties != null) {
                 addProperties(properties, changedProperties, vertexBuilder, visibilityJson, workspace, user);

--- a/core/core/src/main/java/org/visallo/core/model/graph/GraphRepository.java
+++ b/core/core/src/main/java/org/visallo/core/model/graph/GraphRepository.java
@@ -298,25 +298,13 @@ public class GraphRepository {
                 workspaceId
         );
         VisalloVisibility visalloVisibility = visibilityTranslator.toVisibility(visibilityJson);
-
         VertexBuilder vertexBuilder;
         if (vertexId != null) {
             vertexBuilder = graph.prepareVertex(vertexId, visalloVisibility.getVisibility());
         } else {
             vertexBuilder = graph.prepareVertex(visalloVisibility.getVisibility());
         }
-        VisalloProperties.VISIBILITY_JSON.setProperty(vertexBuilder, visibilityJson, visalloVisibility.getVisibility());
-        Metadata conceptTypeMetadata = new Metadata();
-        Visibility metadataVisibility = visibilityTranslator.getDefaultVisibility();
-        VisalloProperties.MODIFIED_DATE_METADATA.setMetadata(conceptTypeMetadata, new Date(), metadataVisibility);
-        VisalloProperties.MODIFIED_BY_METADATA.setMetadata(conceptTypeMetadata, user.getUserId(), metadataVisibility);
-        VisalloProperties.VISIBILITY_JSON_METADATA.setMetadata(conceptTypeMetadata, visibilityJson, metadataVisibility);
-        VisalloProperties.CONCEPT_TYPE.setProperty(
-                vertexBuilder,
-                conceptType,
-                conceptTypeMetadata,
-                visalloVisibility.getVisibility()
-        );
+        updateElementMetadataProperties(vertexBuilder, conceptType, visibilityJson, user);
 
         boolean justificationAdded = addJustification(
                 vertexBuilder,
@@ -375,7 +363,6 @@ public class GraphRepository {
             User user,
             Authorizations authorizations
     ) {
-        Date now = new Date();
         VisibilityJson visibilityJson = VisibilityJson.updateVisibilitySourceAndAddWorkspaceId(
                 null,
                 visibilitySource,
@@ -394,14 +381,7 @@ public class GraphRepository {
                     visalloVisibility.getVisibility()
             );
         }
-        VisalloProperties.VISIBILITY_JSON.setProperty(edgeBuilder, visibilityJson, visalloVisibility.getVisibility());
-        VisalloProperties.CONCEPT_TYPE.setProperty(
-                edgeBuilder,
-                OntologyRepository.TYPE_RELATIONSHIP,
-                visalloVisibility.getVisibility()
-        );
-        VisalloProperties.MODIFIED_DATE.setProperty(edgeBuilder, now, visalloVisibility.getVisibility());
-        VisalloProperties.MODIFIED_BY.setProperty(edgeBuilder, user.getUserId(), visalloVisibility.getVisibility());
+        updateElementMetadataProperties(edgeBuilder, OntologyRepository.TYPE_RELATIONSHIP, visibilityJson, user);
 
         boolean justificationAdded = addJustification(
                 edgeBuilder,
@@ -438,6 +418,29 @@ public class GraphRepository {
         }
 
         return edge;
+    }
+
+    private void updateElementMetadataProperties(
+            ElementBuilder elementBuilder,
+            String conceptType,
+            VisibilityJson visibilityJson,
+            User user
+    ) {
+        Visibility defaultVisibility = visibilityTranslator.getDefaultVisibility();
+        Date now = new Date();
+
+        VisalloProperties.CONCEPT_TYPE.setProperty(
+                elementBuilder,
+                conceptType,
+                defaultVisibility
+        );
+        VisalloProperties.VISIBILITY_JSON.setProperty(
+                elementBuilder,
+                visibilityJson,
+                defaultVisibility
+        );
+        VisalloProperties.MODIFIED_DATE.setProperty(elementBuilder, now, defaultVisibility);
+        VisalloProperties.MODIFIED_BY.setProperty(elementBuilder, user.getUserId(), defaultVisibility);
     }
 
     private boolean addJustification(

--- a/core/core/src/main/java/org/visallo/core/model/properties/types/PropertyMetadata.java
+++ b/core/core/src/main/java/org/visallo/core/model/properties/types/PropertyMetadata.java
@@ -54,6 +54,14 @@ public class PropertyMetadata {
         return metadata;
     }
 
+    public User getModifiedBy() {
+        return modifiedBy;
+    }
+
+    public Date getModifiedDate() {
+        return modifiedDate;
+    }
+
     public void add(String key, Object value, Visibility visibility) {
         additionalMetadataItems.add(new AdditionalMetadataItem(key, value, visibility));
     }

--- a/core/core/src/main/java/org/visallo/core/model/termMention/TermMentionBuilder.java
+++ b/core/core/src/main/java/org/visallo/core/model/termMention/TermMentionBuilder.java
@@ -202,6 +202,7 @@ public class TermMentionBuilder {
 
         Date now = new Date();
         String vertexId = createVertexId();
+        Visibility defaultVisibility = visibilityTranslator.getDefaultVisibility();
         Visibility visibility = VisalloVisibility.and(visibilityTranslator.toVisibility(this.visibilityJson).getVisibility(), TermMentionRepository.VISIBILITY_STRING);
         VertexBuilder vertexBuilder = graph.prepareVertex(vertexId, visibility);
         VisalloProperties.TERM_MENTION_VISIBILITY_JSON.setProperty(vertexBuilder, this.visibilityJson, visibility);
@@ -229,15 +230,15 @@ public class TermMentionBuilder {
         String hasTermMentionId = vertexId + "_hasTermMention";
         EdgeBuilder termMentionEdgeBuilder = graph.prepareEdge(hasTermMentionId, this.outVertex, termMentionVertex, VisalloProperties.TERM_MENTION_LABEL_HAS_TERM_MENTION, visibility);
         VisalloProperties.TERM_MENTION_VISIBILITY_JSON.setProperty(termMentionEdgeBuilder, this.visibilityJson, visibility);
-        VisalloProperties.MODIFIED_BY.setProperty(termMentionEdgeBuilder, user.getUserId(), visibility);
-        VisalloProperties.MODIFIED_DATE.setProperty(termMentionEdgeBuilder, now, visibility);
+        VisalloProperties.MODIFIED_BY.setProperty(termMentionEdgeBuilder, user.getUserId(), defaultVisibility);
+        VisalloProperties.MODIFIED_DATE.setProperty(termMentionEdgeBuilder, now, defaultVisibility);
         termMentionEdgeBuilder.save(authorizations);
         if (this.resolvedToVertexId != null) {
             String resolvedToId = vertexId + "_resolvedTo";
             EdgeMutation resolvedToEdgeBuilder = graph.prepareEdge(resolvedToId, termMentionVertex.getId(), resolvedToVertexId, VisalloProperties.TERM_MENTION_LABEL_RESOLVED_TO, visibility);
             VisalloProperties.TERM_MENTION_VISIBILITY_JSON.setProperty(resolvedToEdgeBuilder, this.visibilityJson, visibility);
-            VisalloProperties.MODIFIED_BY.setProperty(resolvedToEdgeBuilder, user.getUserId(), visibility);
-            VisalloProperties.MODIFIED_DATE.setProperty(resolvedToEdgeBuilder, now, visibility);
+            VisalloProperties.MODIFIED_BY.setProperty(resolvedToEdgeBuilder, user.getUserId(), defaultVisibility);
+            VisalloProperties.MODIFIED_DATE.setProperty(resolvedToEdgeBuilder, now, defaultVisibility);
             resolvedToEdgeBuilder.save(authorizations);
         }
 

--- a/core/core/src/main/java/org/visallo/core/ping/PingUtil.java
+++ b/core/core/src/main/java/org/visallo/core/ping/PingUtil.java
@@ -17,6 +17,7 @@ import org.visallo.core.model.user.UserRepository;
 import org.visallo.core.model.workQueue.Priority;
 import org.visallo.core.model.workQueue.WorkQueueRepository;
 import org.visallo.core.security.VisalloVisibility;
+import org.visallo.core.security.VisibilityTranslator;
 import org.visallo.core.user.User;
 
 import java.net.InetAddress;
@@ -28,12 +29,19 @@ public class PingUtil {
     public static final String VISIBILITY_STRING = "ping";
     public static final Visibility VISIBILITY = new VisalloVisibility(VISIBILITY_STRING).getVisibility();
     private final User systemUser;
+    private final AuthorizationRepository authorizationRepository;
+    private final UserRepository userRepository;
+    private final VisibilityTranslator visibilityTranslator;
 
     @Inject
     public PingUtil(
             AuthorizationRepository authorizationRepository,
-            UserRepository userRepository
+            UserRepository userRepository,
+            VisibilityTranslator visibilityTranslator
     ) {
+        this.authorizationRepository = authorizationRepository;
+        this.userRepository = userRepository;
+        this.visibilityTranslator = visibilityTranslator;
         authorizationRepository.addAuthorizationToGraph(VISIBILITY_STRING);
         this.systemUser = userRepository.getSystemUser();
     }
@@ -60,7 +68,7 @@ public class PingUtil {
         Date createDate = new Date();
         String vertexId = PingOntology.getVertexId(createDate);
         ElementMutation<Vertex> mutation = graph.prepareVertex(vertexId, VISIBILITY);
-        VisalloProperties.CONCEPT_TYPE.setProperty(mutation, PingOntology.IRI_CONCEPT_PING, VISIBILITY);
+        VisalloProperties.CONCEPT_TYPE.setProperty(mutation, PingOntology.IRI_CONCEPT_PING, visibilityTranslator.getDefaultVisibility());
         PingOntology.CREATE_DATE.setProperty(mutation, createDate, VISIBILITY);
         PingOntology.CREATE_REMOTE_ADDR.setProperty(mutation, remoteAddr, VISIBILITY);
         PingOntology.SEARCH_TIME_MS.setProperty(mutation, searchTime, VISIBILITY);

--- a/core/plugins/model-vertexium-inmemory/src/test/java/model/workspace/VertexiumWorkspaceSandboxingTest.java
+++ b/core/plugins/model-vertexium-inmemory/src/test/java/model/workspace/VertexiumWorkspaceSandboxingTest.java
@@ -514,7 +514,7 @@ public class VertexiumWorkspaceSandboxingTest extends VertexiumWorkspaceReposito
                 .addPropertyValue("k1", "p1", "v1", propertyMetadata, initialVisibility)
                 .addPropertyValue("k2", "p2", "v2", propertyMetadata, initialVisibility);
         VisalloProperties.VISIBILITY_JSON.setProperty(
-                vertexBuilder, initialVisibilityJson, propertyMetadata, initialVisibility);
+                vertexBuilder, initialVisibilityJson, propertyMetadata, new Visibility(""));
         Vertex v1 = vertexBuilder.save(workspaceAuthorizations);
         graph.flush();
 
@@ -532,7 +532,7 @@ public class VertexiumWorkspaceSandboxingTest extends VertexiumWorkspaceReposito
                 .addPropertyValue("k3", "p1", "v1", propertyMetadata, initialVisibility)
                 .addPropertyValue("k4", "p2", "v2", propertyMetadata, initialVisibility);
         VisalloProperties.VISIBILITY_JSON.setProperty(
-                vertexBuilder, initialVisibilityJson, propertyMetadata, initialVisibility);
+                vertexBuilder, initialVisibilityJson, propertyMetadata, new Visibility(""));
         vertexBuilder.save(workspaceAuthorizations);
         graph.flush();
 
@@ -666,7 +666,7 @@ public class VertexiumWorkspaceSandboxingTest extends VertexiumWorkspaceReposito
         Vertex v1 = graph.prepareVertex("v1", initialVisibility).save(workspaceAuthorizations);
         Vertex v2 = graph.prepareVertex("v2", initialVisibility).save(workspaceAuthorizations);
         EdgeBuilder edgeBuilder = graph.prepareEdge("edge1", v1, v2, "label1", initialWorkspaceViz);
-        VisalloProperties.VISIBILITY_JSON.setProperty(edgeBuilder, initialVisibilityJson, initialWorkspaceViz);
+        VisalloProperties.VISIBILITY_JSON.setProperty(edgeBuilder, initialVisibilityJson, new Visibility(""));
         VisalloProperties.MODIFIED_BY.setProperty(edgeBuilder, "testUser", initialWorkspaceViz);
         Edge edge = edgeBuilder.save(workspaceAuthorizations);
         graph.flush();
@@ -685,7 +685,7 @@ public class VertexiumWorkspaceSandboxingTest extends VertexiumWorkspaceReposito
         when(ontologyRepository.getPropertyByIRI(VisalloProperties.TITLE.getPropertyName())).thenReturn(titleOntologyProp);
 
         VertexBuilder vertexBuilder = graph.prepareVertex(initialWorkspaceViz);
-        VisalloProperties.VISIBILITY_JSON.setProperty(vertexBuilder, initialVisibilityJson, initialWorkspaceViz);
+        VisalloProperties.VISIBILITY_JSON.setProperty(vertexBuilder, initialVisibilityJson, new Visibility(""));
 
         // Note that GraphRepository does not create new Metadata for each property. Doing that here is needed due
         // to the use of InMemoryGraph.
@@ -693,7 +693,7 @@ public class VertexiumWorkspaceSandboxingTest extends VertexiumWorkspaceReposito
         VisalloProperties.VISIBILITY_JSON_METADATA.setMetadata(propertyMetadata, initialVisibilityJson,
                 DEFAULT_VISIBILITY);
         VisalloProperties.CONCEPT_TYPE.setProperty(vertexBuilder, VERTEX_CONCEPT_TYPE, propertyMetadata,
-                initialWorkspaceViz);
+                new Visibility(""));
 
         propertyMetadata = new Metadata();
         VisalloProperties.VISIBILITY_JSON_METADATA.setMetadata(propertyMetadata, initialVisibilityJson,

--- a/graph-property-worker/plugins/mime-type-ontology-mapper/src/main/java/org/visallo/mimeTypeOntologyMapper/MimeTypeOntologyMapperGraphPropertyWorker.java
+++ b/graph-property-worker/plugins/mime-type-ontology-mapper/src/main/java/org/visallo/mimeTypeOntologyMapper/MimeTypeOntologyMapperGraphPropertyWorker.java
@@ -1,7 +1,9 @@
 package org.visallo.mimeTypeOntologyMapper;
 
 import org.vertexium.Element;
+import org.vertexium.Metadata;
 import org.vertexium.Property;
+import org.vertexium.mutation.ExistingElementMutation;
 import org.visallo.core.exception.VisalloException;
 import org.visallo.core.ingest.graphProperty.GraphPropertyWorkData;
 import org.visallo.core.ingest.graphProperty.GraphPropertyWorker;
@@ -10,6 +12,7 @@ import org.visallo.core.model.Description;
 import org.visallo.core.model.Name;
 import org.visallo.core.model.ontology.Concept;
 import org.visallo.core.model.properties.VisalloProperties;
+import org.visallo.core.model.properties.types.VisalloPropertyUpdate;
 import org.visallo.core.util.VisalloLogger;
 import org.visallo.core.util.VisalloLoggerFactory;
 
@@ -103,12 +106,15 @@ public class MimeTypeOntologyMapperGraphPropertyWorker extends GraphPropertyWork
         }
 
         LOGGER.debug("assigning concept type %s to vertex %s", concept.getIRI(), data.getElement().getId());
-        VisalloProperties.CONCEPT_TYPE.setProperty(data.getElement(), concept.getIRI(), data.createPropertyMetadata(), data.getVisibility(), getAuthorizations());
+
+        List<VisalloPropertyUpdate> changedProperties = new ArrayList<>();
+        ExistingElementMutation<Element> m = data.getElement().prepareMutation();
+        VisalloProperties.CONCEPT_TYPE.updateProperty(changedProperties, data.getElement(), m, concept.getIRI(), (Metadata) null, getVisibilityTranslator().getDefaultVisibility());
+        m.save(getAuthorizations());
         getGraph().flush();
-        getWorkQueueRepository().pushGraphPropertyQueue(
+        getWorkQueueRepository().pushGraphVisalloPropertyQueue(
                 data.getElement(),
-                null,
-                VisalloProperties.CONCEPT_TYPE.getPropertyName(),
+                changedProperties,
                 data.getWorkspaceId(),
                 data.getVisibilitySource(),
                 data.getPriority()

--- a/graph-property-worker/plugins/phone-number-extractor/src/test/java/org/visallo/phoneNumber/PhoneNumberGraphPropertyWorkerTest.java
+++ b/graph-property-worker/plugins/phone-number-extractor/src/test/java/org/visallo/phoneNumber/PhoneNumberGraphPropertyWorkerTest.java
@@ -41,7 +41,7 @@ public class PhoneNumberGraphPropertyWorkerTest extends GraphPropertyWorkerTestS
         VertexBuilder vertexBuilder = graph.prepareVertex("v1", visibility);
         StreamingPropertyValue textPropertyValue = new StreamingPropertyValue(in, String.class);
         VisalloProperties.TEXT.addPropertyValue(vertexBuilder, MULTI_VALUE_KEY, textPropertyValue, visibility);
-        VisalloProperties.VISIBILITY_JSON.setProperty(vertexBuilder, visibilityJson, visibility);
+        VisalloProperties.VISIBILITY_JSON.setProperty(vertexBuilder, visibilityJson, visibilityTranslator.getDefaultVisibility());
         Vertex vertex = vertexBuilder.save(authorizations);
 
         Property property = vertex.getProperty(VisalloProperties.TEXT.getPropertyName());
@@ -78,7 +78,7 @@ public class PhoneNumberGraphPropertyWorkerTest extends GraphPropertyWorkerTestS
         VertexBuilder vertexBuilder = graph.prepareVertex("v1", visibility);
         StreamingPropertyValue textPropertyValue = new StreamingPropertyValue(in, String.class);
         VisalloProperties.TEXT.addPropertyValue(vertexBuilder, MULTI_VALUE_KEY, textPropertyValue, visibility);
-        VisalloProperties.VISIBILITY_JSON.setProperty(vertexBuilder, visibilityJson, visibility);
+        VisalloProperties.VISIBILITY_JSON.setProperty(vertexBuilder, visibilityJson, visibilityTranslator.getDefaultVisibility());
         Vertex vertex = vertexBuilder.save(authorizations);
 
         Property property = vertex.getProperty(VisalloProperties.TEXT.getPropertyName());

--- a/graph-property-worker/plugins/tika-text-extractor/src/main/java/org/visallo/tikaTextExtractor/TikaTextExtractorGraphPropertyWorker.java
+++ b/graph-property-worker/plugins/tika-text-extractor/src/main/java/org/visallo/tikaTextExtractor/TikaTextExtractorGraphPropertyWorker.java
@@ -173,12 +173,13 @@ public class TikaTextExtractorGraphPropertyWorker extends GraphPropertyWorker {
 
         String customImageMetadata = extractTextField(metadata, customFlickrMetadataKeys);
         org.vertexium.Metadata textMetadata = data.createPropertyMetadata();
-        VisalloProperties.MIME_TYPE_METADATA.setMetadata(textMetadata, "text/plain", getVisibilityTranslator().getDefaultVisibility());
+        Visibility defaultVisibility = getVisibilityTranslator().getDefaultVisibility();
+        VisalloProperties.MIME_TYPE_METADATA.setMetadata(textMetadata, "text/plain", defaultVisibility);
         if (!Strings.isNullOrEmpty(textExtractMapping.getTextDescription())) {
             VisalloProperties.TEXT_DESCRIPTION_METADATA.setMetadata(
                     textMetadata,
                     textExtractMapping.getTextDescription(),
-                    getVisibilityTranslator().getDefaultVisibility()
+                    defaultVisibility
             );
         }
 
@@ -193,12 +194,12 @@ public class TikaTextExtractorGraphPropertyWorker extends GraphPropertyWorker {
 
                 Date lastUpdate = GenericDateExtractor
                         .extractSingleDate(customImageMetadataJson.get("lastupdate").toString());
-                VisalloProperties.MODIFIED_DATE.setProperty(m, lastUpdate, data.createPropertyMetadata(), data.getVisibility());
+                VisalloProperties.MODIFIED_DATE.setProperty(m, lastUpdate, defaultVisibility);
 
                 // TODO set("retrievalTime", Long.parseLong(customImageMetadataJson.get("atc:retrieval-timestamp").toString()));
 
                 org.vertexium.Metadata titleMetadata = data.createPropertyMetadata();
-                VisalloProperties.CONFIDENCE_METADATA.setMetadata(titleMetadata, SYSTEM_ASSIGNED_CONFIDENCE, getVisibilityTranslator().getDefaultVisibility());
+                VisalloProperties.CONFIDENCE_METADATA.setMetadata(titleMetadata, SYSTEM_ASSIGNED_CONFIDENCE, defaultVisibility);
                 if (titlePropertyIri != null) {
                     m.addPropertyValue(propertyKey, titlePropertyIri, customImageMetadataJson.get("title").toString(), titleMetadata, data.getVisibility());
                 }
@@ -209,11 +210,11 @@ public class TikaTextExtractorGraphPropertyWorker extends GraphPropertyWorker {
             StreamingPropertyValue textValue = new StreamingPropertyValue(new ByteArrayInputStream(text.getBytes(charset)), String.class);
             addTextProperty(textExtractMapping, m, propertyKey, textValue, textMetadata, data.getVisibility());
 
-            VisalloProperties.MODIFIED_DATE.setProperty(m, extractDate(metadata), data.createPropertyMetadata(), data.getVisibility());
+            VisalloProperties.MODIFIED_DATE.setProperty(m, extractDate(metadata), defaultVisibility);
             String title = extractTextField(metadata, subjectKeys);
             if (title != null && title.length() > 0) {
                 org.vertexium.Metadata titleMetadata = data.createPropertyMetadata();
-                VisalloProperties.CONFIDENCE_METADATA.setMetadata(titleMetadata, SYSTEM_ASSIGNED_CONFIDENCE, getVisibilityTranslator().getDefaultVisibility());
+                VisalloProperties.CONFIDENCE_METADATA.setMetadata(titleMetadata, SYSTEM_ASSIGNED_CONFIDENCE, defaultVisibility);
                 if (titlePropertyIri != null) {
                     m.addPropertyValue(propertyKey, titlePropertyIri, title, titleMetadata, data.getVisibility());
                 }
@@ -225,7 +226,7 @@ public class TikaTextExtractorGraphPropertyWorker extends GraphPropertyWorker {
                 String numberOfPages = extractTextField(metadata, numberOfPagesKeys);
                 if (numberOfPages != null) {
                     org.vertexium.Metadata numberOfPagesMetadata = data.createPropertyMetadata();
-                    VisalloProperties.CONFIDENCE_METADATA.setMetadata(numberOfPagesMetadata, SYSTEM_ASSIGNED_CONFIDENCE, getVisibilityTranslator().getDefaultVisibility());
+                    VisalloProperties.CONFIDENCE_METADATA.setMetadata(numberOfPagesMetadata, SYSTEM_ASSIGNED_CONFIDENCE, defaultVisibility);
                     pageCountProperty.addPropertyValue(m, propertyKey, Long.valueOf(numberOfPages), numberOfPagesMetadata, data.getVisibility());
                 }
             }

--- a/tools/ontology-ingest/common/src/main/java/org/visallo/tools/ontology/ingest/common/IngestRepository.java
+++ b/tools/ontology-ingest/common/src/main/java/org/visallo/tools/ontology/ingest/common/IngestRepository.java
@@ -93,7 +93,7 @@ public class IngestRepository {
     private Vertex save(IngestOptions ingestOptions, ConceptBuilder conceptBuilder) {
         Visibility conceptVisibility = getVisibility(ingestOptions, conceptBuilder.getVisibility());
         VertexBuilder vertexBuilder = graph.prepareVertex(conceptBuilder.getId(), getTimestamp(ingestOptions, conceptBuilder.getTimestamp()), conceptVisibility);
-        vertexBuilder.setProperty(VisalloProperties.CONCEPT_TYPE.getPropertyName(), conceptBuilder.getIri(), conceptVisibility);
+        vertexBuilder.setProperty(VisalloProperties.CONCEPT_TYPE.getPropertyName(), conceptBuilder.getIri(), visibilityTranslator.getDefaultVisibility());
 
         addProperties(ingestOptions, vertexBuilder, conceptBuilder);
 

--- a/web/web-base-test/src/test/java/org/visallo/web/routes/vertex/UnresolveTermEntityTest.java
+++ b/web/web-base-test/src/test/java/org/visallo/web/routes/vertex/UnresolveTermEntityTest.java
@@ -48,7 +48,7 @@ public class UnresolveTermEntityTest extends RouteTestBase {
         Edge e = graph.addEdge("v1_to_v2", v1, v2, "link", visibility, authorizations);
         VisibilityJson visibilityJson = new VisibilityJson();
         visibilityJson.addWorkspace(WORKSPACE_ID);
-        VisalloProperties.VISIBILITY_JSON.setProperty(e, visibilityJson, visibility, authorizations);
+        VisalloProperties.VISIBILITY_JSON.setProperty(e, visibilityJson, new Visibility(""), authorizations);
         graph.flush();
 
         when(userRepository.getAuthorizations(eq(user), eq(WORKSPACE_ID))).thenReturn(authorizations);

--- a/web/web-base/src/main/java/org/visallo/web/routes/vertex/ResolveDetectedObject.java
+++ b/web/web-base/src/main/java/org/visallo/web/routes/vertex/ResolveDetectedObject.java
@@ -29,6 +29,7 @@ import org.visallo.web.clientapi.model.VisibilityJson;
 import org.visallo.web.parameterProviders.ActiveWorkspaceId;
 import org.visallo.web.parameterProviders.JustificationText;
 
+import java.util.Date;
 import java.util.ResourceBundle;
 
 public class ResolveDetectedObject implements ParameterizedHandler {
@@ -103,13 +104,17 @@ public class ResolveDetectedObject implements ParameterizedHandler {
         ElementMutation<Vertex> resolvedVertexMutation;
 
         Metadata metadata = new Metadata();
-        VisalloProperties.VISIBILITY_JSON_METADATA.setMetadata(metadata, visibilityJson, visibilityTranslator.getDefaultVisibility());
+        Visibility defaultVisibility = visibilityTranslator.getDefaultVisibility();
+        VisalloProperties.VISIBILITY_JSON_METADATA.setMetadata(metadata, visibilityJson, defaultVisibility);
 
         Vertex resolvedVertex;
         if (graphVertexId == null || graphVertexId.equals("")) {
             resolvedVertexMutation = graph.prepareVertex(visalloVisibility.getVisibility());
 
-            VisalloProperties.CONCEPT_TYPE.setProperty(resolvedVertexMutation, concept.getIRI(), metadata, visalloVisibility.getVisibility());
+            VisalloProperties.CONCEPT_TYPE.setProperty(resolvedVertexMutation, concept.getIRI(), defaultVisibility);
+            VisalloProperties.VISIBILITY_JSON.setProperty(resolvedVertexMutation, visibilityJson, defaultVisibility);
+            VisalloProperties.MODIFIED_DATE.setProperty(resolvedVertexMutation, new Date(), defaultVisibility);
+            VisalloProperties.MODIFIED_BY.setProperty(resolvedVertexMutation, user.getUserId(), defaultVisibility);
             VisalloProperties.TITLE.addPropertyValue(resolvedVertexMutation, MULTI_VALUE_KEY, title, metadata, visalloVisibility.getVisibility());
 
             resolvedVertex = resolvedVertexMutation.save(authorizations);
@@ -121,7 +126,7 @@ public class ResolveDetectedObject implements ParameterizedHandler {
 
             resolvedVertex = resolvedVertexMutation.save(authorizations);
 
-            VisalloProperties.VISIBILITY_JSON.setProperty(resolvedVertexMutation, visibilityJson, metadata, visalloVisibility.getVisibility());
+            VisalloProperties.VISIBILITY_JSON.setProperty(resolvedVertexMutation, visibilityJson, defaultVisibility);
 
             graph.flush();
 
@@ -132,7 +137,7 @@ public class ResolveDetectedObject implements ParameterizedHandler {
         }
 
         Edge edge = graph.addEdge(artifactVertex, resolvedVertex, artifactContainsImageOfEntityIri, visalloVisibility.getVisibility(), authorizations);
-        VisalloProperties.VISIBILITY_JSON.setProperty(edge, visibilityJson, metadata, visalloVisibility.getVisibility(), authorizations);
+        VisalloProperties.VISIBILITY_JSON.setProperty(edge, visibilityJson, defaultVisibility, authorizations);
 
         ArtifactDetectedObject artifactDetectedObject = new ArtifactDetectedObject(
                 x1,

--- a/web/web-base/src/main/java/org/visallo/web/routes/vertex/ResolveTermEntity.java
+++ b/web/web-base/src/main/java/org/visallo/web/routes/vertex/ResolveTermEntity.java
@@ -99,23 +99,24 @@ public class ResolveTermEntity implements ParameterizedHandler {
         final Vertex artifactVertex = graph.getVertex(artifactId, authorizations);
         VisalloVisibility visalloVisibility = visibilityTranslator.toVisibility(visibilityJson);
         Metadata metadata = new Metadata();
-        VisalloProperties.VISIBILITY_JSON_METADATA.setMetadata(metadata, visibilityJson, visibilityTranslator.getDefaultVisibility());
+        Visibility defaultVisibility = visibilityTranslator.getDefaultVisibility();
+        VisalloProperties.VISIBILITY_JSON_METADATA.setMetadata(metadata, visibilityJson, defaultVisibility);
         Vertex vertex;
         if (resolvedVertexId != null) {
             vertex = graph.getVertex(id, authorizations);
         } else {
             ElementMutation<Vertex> vertexMutation = graph.prepareVertex(id, visalloVisibility.getVisibility());
-            VisalloProperties.CONCEPT_TYPE.setProperty(vertexMutation, conceptId, metadata, visalloVisibility.getVisibility());
+            VisalloProperties.CONCEPT_TYPE.setProperty(vertexMutation, conceptId, defaultVisibility);
+            VisalloProperties.VISIBILITY_JSON.setProperty(vertexMutation, visibilityJson, defaultVisibility);
+            VisalloProperties.MODIFIED_BY.setProperty(vertexMutation, user.getUserId(), defaultVisibility);
+            VisalloProperties.MODIFIED_DATE.setProperty(vertexMutation, new Date(), defaultVisibility);
             VisalloProperties.TITLE.addPropertyValue(vertexMutation, MULTI_VALUE_KEY, title, metadata, visalloVisibility.getVisibility());
-            VisalloProperties.MODIFIED_BY.setProperty(vertexMutation, user.getUserId(), visalloVisibility.getVisibility());
-            VisalloProperties.MODIFIED_DATE.setProperty(vertexMutation, new Date(), visalloVisibility.getVisibility());
 
             if (justificationText != null) {
                 PropertyJustificationMetadata propertyJustificationMetadata = new PropertyJustificationMetadata(justificationText);
                 VisalloProperties.JUSTIFICATION.setProperty(vertexMutation, propertyJustificationMetadata, visalloVisibility.getVisibility());
             }
 
-            VisalloProperties.VISIBILITY_JSON.setProperty(vertexMutation, visibilityJson, metadata, visalloVisibility.getVisibility());
             vertex = vertexMutation.save(authorizations);
 
             this.graph.flush();
@@ -124,9 +125,9 @@ public class ResolveTermEntity implements ParameterizedHandler {
         }
 
         EdgeBuilder edgeBuilder = graph.prepareEdge(artifactVertex, vertex, this.artifactHasEntityIri, visalloVisibility.getVisibility());
-        VisalloProperties.MODIFIED_BY.setProperty(edgeBuilder, user.getUserId(), visalloVisibility.getVisibility());
-        VisalloProperties.MODIFIED_DATE.setProperty(edgeBuilder, new Date(), visalloVisibility.getVisibility());
-        VisalloProperties.VISIBILITY_JSON.setProperty(edgeBuilder, visibilityJson, metadata, visalloVisibility.getVisibility());
+        VisalloProperties.MODIFIED_BY.setProperty(edgeBuilder, user.getUserId(), defaultVisibility);
+        VisalloProperties.MODIFIED_DATE.setProperty(edgeBuilder, new Date(), defaultVisibility);
+        VisalloProperties.VISIBILITY_JSON.setProperty(edgeBuilder, visibilityJson, defaultVisibility);
         Edge edge = edgeBuilder.save(authorizations);
 
         ClientApiSourceInfo sourceInfo = ClientApiSourceInfo.fromString(sourceInfoString);


### PR DESCRIPTION
- [ ] @srfarley @joeferner
- [ ] @mwizeman @dsingley @EvanOxfeld 
- [ ] @joeybrk372 @sfeng88 @rygim @jharwig 

Properties: VISIBILITY_JSON, MODIFIED_DATE, MODIFIED_BY, and CONCEPT_TYPE

* metadata is optional and should be discouraged
* all 4 of these properties should be set on all elements
* all 4 of these properties should be set to the default visibility

If these conditions are not true, workspace publish will warn in the logs. I have also upped the logging to warn if a property (other than the ones above) is missing visibility json metadata when published, this should help catch mistakes sooner.

After the release I would like to refactor out setting these properties into a helper method so that we can be more consistent, but I didn't want to change too much at one time with this PR.