### PR TITLE
Allow ACLProvider to continue even if a concept or relationship cannot be found.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ==================
 
   * Add methods which take timestamps to SingleValueVisalloProperty and VisalloProperty
+  * Allow ACLProvider to continue even if a concept or relationship cannot be found
 
 #v2.1.1
 ==================


### PR DESCRIPTION
- [x] @srfarley @kunklejr 
- [x] @mwizeman @dsingley @EvanOxfeld 
- [x] @joeybrk372 @sfeng88 @rygim @jharwig 

Currently if a vertex or edge is create with a given concept or relationship and
that concept or relationship ontology item is later removed ACLProvider throws
an exception causing the UI to become unusable.