### PR TITLE
RDF: Increase RDF triple import performance by hanging onto the Vertexium mutations between lines

### DIFF
--- a/common/rdf/src/main/java/org/visallo/common/rdf/AddEdgeVisalloRdfTriple.java
+++ b/common/rdf/src/main/java/org/visallo/common/rdf/AddEdgeVisalloRdfTriple.java
@@ -1,6 +1,8 @@
 package org.visallo.common.rdf;
 
 import com.google.common.base.Strings;
+import org.vertexium.Authorizations;
+import org.vertexium.mutation.ElementMutation;
 
 public class AddEdgeVisalloRdfTriple extends VisalloRdfTriple {
     private final String edgeId;
@@ -25,6 +27,11 @@ public class AddEdgeVisalloRdfTriple extends VisalloRdfTriple {
 
     public String getEdgeId() {
         return edgeId;
+    }
+
+    @Override
+    public String getElementId() {
+        return getEdgeId();
     }
 
     public String getEdgeLabel() {
@@ -83,6 +90,22 @@ public class AddEdgeVisalloRdfTriple extends VisalloRdfTriple {
         }
 
         return super.equals(that);
+    }
+
+    @Override
+    public ImportContext updateImportContext(
+            ImportContext ctx,
+            RdfTripleImportHelper rdfTripleImportHelper,
+            Authorizations authorizations
+    ) {
+        ElementMutation m = rdfTripleImportHelper.getGraph().prepareEdge(
+                getEdgeId(),
+                getOutVertexId(),
+                getInVertexId(),
+                getEdgeLabel(),
+                rdfTripleImportHelper.getVisibility(getEdgeVisibilitySource())
+        );
+        return new ImportContext(getEdgeId(), m);
     }
 
     @Override

--- a/common/rdf/src/main/java/org/visallo/common/rdf/ConceptTypeVisalloRdfTriple.java
+++ b/common/rdf/src/main/java/org/visallo/common/rdf/ConceptTypeVisalloRdfTriple.java
@@ -1,6 +1,9 @@
 package org.visallo.common.rdf;
 
+import org.vertexium.Authorizations;
 import org.vertexium.ElementType;
+import org.vertexium.VertexBuilder;
+import org.vertexium.Visibility;
 
 public class ConceptTypeVisalloRdfTriple extends ElementVisalloRdfTriple {
     private final String conceptType;
@@ -39,5 +42,16 @@ public class ConceptTypeVisalloRdfTriple extends ElementVisalloRdfTriple {
         }
 
         return super.equals(o);
+    }
+
+    @Override
+    public ImportContext updateImportContext(
+            ImportContext ctx,
+            RdfTripleImportHelper rdfTripleImportHelper,
+            Authorizations authorizations
+    ) {
+        Visibility elementVisibility = rdfTripleImportHelper.getVisibility(getElementVisibilitySource());
+        VertexBuilder m = rdfTripleImportHelper.getGraph().prepareVertex(getElementId(), elementVisibility);
+        return new ImportContext(getElementId(), m);
     }
 }

--- a/common/rdf/src/main/java/org/visallo/common/rdf/ElementVisalloRdfTriple.java
+++ b/common/rdf/src/main/java/org/visallo/common/rdf/ElementVisalloRdfTriple.java
@@ -22,6 +22,7 @@ public abstract class ElementVisalloRdfTriple extends VisalloRdfTriple {
         return elementType;
     }
 
+    @Override
     public String getElementId() {
         return elementId;
     }

--- a/common/rdf/src/main/java/org/visallo/common/rdf/ImportContext.java
+++ b/common/rdf/src/main/java/org/visallo/common/rdf/ImportContext.java
@@ -1,0 +1,27 @@
+package org.visallo.common.rdf;
+
+import org.vertexium.Authorizations;
+import org.vertexium.Element;
+import org.vertexium.mutation.ElementMutation;
+
+class ImportContext {
+    private final ElementMutation m;
+    private final String elementId;
+
+    ImportContext(String elementId, ElementMutation m) {
+        this.m = m;
+        this.elementId = elementId;
+    }
+
+    public Element save(Authorizations authorizations) {
+        return getElementMutation().save(authorizations);
+    }
+
+    public boolean isNewElement(VisalloRdfTriple triple) {
+        return !this.elementId.equals(triple.getElementId());
+    }
+
+    public ElementMutation getElementMutation() {
+        return m;
+    }
+}

--- a/common/rdf/src/main/java/org/visallo/common/rdf/RdfTripleImportHelper.java
+++ b/common/rdf/src/main/java/org/visallo/common/rdf/RdfTripleImportHelper.java
@@ -1,5 +1,6 @@
 package org.visallo.common.rdf;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Inject;
 import org.vertexium.*;
 import org.vertexium.mutation.ElementMutation;
@@ -18,8 +19,6 @@ import org.visallo.web.clientapi.model.VisibilityJson;
 
 import java.io.*;
 import java.util.*;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 public class RdfTripleImportHelper {
     private static final VisalloLogger LOGGER = VisalloLoggerFactory.getLogger(RdfTripleImportHelper.class);
@@ -101,10 +100,11 @@ public class RdfTripleImportHelper {
         BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
         int lineNum = 1;
         String line;
+        ImportContext ctx = null;
         while ((line = reader.readLine()) != null) {
             LOGGER.debug("Importing RDF triple on line: %d", lineNum);
             try {
-                importRdfLine(elements, sourceFileName, line, workingDir, timeZone, defaultVisibilitySource, user, authorizations);
+                ctx = importRdfLine(ctx, elements, sourceFileName, line, workingDir, timeZone, defaultVisibilitySource, user, authorizations);
             } catch (Exception e) {
                 String errMsg = String.format("Error importing RDF triple on line: %d. %s", lineNum, e.getMessage());
                 if (failOnFirstError) {
@@ -117,6 +117,9 @@ public class RdfTripleImportHelper {
 
             ++lineNum;
         }
+        if (ctx != null) {
+            elements.add(ctx.save(authorizations));
+        }
 
         graph.flush();
         LOGGER.info("pushing %d elements from RDF import on to work queue", elements.size());
@@ -126,7 +129,9 @@ public class RdfTripleImportHelper {
         LOGGER.debug("RDF %s imported in %dms", sourceFileName, endTime - startTime);
     }
 
-    public void importRdfLine(
+    @VisibleForTesting
+    ImportContext importRdfLine(
+            ImportContext ctx,
             Set<Element> elements,
             String sourceFileName,
             String line,
@@ -137,17 +142,15 @@ public class RdfTripleImportHelper {
             Authorizations authorizations
     ) {
         if (line.length() == 0 || line.charAt(0) == '#') {
-            return;
+            return ctx;
         }
         RdfTriple rdfTriple = RdfTripleParser.parseLine(line);
-        if (importRdfTriple(elements, rdfTriple, sourceFileName, workingDir, timeZone, defaultVisibilitySource, user, authorizations)) {
-            return;
-        }
 
-        throw new VisalloException("Unhandled combination of RDF triples");
+        return importRdfTriple(ctx, elements, rdfTriple, sourceFileName, workingDir, timeZone, defaultVisibilitySource, user, authorizations);
     }
 
-    public boolean importRdfTriple(
+    private ImportContext importRdfTriple(
+            ImportContext ctx,
             Set<Element> elements,
             RdfTriple rdfTriple,
             String sourceFileName,
@@ -158,10 +161,10 @@ public class RdfTripleImportHelper {
             Authorizations authorizations
     ) {
         if (!(rdfTriple.getFirst() instanceof RdfTriple.UriPart)) {
-            return true;
+            throw new VisalloException("Unhandled combination of RDF triples. First triple expected to be a URI, but was " + rdfTriple.getFirst().getClass().getName());
         }
         if (!(rdfTriple.getSecond() instanceof RdfTriple.UriPart)) {
-            return true;
+            throw new VisalloException("Unhandled combination of RDF triples. Second triple expected to be a URI, but was " + rdfTriple.getFirst().getClass().getName());
         }
 
         VisalloRdfTriple triple = VisalloRdfTriple.parse(
@@ -171,53 +174,41 @@ public class RdfTripleImportHelper {
                 timeZone
         );
         if (triple == null) {
-            return false;
+            throw new VisalloException("Unhandled combination of RDF triples");
+        }
+
+        if (ctx == null || ctx.isNewElement(triple)) {
+            if (ctx != null) {
+                elements.add(ctx.save(authorizations));
+            }
+            ctx = triple.updateImportContext(ctx, this, authorizations);
         }
 
         if (triple instanceof ConceptTypeVisalloRdfTriple) {
-            setConceptType(elements, sourceFileName, (ConceptTypeVisalloRdfTriple) triple, user, authorizations);
-            return true;
+            setConceptType(ctx, sourceFileName, (ConceptTypeVisalloRdfTriple) triple, user);
+            return ctx;
         }
 
         if (triple instanceof PropertyVisalloRdfTriple) {
-            setProperty(
-                    elements,
-                    sourceFileName,
-                    (PropertyVisalloRdfTriple) triple,
-                    user,
-                    authorizations
-            );
-            return true;
+            setProperty(ctx, sourceFileName, (PropertyVisalloRdfTriple) triple, user);
+            return ctx;
         }
 
         if (triple instanceof AddEdgeVisalloRdfTriple) {
-            addEdge(elements, (AddEdgeVisalloRdfTriple) triple, authorizations);
-            return true;
+            // handled by ImportContext
+            return ctx;
         }
 
         throw new VisalloException("Unexpected triple type: " + triple.getClass().getName());
     }
 
-    private void addEdge(Set<Element> elements, AddEdgeVisalloRdfTriple triple, Authorizations authorizations) {
-        Edge edge = graph.addEdge(
-                triple.getEdgeId(),
-                triple.getOutVertexId(),
-                triple.getInVertexId(),
-                triple.getEdgeLabel(),
-                getVisibility(triple.getEdgeVisibilitySource()),
-                authorizations
-        );
-        elements.add(edge);
-    }
-
     private void setProperty(
-            Set<Element> elements,
+            ImportContext ctx,
             String sourceFileName,
             PropertyVisalloRdfTriple triple,
-            User user,
-            Authorizations authorizations
+            User user
     ) {
-        ElementMutation m;
+        ElementMutation m = ctx.getElementMutation();
 
         // metadata
         Date now = new Date();
@@ -237,8 +228,6 @@ public class RdfTripleImportHelper {
         if (triple instanceof SetMetadataVisalloRdfTriple) {
             SetMetadataVisalloRdfTriple setMetadataVisalloRdfTriple = (SetMetadataVisalloRdfTriple) triple;
 
-            Element elem = getExistingElement(triple, authorizations);
-            m = elem.prepareMutation();
             ((ExistingElementMutation) m).setPropertyMetadata(
                     triple.getPropertyKey(),
                     triple.getPropertyName(),
@@ -247,7 +236,6 @@ public class RdfTripleImportHelper {
                     getVisibility(setMetadataVisalloRdfTriple.getMetadataVisibilitySource())
             );
         } else {
-            m = getMutationForUpdate(triple, authorizations);
             m.addPropertyValue(
                     triple.getPropertyKey(),
                     triple.getPropertyName(),
@@ -256,46 +244,19 @@ public class RdfTripleImportHelper {
                     getVisibility(triple.getPropertyVisibilitySource())
             );
         }
-
-        Element element = m.save(authorizations);
-        elements.add(element);
-    }
-
-    private ElementMutation getMutationForUpdate(PropertyVisalloRdfTriple triple, Authorizations authorizations) {
-        if (triple.getElementType() == ElementType.VERTEX) {
-            return graph.prepareVertex(triple.getElementId(), getVisibility(triple.getElementVisibilitySource()));
-        } else {
-            Edge element = (Edge) getExistingElement(triple, authorizations);
-            return element.prepareMutation();
-        }
-    }
-
-    private Element getExistingElement(PropertyVisalloRdfTriple triple, Authorizations authorizations) {
-        Element elem = triple.getElementType() == ElementType.VERTEX
-                ? graph.getVertex(triple.getElementId(), authorizations)
-                : graph.getEdge(triple.getElementId(), authorizations);
-        if (elem == null) {
-            graph.flush();
-            elem = triple.getElementType() == ElementType.VERTEX
-                    ? graph.getVertex(triple.getElementId(), authorizations)
-                    : graph.getEdge(triple.getElementId(), authorizations);
-        }
-        checkNotNull(elem, "Could not find element with id " + triple.getElementId());
-        return elem;
     }
 
     private void setConceptType(
-            Set<Element> elements,
+            ImportContext ctx,
             String sourceFileName,
             ConceptTypeVisalloRdfTriple triple,
-            User user,
-            Authorizations authorizations
+            User user
     ) {
         Date now = new Date();
         Visibility defaultVisibility = visibilityTranslator.getDefaultVisibility();
 
         Visibility elementVisibility = getVisibility(triple.getElementVisibilitySource());
-        VertexBuilder m = graph.prepareVertex(triple.getElementId(), elementVisibility);
+        ElementMutation m = ctx.getElementMutation();
         VisalloProperties.CONCEPT_TYPE.setProperty(m, triple.getConceptType(), defaultVisibility);
         if (!isLiteralVisibilityString(triple.getElementVisibilitySource())) {
             VisibilityJson visibilityJson = new VisibilityJson(triple.getElementVisibilitySource());
@@ -304,11 +265,9 @@ public class RdfTripleImportHelper {
         VisalloProperties.MODIFIED_BY.setProperty(m, user.getUserId(), defaultVisibility);
         VisalloProperties.MODIFIED_DATE.setProperty(m, now, defaultVisibility);
         VisalloProperties.SOURCE.addPropertyValue(m, MULTIVALUE_KEY, sourceFileName, elementVisibility);
-        Vertex vertex = m.save(authorizations);
-        elements.add(vertex);
     }
 
-    private Visibility getVisibility(String visibilityString) {
+    Visibility getVisibility(String visibilityString) {
         Visibility visibility = visibilityCache.get(visibilityString);
         if (visibility != null) {
             return visibility;
@@ -324,5 +283,9 @@ public class RdfTripleImportHelper {
 
     private boolean isLiteralVisibilityString(String visibilitySource) {
         return visibilitySource != null && visibilitySource.startsWith("!");
+    }
+
+    Graph getGraph() {
+        return graph;
     }
 }

--- a/common/rdf/src/main/java/org/visallo/common/rdf/SetMetadataVisalloRdfTriple.java
+++ b/common/rdf/src/main/java/org/visallo/common/rdf/SetMetadataVisalloRdfTriple.java
@@ -1,7 +1,10 @@
 package org.visallo.common.rdf;
 
 import com.google.common.base.Strings;
+import org.vertexium.Authorizations;
+import org.vertexium.Element;
 import org.vertexium.ElementType;
+import org.vertexium.mutation.ExistingElementMutation;
 
 public class SetMetadataVisalloRdfTriple extends PropertyVisalloRdfTriple {
     private final String metadataName;
@@ -77,5 +80,27 @@ public class SetMetadataVisalloRdfTriple extends PropertyVisalloRdfTriple {
         }
 
         return super.equals(o);
+    }
+
+    @Override
+    public ImportContext updateImportContext(
+            ImportContext ctx,
+            RdfTripleImportHelper rdfTripleImportHelper,
+            Authorizations authorizations
+    ) {
+        // Currently Vertexium only supports updating metadata on ExistingElementMutation if that ever
+        //  changes this logic can be removed, updateImportContext can be renamed createImportContext
+        //  and ImportContext can be removed from the parameter list
+        if (!(ctx instanceof ExistingElementMutation)) {
+            if (ctx != null) {
+                ctx.save(authorizations);
+            }
+
+            Element element = getExistingElement(rdfTripleImportHelper.getGraph(), this, authorizations);
+            ExistingElementMutation<Element> m = element.prepareMutation();
+            return new ImportContext(getElementId(), m);
+        }
+
+        return super.updateImportContext(ctx, rdfTripleImportHelper, authorizations);
     }
 }

--- a/common/rdf/src/main/java/org/visallo/common/rdf/VisalloRdfTriple.java
+++ b/common/rdf/src/main/java/org/visallo/common/rdf/VisalloRdfTriple.java
@@ -1,6 +1,7 @@
 package org.visallo.common.rdf;
 
 import org.apache.commons.lang.StringUtils;
+import org.vertexium.Authorizations;
 import org.vertexium.ElementType;
 import org.vertexium.property.StreamingPropertyValue;
 import org.vertexium.type.GeoPoint;
@@ -359,4 +360,12 @@ public abstract class VisalloRdfTriple {
 
         return true;
     }
+
+    public abstract String getElementId();
+
+    public abstract ImportContext updateImportContext(
+            ImportContext ctx,
+            RdfTripleImportHelper rdfTripleImportHelper,
+            Authorizations authorizations
+    );
 }

--- a/common/rdf/src/test/java/org/visallo/common/rdf/RdfTripleImportHelperTest.java
+++ b/common/rdf/src/test/java/org/visallo/common/rdf/RdfTripleImportHelperTest.java
@@ -464,7 +464,8 @@ public class RdfTripleImportHelperTest {
 
     private void importRdfLine(String line) {
         Set<Element> elements = new HashSet<>();
-        rdfTripleImportHelper.importRdfLine(
+        ImportContext ctx = rdfTripleImportHelper.importRdfLine(
+                null,
                 elements,
                 sourceFileName,
                 line,
@@ -474,5 +475,6 @@ public class RdfTripleImportHelperTest {
                 user,
                 authorizations
         );
+        ctx.save(authorizations);
     }
 }


### PR DESCRIPTION
- [x] @srfarley
- [ ] @mwizeman @dsingley @EvanOxfeld 
- [x] @joeybrk372 @sfeng88 @rygim @jharwig 

For my sample RDF:
RDF Import before: 3834ms
RDF Import after:  2772ms
With this I think much of the time was spent in setup, for longer RDFs the savings will be even better