### PR TITLE
Fix double import when using enter to import file (release-2.1)

### DIFF
--- a/web/war/src/main/webapp/js/util/popovers/fileImport/fileImport.js
+++ b/web/war/src/main/webapp/js/util/popovers/fileImport/fileImport.js
@@ -91,15 +91,6 @@ define([
                     importFileSelector: this.onFileChange
                 })
 
-                this.on(this.popover, 'keyup', {
-                    visibilityInputSelector: function(e) {
-                        if ($(e.target).closest('.single').length &&
-                            e.which === $.ui.keyCode.ENTER) {
-                            this.onImport();
-                        }
-                    }
-                })
-
                 this.setFiles(this.attr.files);
                 this.checkValid();
             })


### PR DESCRIPTION
- [x] @srfarley @joeferner
- [x] @mwizeman @dsingley @EvanOxfeld 
- [x] @joeybrk372 @sfeng88 @rygim @jharwig 

The popover mixin already handles enter->submit. So delete the special visibility on enter check and submit.