### PR TITLE
Match visallo dep to poi with tika's dep version. Fixes importing docx

### DIFF
--- a/root/pom.xml
+++ b/root/pom.xml
@@ -110,7 +110,7 @@
         <mysql.version>5.1.38</mysql.version>
         <tika.version>1.13</tika.version>
         <pdfbox.version>2.0.1</pdfbox.version>
-        <apache.poi.version>3.11</apache.poi.version>
+        <apache.poi.version>3.15-beta1</apache.poi.version>
 
         <!-- Test Dependency Versions -->
         <junit.version>4.11</junit.version>


### PR DESCRIPTION
- [x] @srfarley @joeferner
- [ ] @mwizeman @dsingley @EvanOxfeld 
- [x] @joeybrk372 @sfeng88 @rygim @jharwig 

Visallo required `3.11`, but tika required poi version `3.15-beta1`. Was causing several docx parsers to not be found, thus not import correctly.

Change visallo requirement to match tika's