### PR TITLE
Correctly add a vertex to shared workspace when visibility changes

### DIFF
--- a/web/web-base/src/main/java/org/visallo/web/routes/vertex/VertexSetVisibility.java
+++ b/web/web-base/src/main/java/org/visallo/web/routes/vertex/VertexSetVisibility.java
@@ -12,6 +12,7 @@ import org.visallo.core.model.graph.GraphRepository;
 import org.visallo.core.model.properties.VisalloProperties;
 import org.visallo.core.model.workQueue.Priority;
 import org.visallo.core.model.workQueue.WorkQueueRepository;
+import org.visallo.core.model.workspace.Workspace;
 import org.visallo.core.model.workspace.WorkspaceRepository;
 import org.visallo.core.security.VisibilityTranslator;
 import org.visallo.core.user.User;
@@ -21,7 +22,9 @@ import org.visallo.core.util.VisalloLogger;
 import org.visallo.core.util.VisalloLoggerFactory;
 import org.visallo.web.BadRequestException;
 import org.visallo.web.clientapi.model.ClientApiElement;
+import org.visallo.web.clientapi.model.ClientApiWorkspace;
 import org.visallo.web.parameterProviders.ActiveWorkspaceId;
+import org.visallo.web.parameterProviders.SourceGuid;
 
 import java.util.ResourceBundle;
 
@@ -53,6 +56,7 @@ public class VertexSetVisibility implements ParameterizedHandler {
             @Required(name = "graphVertexId") String graphVertexId,
             @Required(name = "visibilitySource") String visibilitySource,
             @ActiveWorkspaceId String workspaceId,
+            @SourceGuid String sourceGuid,
             ResourceBundle resourceBundle,
             User user,
             Authorizations authorizations
@@ -90,6 +94,10 @@ public class VertexSetVisibility implements ParameterizedHandler {
                 visibilitySource,
                 Priority.HIGH
         );
+
+        Workspace workspace = workspaceRepository.findById(workspaceId, user);
+        ClientApiWorkspace clientApiWorkspace = workspaceRepository.toClientApi(workspace, user, true, authorizations);
+        workQueueRepository.pushWorkspaceChange(clientApiWorkspace, clientApiWorkspace.getUsers(), user.getUserId(), sourceGuid);
 
         return ClientApiConverter.toClientApi(graphVertex, workspaceId, authorizations);
     }


### PR DESCRIPTION
- [x] @srfarley @joeferner
- [x] @mwizeman @dsingley @EvanOxfeld 
- [x] @joeybrk372 @sfeng88 @rygim @jharwig 

If visibility is changed and a shared workspace user can now see it (it had a visibility that the user didn't have before), make sure it appears on that users shared workspace without refreshing.

We do this in 2 parts:

1. workspaceChanged web socket message now filters the vertices it sends to all shared users based on their auth.
2. on setVisibility route, we also send workspaceChange events. (They will be ignored on the client if no changes)


