### PR TITLE
Change exec-maven-plugin group id from org.apache.maven.plugins to org.codehaus.mojo.

### DIFF
--- a/root/pom.xml
+++ b/root/pom.xml
@@ -131,7 +131,7 @@
         <plugin.maven.clean.version>2.5</plugin.maven.clean.version>
         <plugin.maven.compiler.version>3.1</plugin.maven.compiler.version>
         <plugin.maven.dependency.version>2.8</plugin.maven.dependency.version>
-        <plugin.maven.exec.version>1.4.0</plugin.maven.exec.version>
+        <plugin.maven.exec.version>1.5.0</plugin.maven.exec.version>
         <plugin.maven.war.version>2.4</plugin.maven.war.version>
         <plugin.maven.jar.version>2.4</plugin.maven.jar.version>
         <plugin.maven.javadoc.version>2.9.1</plugin.maven.javadoc.version>
@@ -851,7 +851,7 @@
                 </plugin>
 
                 <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
+                    <groupId>org.codehaus.mojo</groupId>
                     <artifactId>exec-maven-plugin</artifactId>
                     <version>${plugin.maven.exec.version}</version>
                 </plugin>


### PR DESCRIPTION
- [x] @srfarley @kunklejr 
- [x] @mwizeman @dsingley @EvanOxfeld 
- [x] @joeybrk372 @sfeng88 @rygim @jharwig 

Maven was showing warning for this plugin because
org.apache.maven.plugins was the old package name and has since been
deprecated.