### PR TITLE
Fix NPE when calling toString on ClientApiWorkspace when users or vertices are null

### DIFF
--- a/web/client-api/src/main/java/org/visallo/web/clientapi/model/ClientApiWorkspace.java
+++ b/web/client-api/src/main/java/org/visallo/web/clientapi/model/ClientApiWorkspace.java
@@ -93,8 +93,6 @@ public class ClientApiWorkspace implements ClientApiObject {
                 ", isSharedToUser=" + isSharedToUser +
                 ", isEditable=" + isEditable +
                 ", active=" + active +
-                ", users=" + StringUtils.join(users) +
-                ", vertices=" + StringUtils.join(vertices) +
                 '}';
     }
 


### PR DESCRIPTION
- [x] @srfarley @joeferner
- [x] @mwizeman @dsingley @EvanOxfeld 
- [x] @joeybrk372 @sfeng88 @rygim @jharwig 

`users` and `vertices` are allowed to be null this just fixes a NPE when `toString` is called. Probably don't need to print out all users and vertices anyway