### PR TITLE
Fix flashing of right aligned numbers in multiple selection histogram (master)

### DIFF
--- a/web/war/src/main/webapp/less/detail/detail.less
+++ b/web/war/src/main/webapp/less/detail/detail.less
@@ -371,6 +371,13 @@
     }
   }
 
+  @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
+    /* Force scrollbar in IE to stop right aligned values from flashing on resize/scroll */
+    .org-visallo-layout-elements-body {
+      overflow-y: scroll !important;
+    }
+  }
+
   .multiple {
     svg, .svg-container {
 


### PR DESCRIPTION
- [x] @srfarley @joeferner
- [x] @mwizeman @dsingley @EvanOxfeld 
- [x] @joeybrk372 @sfeng88 @rygim @jharwig 

… detail pane.

The svg is set to be 100% of the detail pane width, IE doesn't update those elements sizes until after mouseup. So the numbers were being pushed offscreen for a little.

Use a media query to target ie 10+ to fix IE11, and force the scrollbar to stick around so the width isn't changing based on scrollbar visibility.