### PR TITLE
RDF: Support raw (not transformed by VisibilityTranslator) visibility.

### DIFF
--- a/core/core/src/main/java/org/visallo/core/security/DirectVisibilityTranslator.java
+++ b/core/core/src/main/java/org/visallo/core/security/DirectVisibilityTranslator.java
@@ -1,7 +1,7 @@
 package org.visallo.core.security;
 
-import org.visallo.web.clientapi.model.VisibilityJson;
 import org.vertexium.Visibility;
+import org.visallo.web.clientapi.model.VisibilityJson;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -21,7 +21,11 @@ public class DirectVisibilityTranslator extends VisibilityTranslator {
 
     @Override
     public VisalloVisibility toVisibility(String visibilitySource) {
-        return new VisalloVisibility(toVisibilityNoSuperUser(new VisibilityJson(visibilitySource)));
+        return toVisibility(visibilitySourceToVisibilityJson(visibilitySource));
+    }
+
+    protected VisibilityJson visibilitySourceToVisibilityJson(String visibilitySource) {
+        return new VisibilityJson(visibilitySource);
     }
 
     @Override

--- a/tools/rdf-import/README.md
+++ b/tools/rdf-import/README.md
@@ -20,6 +20,9 @@ You can supply visibility to a vertex by appending `[visibility string]`.
 
 This will create a vertex with the visibility `SECRET`.
 
+If the visibility string starts with a `!` the visibility string will not be transformed using the visibility translator
+and instead be used directly.
+
 ### Multi-value key
 
 You can supply multi-value keys by appending `:key` to a property name.


### PR DESCRIPTION
- [x] @srfarley
- [x] @mwizeman @dsingley @EvanOxfeld 
- [x] @joeybrk372 @sfeng88 @rygim @jharwig 

This feature is needed to import workspaces using RDF when a `VisibilityTranslator` is setup.