### PR TITLE
Fix pie erroring on resize in Firefox

### DIFF
--- a/web/war/src/main/webapp/js/dashboard/reportRenderers/pie.js
+++ b/web/war/src/main/webapp/js/dashboard/reportRenderers/pie.js
@@ -265,7 +265,7 @@ define([
             } else {
                 gLegend.style('opacity', 1);
                 if (gLegend.node().getBBox().width > availableLegendSpace) {
-                    gLegend.selectAll('text').each(function(d) {
+                    gLegend.selectAll('g:not(.hidden) > text').each(function(d) {
                         var d3Self = d3.select(this),
                             text = d3.select(this).text();
                         while (this.getBBox().width > availableLegendTextWidth) {


### PR DESCRIPTION
- [x] @srfarley @joeferner
- [x] @mwizeman @dsingley @EvanOxfeld 
- [x] @joeybrk372 @sfeng88 @rygim @jharwig 

Firefox doesn't support `getBBox()` on elements that aren't rendered.