### PR TITLE
Add popover positioning to map component

### DIFF
--- a/web/war/src/main/webapp/js/map/map.js
+++ b/web/war/src/main/webapp/js/map/map.js
@@ -166,6 +166,8 @@ define([
         };
 
         this.onUnregisterForPositionChanges = function(event, data) {
+            var self = this;
+
             if (this.viewportPositionChanges) {
                 var index = _.findIndex(this.viewportPositionChanges, function(vpc) {
                     return vpc.el === event.target;


### PR DESCRIPTION
- [x] @srfarley @joeferner
- [x] @mwizeman @dsingley @EvanOxfeld 
- [x] @joeybrk372 @sfeng88 @rygim @jharwig 

Previously if the map or created a popover, it would just be centered instead of attached to vertex