### PR TITLE
Fix syntax error in style url background-image

### DIFF
--- a/web/war/src/main/webapp/js/workspaces/diff/DiffPanel.jsx
+++ b/web/war/src/main/webapp/js/workspaces/diff/DiffPanel.jsx
@@ -152,7 +152,7 @@ define([
                 backgroundImage: conceptImage || vertex ? `url(${conceptImage || F.vertex.image(vertex, null, 80)})` : ''
             };
             const selectedConceptImageStyle = {
-                backgroundImage: selectedConceptImage || vertex ? `url${selectedConceptImage || F.vertex.selectedImage(vertex, null, 80)})` : ''
+                backgroundImage: selectedConceptImage || vertex ? `url(${selectedConceptImage || F.vertex.selectedImage(vertex, null, 80)})` : ''
             };
 
             return (


### PR DESCRIPTION
- [x] @srfarley @joeferner
- [ ] @mwizeman @dsingley @EvanOxfeld 
- [x] @joeybrk372 @sfeng88 @rygim @jharwig 

Missing paren in `url()` css style. Was causing the diff panel concept images to disappear on selection.