### PR TITLE
RDF Export: add rdf comment to exported file for unsupported data types

### DIFF
--- a/common/rdf/src/main/java/org/visallo/common/rdf/PropertyVisalloRdfTriple.java
+++ b/common/rdf/src/main/java/org/visallo/common/rdf/PropertyVisalloRdfTriple.java
@@ -5,6 +5,8 @@ import org.vertexium.*;
 import org.vertexium.mutation.ElementMutation;
 import org.vertexium.type.GeoPoint;
 import org.visallo.core.exception.VisalloException;
+import org.visallo.core.util.VisalloLogger;
+import org.visallo.core.util.VisalloLoggerFactory;
 import org.visallo.web.clientapi.model.DirectoryEntity;
 
 import javax.xml.bind.DatatypeConverter;
@@ -17,6 +19,7 @@ import java.util.TimeZone;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public abstract class PropertyVisalloRdfTriple extends ElementVisalloRdfTriple {
+    private final VisalloLogger LOGGER = VisalloLoggerFactory.getLogger(PropertyVisalloRdfTriple.class);
     private final String propertyKey;
     private final String propertyName;
     private final String propertyVisibilitySource;
@@ -101,7 +104,8 @@ public abstract class PropertyVisalloRdfTriple extends ElementVisalloRdfTriple {
         if (getValue() instanceof DateOnly) {
             return getValueRdfStringWithType(getValue(), VisalloRdfTriple.PROPERTY_TYPE_DATE);
         }
-        throw new VisalloException("Unhandled value type \"" + getValue().getClass().getName() + "\" to convert to RDF string");
+        LOGGER.warn ("\"Unhandled value type " + getValue().getClass().getName() + " to convert to RDF string\"");
+        return null;
     }
 
     private static String getValueRdfStringWithType(Object value, String typeUri) {

--- a/common/rdf/src/main/java/org/visallo/common/rdf/RdfExportHelper.java
+++ b/common/rdf/src/main/java/org/visallo/common/rdf/RdfExportHelper.java
@@ -65,18 +65,20 @@ public class RdfExportHelper {
     }
 
     private void writePropertyRdfTriples(Element element, Property property, OutputStream out) throws IOException {
-        write(new SetPropertyVisalloRdfTriple(
+        SetPropertyVisalloRdfTriple setPropertyVisalloRdfTriple = new SetPropertyVisalloRdfTriple(
                 element instanceof Vertex ? ElementType.VERTEX : ElementType.EDGE,
                 element.getId(),
                 getVisibilitySource(element),
                 property.getKey(),
                 property.getName(),
                 getVisibilitySource(property),
-                property.getValue()
-        ), out);
+                property.getValue());
+        write(setPropertyVisalloRdfTriple, out);
 
-        for (Metadata.Entry entry : property.getMetadata().entrySet()) {
-            writeMetadataEntryRdfTriple(element, property, entry, out);
+        if (setPropertyVisalloRdfTriple.getValueRdfString() != null) {
+            for (Metadata.Entry entry : property.getMetadata().entrySet()) {
+                writeMetadataEntryRdfTriple(element, property, entry, out);
+            }
         }
     }
 

--- a/common/rdf/src/main/java/org/visallo/common/rdf/SetMetadataVisalloRdfTriple.java
+++ b/common/rdf/src/main/java/org/visallo/common/rdf/SetMetadataVisalloRdfTriple.java
@@ -44,13 +44,14 @@ public class SetMetadataVisalloRdfTriple extends PropertyVisalloRdfTriple {
 
     @Override
     public String toString() {
-        return String.format(
-                "<%s> <%s%s> %s",
+        String warning = "\"Unhandled value type " + getValue().getClass().getName() + " to convert to RDF string\"";
+        String value = getValueRdfString();
+        return String.format("%s<%s> <%s%s> %s",
+                value == null ? "# " : "",
                 getElementRdfString(),
                 getPropertyRdfString(),
                 getMetadataRdfString(),
-                getValueRdfString()
-        );
+                value == null ? warning : value);
     }
 
     protected String getMetadataRdfString() {

--- a/common/rdf/src/main/java/org/visallo/common/rdf/SetPropertyVisalloRdfTriple.java
+++ b/common/rdf/src/main/java/org/visallo/common/rdf/SetPropertyVisalloRdfTriple.java
@@ -25,6 +25,12 @@ public class SetPropertyVisalloRdfTriple extends PropertyVisalloRdfTriple {
 
     @Override
     public String toString() {
-        return String.format("<%s> <%s> %s", getElementRdfString(), getPropertyRdfString(), getValueRdfString());
+        String warning = "\"Unhandled value type " + getValue().getClass().getName() + " to convert to RDF string\"";
+        String value = getValueRdfString();
+        return String.format("%s<%s> <%s> %s",
+                value == null ? "# " : "",
+                getElementRdfString(),
+                getPropertyRdfString(),
+                value == null ? warning : value);
     }
 }


### PR DESCRIPTION
- [x] @srfarley @joeferner
- [x] @mwizeman @dsingley @EvanOxfeld 
- [ ] @joeybrk372 @rygim @jharwig 

Note: If the data type is not supported, I don't export the metadata of the unsupported property.