### PR TITLE
Fix dashboard missing extension toolbar items when on shared workspace dashboard

### DIFF
--- a/web/war/src/main/webapp/js/dashboard/dashboard.js
+++ b/web/war/src/main/webapp/js/dashboard/dashboard.js
@@ -742,14 +742,21 @@ define([
                             element: _.isElement(el) ? el : el.get(0)
                         });
                 }),
-                $toolbar = $(el).find('.card-toolbar');
+                $toolbar = $(el).find('.card-toolbar'),
+                $configureLi = $toolbar.find('.configure').closest('li'),
+                $extensionRows = $.map(validExtensions, function(e) {
+                    return $('<li>')
+                        .addClass('card-toolbar-item')
+                        .attr('data-identifier', e.identifier)
+                        .append($('<button>').attr('title', e.tooltip).css('background-image', 'url(' + e.icon + ')'))
+                });
+
             $toolbar.find('.card-toolbar-item').remove();
-            $toolbar.find('.configure').closest('li').before($.map(validExtensions, function(e) {
-                return $('<li>')
-                    .addClass('card-toolbar-item')
-                    .attr('data-identifier', e.identifier)
-                    .append($('<button>').attr('title', e.tooltip).css('background-image', 'url(' + e.icon + ')'))
-            }));
+            if ($configureLi.length) {
+                $configureLi.before($extensionRows);
+            } else {
+                $toolbar.prepend($extensionRows);
+            }
         };
 
         this.loadDashboards = function(workspace) {


### PR DESCRIPTION
- [x] @srfarley @joeferner
- [ ] @mwizeman @dsingley @EvanOxfeld 
- [x] @joeybrk372 @sfeng88 @rygim @jharwig 

Was using the configure toolbar button to add new ones, but that only shows for creator.