### PR TITLE
Fix saved search issues (release-2.1)

### DIFF
--- a/config/visallo.properties
+++ b/config/visallo.properties
@@ -1,6 +1,6 @@
 
 # application privileges granted to new users by default
-org.visallo.core.model.user.UserPropertyPrivilegeRepository.defaultPrivileges=READ,COMMENT,EDIT,PUBLISH,ADMIN
+org.visallo.core.model.user.UserPropertyPrivilegeRepository.defaultPrivileges=READ,COMMENT,EDIT,PUBLISH,SEARCH_SAVE_GLOBAL,ADMIN
 org.visallo.core.model.user.UserPropertyAuthorizationRepository.defaultAuthorizations=
 
 #

--- a/core/core/src/main/java/org/visallo/core/model/user/VisalloPrivilegeProvider.java
+++ b/core/core/src/main/java/org/visallo/core/model/user/VisalloPrivilegeProvider.java
@@ -1,28 +1,10 @@
 package org.visallo.core.model.user;
 
-import com.google.common.collect.ImmutableList;
 import org.visallo.web.clientapi.model.Privilege;
 
-import java.util.ArrayList;
-import java.util.List;
-
 public class VisalloPrivilegeProvider implements PrivilegesProvider {
-    private static final ImmutableList<Privilege> ALL_BUILT_IN;
-
-    static {
-        List<Privilege> allBuiltIn = new ArrayList<>();
-        allBuiltIn.add(new Privilege(Privilege.READ));
-        allBuiltIn.add(new Privilege(Privilege.COMMENT));
-        allBuiltIn.add(new Privilege(Privilege.COMMENT_EDIT_ANY));
-        allBuiltIn.add(new Privilege(Privilege.COMMENT_DELETE_ANY));
-        allBuiltIn.add(new Privilege(Privilege.EDIT));
-        allBuiltIn.add(new Privilege(Privilege.PUBLISH));
-        allBuiltIn.add(new Privilege(Privilege.ADMIN));
-        ALL_BUILT_IN = ImmutableList.copyOf(allBuiltIn);
-    }
-
     @Override
     public Iterable<Privilege> getPrivileges() {
-        return ALL_BUILT_IN;
+        return Privilege.ALL_BUILT_IN;
     }
 }

--- a/core/plugins/model-vertexium/src/test/java/org/visallo/vertexium/model/search/VertexiumSearchRepositoryTest.java
+++ b/core/plugins/model-vertexium/src/test/java/org/visallo/vertexium/model/search/VertexiumSearchRepositoryTest.java
@@ -1,5 +1,6 @@
 package org.visallo.vertexium.model.search;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.inject.Injector;
 import org.json.JSONObject;
 import org.junit.Before;
@@ -11,6 +12,7 @@ import org.vertexium.*;
 import org.vertexium.inmemory.InMemoryGraph;
 import org.visallo.core.bootstrap.InjectHelper;
 import org.visallo.core.config.Configuration;
+import org.visallo.core.exception.VisalloAccessDeniedException;
 import org.visallo.core.exception.VisalloException;
 import org.visallo.core.model.properties.VisalloProperties;
 import org.visallo.core.model.search.SearchProperties;
@@ -21,21 +23,29 @@ import org.visallo.core.model.user.UserRepository;
 import org.visallo.core.user.User;
 import org.visallo.web.clientapi.model.ClientApiSearch;
 import org.visallo.web.clientapi.model.ClientApiSearchListResponse;
+import org.visallo.web.clientapi.model.Privilege;
 
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.when;
 import static org.vertexium.util.IterableUtils.toList;
 
 @RunWith(MockitoJUnitRunner.class)
 public class VertexiumSearchRepositoryTest {
+    private static final Visibility VISIBILITY = Visibility.EMPTY;
+    private static final String USER_ID = "USER123";
+    private static final String ID = "123";
+    private static final String NAME = "search1";
+    private static final String URL = "/vertex/search";
+    private static final JSONObject PARAMETERS = new JSONObject(ImmutableMap.of("key1", "value1"));
+
     private VertexiumSearchRepository searchRepository;
     private InMemoryGraph graph;
     private Authorizations authorizations;
-    private String userId;
 
     @Mock
     private UserRepository userRepository;
@@ -79,9 +89,8 @@ public class VertexiumSearchRepositoryTest {
                 privilegeRepository
         );
 
-        userId = "USER123";
-        when(user.getUserId()).thenReturn(userId);
-        graph.addVertex(userId, new Visibility(""), authorizations);
+        when(user.getUserId()).thenReturn(USER_ID);
+        graph.addVertex(USER_ID, VISIBILITY, authorizations);
         graph.flush();
 
         when(userRepository.getSystemUser()).thenReturn(systemUser);
@@ -91,7 +100,7 @@ public class VertexiumSearchRepositoryTest {
         )).thenReturn(authorizations);
 
         when(authorizationRepository.getGraphAuthorizations(
-                eq(user),
+                any(User.class),
                 eq(VertexiumSearchRepository.VISIBILITY_STRING),
                 eq(UserRepository.VISIBILITY_STRING)
         )).thenReturn(authorizations);
@@ -99,62 +108,133 @@ public class VertexiumSearchRepositoryTest {
 
     @Test
     public void testSaveSearch() {
-        String id = "123";
-        String name = "search1";
-        String url = "/vertex/search";
-        JSONObject searchParameters = new JSONObject();
-        searchParameters.put("key1", "value1");
+        String foundId = searchRepository.saveSearch(ID, NAME, URL, PARAMETERS, user);
+        assertEquals(ID, foundId);
 
-        String foundId = searchRepository.saveSearch(id, name, url, searchParameters, user);
-        assertEquals(id, foundId);
-
-        Vertex userVertex = graph.getVertex(userId, authorizations);
+        Vertex userVertex = graph.getVertex(USER_ID, authorizations);
         List<Edge> hasSavedSearchEdges = toList(userVertex.getEdges(
                 Direction.OUT,
                 SearchProperties.HAS_SAVED_SEARCH,
                 authorizations
         ));
         assertEquals(1, hasSavedSearchEdges.size());
-        Vertex savedSearchVertex = hasSavedSearchEdges.get(0).getOtherVertex(userId, authorizations);
+        Vertex savedSearchVertex = hasSavedSearchEdges.get(0).getOtherVertex(USER_ID, authorizations);
         assertEquals(
                 SearchProperties.CONCEPT_TYPE_SAVED_SEARCH,
                 VisalloProperties.CONCEPT_TYPE.getPropertyValue(savedSearchVertex, null)
         );
-        assertEquals(name, SearchProperties.NAME.getPropertyValue(savedSearchVertex, null));
-        assertEquals(url, SearchProperties.URL.getPropertyValue(savedSearchVertex, null));
+        assertEquals(NAME, SearchProperties.NAME.getPropertyValue(savedSearchVertex, null));
+        assertEquals(URL, SearchProperties.URL.getPropertyValue(savedSearchVertex, null));
         assertEquals(
-                searchParameters.toString(),
+                PARAMETERS.toString(),
                 SearchProperties.PARAMETERS.getPropertyValueRequired(savedSearchVertex).toString()
         );
     }
 
     @Test
-    public void testGetSavedSearched() {
-        String id = "SS123";
-        String name = "saved search 123";
-        String url = "/vertex/search";
-        JSONObject parameters = new JSONObject();
-        parameters.put("key1", "value1");
-        VertexBuilder vb = graph.prepareVertex(id, new Visibility(""));
-        VisalloProperties.CONCEPT_TYPE.setProperty(vb, SearchProperties.CONCEPT_TYPE_SAVED_SEARCH, new Visibility(""));
-        SearchProperties.NAME.setProperty(vb, name, new Visibility(""));
-        SearchProperties.URL.setProperty(vb, url, new Visibility(""));
-        SearchProperties.PARAMETERS.setProperty(vb, parameters, new Visibility(""));
+    public void testSaveGlobalSearch() {
+        // User without the SEARCH_SAVE_GLOBAL privilege can't save as global.
+
+        try {
+            searchRepository.saveGlobalSearch(ID, NAME, URL, PARAMETERS, user);
+            fail("Expected VisalloAccessDeniedException");
+        } catch (VisalloAccessDeniedException ex) {
+            // expected
+        }
+
+        // User with the SEARCH_SAVE_GLOBAL privilege can save as global.
+
+        when(privilegeRepository.hasPrivilege(user, Privilege.SEARCH_SAVE_GLOBAL)).thenReturn(true);
+
+        String foundId = searchRepository.saveGlobalSearch(ID, NAME, URL, PARAMETERS, user);
+        assertEquals(ID, foundId);
+
+        Vertex savedSearchVertex = graph.getVertex(ID, authorizations);
+        List<Edge> hasSavedSearchEdges = toList(savedSearchVertex.getEdges(
+                Direction.IN,
+                SearchProperties.HAS_SAVED_SEARCH,
+                authorizations
+        ));
+        assertEquals(1, hasSavedSearchEdges.size());
+        assertEquals(
+                SearchProperties.CONCEPT_TYPE_SAVED_SEARCH,
+                VisalloProperties.CONCEPT_TYPE.getPropertyValue(savedSearchVertex, null)
+        );
+        assertEquals(NAME, SearchProperties.NAME.getPropertyValue(savedSearchVertex, null));
+        assertEquals(URL, SearchProperties.URL.getPropertyValue(savedSearchVertex, null));
+        assertEquals(
+                PARAMETERS.toString(),
+                SearchProperties.PARAMETERS.getPropertyValueRequired(savedSearchVertex).toString()
+        );
+
+        // User without the privilege can't re-save as a non-global, private saved search.
+
+        when(privilegeRepository.hasPrivilege(user, Privilege.SEARCH_SAVE_GLOBAL)).thenReturn(false);
+
+        try {
+            searchRepository.saveSearch(ID, NAME, URL, PARAMETERS, user);
+            fail("Expected VisalloAccessDeniedException");
+        } catch (VisalloAccessDeniedException ex) {
+            // expected
+        }
+
+        // User with the privilege can re-save as a non-global, private saved search.
+
+        when(privilegeRepository.hasPrivilege(user, Privilege.SEARCH_SAVE_GLOBAL)).thenReturn(true);
+
+        foundId = searchRepository.saveSearch(ID, NAME, URL, PARAMETERS, user);
+        assertEquals(ID, foundId);
+    }
+
+    @Test
+    public void testSaveSearchAlternatingPrivateGlobalPrivate() {
+        when(privilegeRepository.hasPrivilege(user, Privilege.SEARCH_SAVE_GLOBAL)).thenReturn(true);
+
+        searchRepository.saveSearch(ID, NAME, URL, PARAMETERS, user);
+        assertSavedSearchState(false);
+
+        searchRepository.saveGlobalSearch(ID, NAME, URL, PARAMETERS, user);
+        assertSavedSearchState(true);
+
+        searchRepository.saveSearch(ID, NAME, URL, PARAMETERS, user);
+        assertSavedSearchState(false);
+    }
+
+    @Test
+    public void testSaveSearchAlternatingGlobalPrivateGlobal() {
+        when(privilegeRepository.hasPrivilege(user, Privilege.SEARCH_SAVE_GLOBAL)).thenReturn(true);
+
+        searchRepository.saveGlobalSearch(ID, NAME, URL, PARAMETERS, user);
+        assertSavedSearchState(true);
+
+        searchRepository.saveSearch(ID, NAME, URL, PARAMETERS, user);
+        assertSavedSearchState(false);
+
+        searchRepository.saveGlobalSearch(ID, NAME, URL, PARAMETERS, user);
+        assertSavedSearchState(true);
+    }
+
+    @Test
+    public void testGetSavedSearches() {
+        VertexBuilder vb = graph.prepareVertex(ID, VISIBILITY);
+        VisalloProperties.CONCEPT_TYPE.setProperty(vb, SearchProperties.CONCEPT_TYPE_SAVED_SEARCH, VISIBILITY);
+        SearchProperties.NAME.setProperty(vb, NAME, VISIBILITY);
+        SearchProperties.URL.setProperty(vb, URL, VISIBILITY);
+        SearchProperties.PARAMETERS.setProperty(vb, PARAMETERS, VISIBILITY);
         vb.save(authorizations);
-
-        graph.addEdge(userId, id, SearchProperties.HAS_SAVED_SEARCH, new Visibility(""), authorizations);
-
+        graph.addEdge(USER_ID, ID, SearchProperties.HAS_SAVED_SEARCH, VISIBILITY, authorizations);
         graph.flush();
 
         ClientApiSearchListResponse response = searchRepository.getSavedSearches(user);
+
         assertEquals(1, response.searches.size());
         for (ClientApiSearch search : response.searches) {
-            if (search.id.equals(id)) {
-                assertEquals(id, search.id);
-                assertEquals(name, search.name);
-                assertEquals(url, search.url);
-                assertEquals(parameters.keySet().size(), search.parameters.size());
-                assertEquals(parameters.getString("key1"), search.parameters.get("key1"));
+            if (search.id.equals(ID)) {
+                assertEquals(ID, search.id);
+                assertEquals(NAME, search.name);
+                assertEquals(URL, search.url);
+                assertEquals(PARAMETERS.keySet().size(), search.parameters.size());
+                assertEquals(PARAMETERS.getString("key1"), search.parameters.get("key1"));
             } else {
                 throw new VisalloException("Invalid search item");
             }
@@ -163,50 +243,59 @@ public class VertexiumSearchRepositoryTest {
 
     @Test
     public void testGetSavedSearch() {
-        String id = "SS123";
-        String name = "saved search 123";
-        String url = "/vertex/search";
-        JSONObject parameters = new JSONObject();
-        parameters.put("key1", "value1");
-        VertexBuilder vb = graph.prepareVertex(id, new Visibility(""));
-        VisalloProperties.CONCEPT_TYPE.setProperty(vb, SearchProperties.CONCEPT_TYPE_SAVED_SEARCH, new Visibility(""));
-        SearchProperties.NAME.setProperty(vb, name, new Visibility(""));
-        SearchProperties.URL.setProperty(vb, url, new Visibility(""));
-        SearchProperties.PARAMETERS.setProperty(vb, parameters, new Visibility(""));
+        VertexBuilder vb = graph.prepareVertex(ID, VISIBILITY);
+        VisalloProperties.CONCEPT_TYPE.setProperty(vb, SearchProperties.CONCEPT_TYPE_SAVED_SEARCH, VISIBILITY);
+        SearchProperties.NAME.setProperty(vb, NAME, VISIBILITY);
+        SearchProperties.URL.setProperty(vb, URL, VISIBILITY);
+        SearchProperties.PARAMETERS.setProperty(vb, PARAMETERS, VISIBILITY);
         vb.save(authorizations);
-
-        graph.addEdge(userId, id, SearchProperties.HAS_SAVED_SEARCH, new Visibility(""), authorizations);
-
+        graph.addEdge(USER_ID, ID, SearchProperties.HAS_SAVED_SEARCH, VISIBILITY, authorizations);
         graph.flush();
 
-        ClientApiSearch search = searchRepository.getSavedSearch(id, user);
-        assertEquals(id, search.id);
-        assertEquals(name, search.name);
-        assertEquals(url, search.url);
-        assertEquals(parameters.keySet().size(), search.parameters.size());
-        assertEquals(parameters.getString("key1"), search.parameters.get("key1"));
+        ClientApiSearch search = searchRepository.getSavedSearch(ID, user);
+
+        assertEquals(ID, search.id);
+        assertEquals(NAME, search.name);
+        assertEquals(URL, search.url);
+        assertEquals(PARAMETERS.keySet().size(), search.parameters.size());
+        assertEquals(PARAMETERS.getString("key1"), search.parameters.get("key1"));
     }
 
     @Test
     public void testDeleteSearch() {
-        String id = "SS123";
-        String name = "saved search 123";
-        String url = "/vertex/search";
-        JSONObject parameters = new JSONObject();
-        parameters.put("key1", "value1");
-        VertexBuilder vb = graph.prepareVertex(id, new Visibility(""));
-        VisalloProperties.CONCEPT_TYPE.setProperty(vb, SearchProperties.CONCEPT_TYPE_SAVED_SEARCH, new Visibility(""));
-        SearchProperties.NAME.setProperty(vb, name, new Visibility(""));
-        SearchProperties.URL.setProperty(vb, url, new Visibility(""));
-        SearchProperties.PARAMETERS.setProperty(vb, parameters, new Visibility(""));
-        vb.save(authorizations);
+        String foundId = searchRepository.saveSearch(ID, NAME, URL, PARAMETERS, user);
+        assertEquals(ID, foundId);
 
-        graph.addEdge(userId, id, SearchProperties.HAS_SAVED_SEARCH, new Visibility(""), authorizations);
+        searchRepository.deleteSearch(ID, user);
 
-        graph.flush();
+        assertEquals(null, graph.getVertex(ID, authorizations));
+    }
 
-        assertNotEquals(null, graph.getVertex(id, authorizations));
-        searchRepository.deleteSearch(id, user);
-        assertEquals(null, graph.getVertex(id, authorizations));
+    @Test
+    public void testDeleteGlobalSearch() {
+        when(privilegeRepository.hasPrivilege(user, Privilege.SEARCH_SAVE_GLOBAL)).thenReturn(true);
+        String foundId = searchRepository.saveGlobalSearch(ID, NAME, URL, PARAMETERS, user);
+        assertEquals(ID, foundId);
+        when(privilegeRepository.hasPrivilege(user, Privilege.SEARCH_SAVE_GLOBAL)).thenReturn(false);
+
+        try {
+            searchRepository.deleteSearch(ID, user);
+            fail("Expected VisalloAccessDeniedException");
+        } catch (VisalloAccessDeniedException ex) {
+            // expected
+        }
+
+        when(privilegeRepository.hasPrivilege(user, Privilege.SEARCH_SAVE_GLOBAL)).thenReturn(true);
+
+        searchRepository.deleteSearch(ID, user);
+
+        assertEquals(null, graph.getVertex(ID, authorizations));
+    }
+
+    private void assertSavedSearchState(boolean expectGlobal) {
+        ClientApiSearchListResponse response = searchRepository.getSavedSearches(user);
+        assertEquals(1, response.searches.size());
+        assertEquals(searchRepository.isSearchGlobal(ID, authorizations), expectGlobal);
+        assertEquals(searchRepository.isSearchPrivateToUser(ID, user, authorizations), !expectGlobal);
     }
 }

--- a/graph-property-worker/graph-property-worker-plugin-test/src/main/resources/org/visallo/test/visallo.properties
+++ b/graph-property-worker/graph-property-worker-plugin-test/src/main/resources/org/visallo/test/visallo.properties
@@ -16,7 +16,7 @@ org.visallo.geoip.GeoIpGraphPropertyWorker.pathPrefix=file:///tmp/visallo-integr
 #hdfsLib.sourceDirectory=hdfs://visallo-dev/visallo/lib
 #hdfsLib.tempDirectory=/tmp/hdfslib
 
-org.visallo.core.model.user.UserPropertyPrivilegeRepository.defaultPrivileges=READ,COMMENT,EDIT,PUBLISH,ADMIN
+org.visallo.core.model.user.UserPropertyPrivilegeRepository.defaultPrivileges=READ,COMMENT,EDIT,PUBLISH,SEARCH_SAVE_GLOBAL,ADMIN
 org.visallo.core.model.user.UserPropertyAuthorizationRepository.defaultAuthorizations=
 
 web.cacheServletFilter.maxAge=3600

--- a/web/client-api/src/main/java/org/visallo/web/clientapi/model/Privilege.java
+++ b/web/client-api/src/main/java/org/visallo/web/clientapi/model/Privilege.java
@@ -15,7 +15,19 @@ public final class Privilege {
     public static final String PUBLISH = "PUBLISH";
     public static final String ADMIN = "ADMIN";
 
-    public static final Set<String> NONE = Collections.emptySet();
+    static {
+        // NOTE: Keep allNames in sync with the above public static strings.
+        final String[] allNames = new String[] {
+                READ, COMMENT, COMMENT_EDIT_ANY, COMMENT_DELETE_ANY, SEARCH_SAVE_GLOBAL, EDIT, PUBLISH, ADMIN
+        };
+        Set<Privilege> allPrivileges = new HashSet<Privilege>(allNames.length);
+        for (String name : allNames) {
+            allPrivileges.add(new Privilege(name));
+        }
+        ALL_BUILT_IN = Collections.unmodifiableSet(allPrivileges);
+    }
+
+    public static final Set<Privilege> ALL_BUILT_IN;
 
     private final String name;
 
@@ -48,7 +60,7 @@ public final class Privilege {
 
     public static Set<String> stringToPrivileges(String privilegesString) {
         if (privilegesString == null || privilegesString.equalsIgnoreCase("NONE")) {
-            return NONE;
+            return Collections.emptySet();
         }
 
         String[] privilegesStringParts = privilegesString.split(",");

--- a/web/war/src/main/webapp/js/search/save/popover.js
+++ b/web/war/src/main/webapp/js/search/save/popover.js
@@ -2,13 +2,11 @@
 define([
     'flight/lib/component',
     'util/popovers/withPopover',
-    'util/withDataRequest',
-    'util/privileges'
+    'util/withDataRequest'
 ], function(
     defineComponent,
     withPopover,
-    withDataRequest,
-    Privileges) {
+    withDataRequest) {
     'use strict';
 
     var SCOPES = {
@@ -48,19 +46,20 @@ define([
         });
 
         this.before('initialize', function(node, config) {
-            var hasSearchSaveGlobalPrivilege = visalloData.currentUser.privileges.indexOf('SEARCH_SAVE_GLOBAL') > -1;
             config.template = '/search/save/template';
-            config.canSaveGlobal = hasSearchSaveGlobalPrivilege;
+            config.canSaveGlobal = visalloData.currentUser.privileges.indexOf('SEARCH_SAVE_GLOBAL') > -1;
             config.maxHeight = $(window).height() / 2;
             config.name = config.update && config.update.name || '';
             config.updatingGlobal = config.update && config.update.scope === SCOPES.GLOBAL;
             config.text = i18n('search.savedsearches.button.' + (config.update ? 'update' : 'create'));
             config.teardownOnTap = true;
+            config.canAddOrUpdate = _.isUndefined(config.update) || !config.updatingGlobal ||
+                (config.updatingGlobal && config.canSaveGlobal);
             config.list = config.list.map(function(item) {
                 var isGlobal = item.scope === SCOPES.GLOBAL,
                     canDelete = true;
                 if (isGlobal) {
-                    canDelete = hasSearchSaveGlobalPrivilege;
+                    canDelete = config.canSaveGlobal;
                 }
                 return _.extend({}, item, {
                     isGlobal: isGlobal,

--- a/web/war/src/main/webapp/js/search/save/template.hbs
+++ b/web/war/src/main/webapp/js/search/save/template.hbs
@@ -2,11 +2,16 @@
   <div class="arrow"></div>
   <div class="popover-content" style="max-height:{{maxHeight}}px">
     <div class="form">
-      <div class="form-item">
-        <input placeholder="Name" class="name" value="{{ name }}" type="text"><button class="btn btn-mini" type="button">{{ text }}</button>
-      </div>
-      {{#if canSaveGlobal }}
-        <label style="display: none" class="global-search" title="{{ i18n 'search.savedsearches.global.tooltip' }}"><input type="checkbox" {{#if updatingGlobal}}checked{{/if}} />{{ i18n 'search.savedsearches.global' }}</label>
+      {{#if canAddOrUpdate}}
+        <div class="form-item">
+          <input placeholder="Name" class="name" value="{{name}}" type="text">
+          <button class="btn btn-mini" type="button">{{text}}</button>
+        </div>
+      {{/if}}
+      {{#if canSaveGlobal}}
+        <label style="display: none" class="global-search" title="{{i18n 'search.savedsearches.global.tooltip'}}">
+          <input type="checkbox" {{#if updatingGlobal}}checked{{/if}} />{{i18n 'search.savedsearches.global'}}
+        </label>
       {{/if}}
     </div>
     <ul class="nav nav-list">
@@ -14,11 +19,11 @@
         <li><a><h1>{{name}}</h1></a>
             <span class="badge">{{scope}}</span>
             {{#if canDelete}}
-              <button class="btn btn-mini btn-danger">{{ i18n 'search.savedsearches.button.delete' }}</button>
+              <button class="btn btn-mini btn-danger">{{i18n 'search.savedsearches.button.delete'}}</button>
             {{/if}}
         </li>
       {{else}}
-      <li class="empty">{{ i18n 'search.savedsearches.none' }}</li>
+      <li class="empty">{{i18n 'search.savedsearches.none'}}</li>
       {{/each}}
     </ul>
   </div>


### PR DESCRIPTION
- [ ] @joeferner
- [ ] @mwizeman @dsingley @EvanOxfeld 
- [x] @joeybrk372 @sfeng88 @rygim @jharwig 

===
* Fix issues so saved searches can switch between global and private with the appropriate user privilege
* Add more tests for global saved searches
* Return all privileges using Privilege.ALL
* Add SEARCH_SAVE_GLOBAL to UserPropertyPrivilegeRepository.defaultPrivileges config property
