### PR TITLE
Move eslint and set root flag

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,5 @@
 module.exports = {
+    "root": true,
     "env": {
         "browser": true,
         "es6": true,


### PR DESCRIPTION
- [x] @srfarley @joeferner
- [x] @mwizeman @dsingley @EvanOxfeld 
- [x] @joeybrk372 @sfeng88 @rygim @jharwig 

ESLint walks up the dir hierarchy in search of config files, but could fail if it finds one outside of the visallo dir. This moves the config to the root of the project (from web app) and sets the `root:true` flag to prevent this.