### PR TITLE
Add workspace and user title formulas. Add concept type properties to dashboard and dashboard item vertices

### DIFF
--- a/core/core/src/main/java/org/visallo/core/model/workspace/WorkspaceProperties.java
+++ b/core/core/src/main/java/org/visallo/core/model/workspace/WorkspaceProperties.java
@@ -6,6 +6,8 @@ import org.visallo.core.model.properties.types.StringSingleValueVisalloProperty;
 
 public class WorkspaceProperties {
     public static final String WORKSPACE_CONCEPT_IRI = "http://visallo.org/workspace#workspace";
+    public static final String DASHBOARD_CONCEPT_IRI = "http://visallo.org/workspace#dashboard";
+    public static final String DASHBOARD_ITEM_CONCEPT_IRI = "http://visallo.org/workspace#dashboardItem";
     public static final String WORKSPACE_TO_ENTITY_RELATIONSHIP_IRI = "http://visallo.org/workspace#toEntity";
     public static final String WORKSPACE_TO_USER_RELATIONSHIP_IRI = "http://visallo.org/workspace#toUser";
     public static final String WORKSPACE_TO_DASHBOARD_RELATIONSHIP_IRI = "http://visallo.org/workspace#toDashboard";

--- a/core/core/src/main/resources/org/visallo/core/model/ontology/user.owl
+++ b/core/core/src/main/resources/org/visallo/core/model/ontology/user.owl
@@ -237,6 +237,8 @@
     <!-- http://visallo.org/user#user -->
 
     <owl:Class rdf:about="http://visallo.org/user#user">
+        <rdfs:label xml:lang="en">User</rdfs:label>
+        <visallo:titleFormula>&apos;User: &apos; + prop(&apos;http://visallo.org/user#username&apos;)</visallo:titleFormula>
         <visallo:userVisible>false</visallo:userVisible>
     </owl:Class>
 </rdf:RDF>

--- a/core/core/src/main/resources/org/visallo/core/model/ontology/workspace.owl
+++ b/core/core/src/main/resources/org/visallo/core/model/ontology/workspace.owl
@@ -89,9 +89,9 @@
     <!-- http://visallo.org/workspace#configuration -->
 
     <owl:DatatypeProperty rdf:about="http://visallo.org/workspace#configuration">
+        <visallo:userVisible>false</visallo:userVisible>
         <rdfs:domain rdf:resource="http://visallo.org/workspace#dashboardItem"/>
         <rdfs:range rdf:resource="&xsd;string"/>
-        <visallo:userVisible>false</visallo:userVisible>
     </owl:DatatypeProperty>
     
 
@@ -99,9 +99,9 @@
     <!-- http://visallo.org/workspace#extensionId -->
 
     <owl:DatatypeProperty rdf:about="http://visallo.org/workspace#extensionId">
+        <visallo:userVisible>false</visallo:userVisible>
         <rdfs:domain rdf:resource="http://visallo.org/workspace#dashboardItem"/>
         <rdfs:range rdf:resource="&xsd;string"/>
-        <visallo:userVisible>false</visallo:userVisible>
     </owl:DatatypeProperty>
     
 
@@ -194,6 +194,7 @@
     <owl:Class rdf:about="http://visallo.org/workspace#dashboard">
         <rdfs:label xml:lang="en">Dashboard</rdfs:label>
         <visallo:userVisible>false</visallo:userVisible>
+        <visallo:titleFormula>&apos;Dashboard: &apos; + prop(&apos;http://visallo.org/workspace#workspace/title&apos;)</visallo:titleFormula>
     </owl:Class>
     
 
@@ -202,6 +203,7 @@
 
     <owl:Class rdf:about="http://visallo.org/workspace#dashboardItem">
         <rdfs:label xml:lang="en">Dashboard Item</rdfs:label>
+        <visallo:titleFormula>&apos;Dashboard Item: &apos; + prop(&apos;http://visallo.org/workspace#extensionId&apos;)</visallo:titleFormula>
         <visallo:userVisible>false</visallo:userVisible>
     </owl:Class>
     
@@ -210,6 +212,8 @@
     <!-- http://visallo.org/workspace#workspace -->
 
     <owl:Class rdf:about="http://visallo.org/workspace#workspace">
+        <rdfs:label xml:lang="en">Workspace</rdfs:label>
+        <visallo:titleFormula>&apos;Workspace: &apos; + prop(&apos;http://visallo.org/workspace#workspace/title&apos;)</visallo:titleFormula>
         <visallo:userVisible>false</visallo:userVisible>
     </owl:Class>
 </rdf:RDF>

--- a/core/plugins/model-vertexium/src/main/java/org/visallo/vertexium/model/workspace/VertexiumWorkspaceRepository.java
+++ b/core/plugins/model-vertexium/src/main/java/org/visallo/vertexium/model/workspace/VertexiumWorkspaceRepository.java
@@ -223,7 +223,7 @@ public class VertexiumWorkspaceRepository extends WorkspaceRepository {
         VisalloProperties.CONCEPT_TYPE.setProperty(
                 workspaceVertexBuilder,
                 WORKSPACE_CONCEPT_IRI,
-                VISIBILITY.getVisibility()
+                getVisibilityTranslator().getDefaultVisibility()
         );
         WorkspaceProperties.TITLE.setProperty(workspaceVertexBuilder, title, VISIBILITY.getVisibility());
         Vertex workspaceVertex = workspaceVertexBuilder.save(authorizations);
@@ -722,6 +722,11 @@ public class VertexiumWorkspaceRepository extends WorkspaceRepository {
         Authorizations authorizations = getUserRepository().getAuthorizations(user, VISIBILITY_STRING, workspaceId);
         Visibility visibility = VISIBILITY.getVisibility();
         VertexBuilder dashboardItemVertexBuilder = getGraph().prepareVertex(dashboardItemId, visibility);
+        VisalloProperties.CONCEPT_TYPE.setProperty(
+                dashboardItemVertexBuilder,
+                WorkspaceProperties.DASHBOARD_ITEM_CONCEPT_IRI,
+                getVisibilityTranslator().getDefaultVisibility()
+        );
         WorkspaceProperties.DASHBOARD_ITEM_EXTENSION_ID.setProperty(
                 dashboardItemVertexBuilder,
                 extensionId == null ? "" : extensionId,
@@ -791,6 +796,11 @@ public class VertexiumWorkspaceRepository extends WorkspaceRepository {
         Authorizations authorizations = getUserRepository().getAuthorizations(user, VISIBILITY_STRING, workspaceId);
         Visibility visibility = VISIBILITY.getVisibility();
         VertexBuilder dashboardVertexBuilder = getGraph().prepareVertex(dashboardId, visibility);
+        VisalloProperties.CONCEPT_TYPE.setProperty(
+                dashboardVertexBuilder,
+                WorkspaceProperties.DASHBOARD_CONCEPT_IRI,
+                getVisibilityTranslator().getDefaultVisibility()
+        );
         WorkspaceProperties.TITLE.setProperty(dashboardVertexBuilder, title == null ? "" : title, visibility);
         Vertex dashboardVertex = dashboardVertexBuilder.save(authorizations);
 


### PR DESCRIPTION
- [x] @srfarley @joeferner
- [x] @mwizeman @dsingley @EvanOxfeld 
- [x] @joeybrk372 @sfeng88 @rygim @jharwig 

This PR is only useful for debugging the graph after you add `user` and `workspace` authorizations to yourself. It allows you to view the vertex titles instead of "No Title".

Also sets the concept type on dashboard and dashboard items which will make migrations easier down the road.