### PR TITLE
throw visallo access denied exception when there a security exception(master)

### DIFF
--- a/core/plugins/model-vertexium/src/main/java/org/visallo/vertexium/model/workspace/VertexiumWorkspaceRepository.java
+++ b/core/plugins/model-vertexium/src/main/java/org/visallo/vertexium/model/workspace/VertexiumWorkspaceRepository.java
@@ -192,14 +192,26 @@ public class VertexiumWorkspaceRepository extends WorkspaceRepository {
                 VISIBILITY_STRING,
                 workspaceId
         );
-        Vertex workspaceVertex = getGraph().getVertex(
-                workspaceId,
-                includeHidden ? FetchHint.ALL_INCLUDING_HIDDEN : FetchHint.ALL,
-                authorizations
-        );
+
+        Vertex workspaceVertex;
+        try {
+            workspaceVertex = getGraph().getVertex(
+                    workspaceId,
+                    includeHidden ? FetchHint.ALL_INCLUDING_HIDDEN : FetchHint.ALL,
+                    authorizations
+            );
+        } catch (SecurityVertexiumException e) {
+            throw new VisalloAccessDeniedException(
+                    "user " + user.getUserId() + " does not have read access to workspace " + workspaceId,
+                    user,
+                    workspaceId
+            );
+        }
+
         if (workspaceVertex == null) {
             return null;
         }
+
         if (!hasReadPermissions(workspaceId, user)) {
             throw new VisalloAccessDeniedException(
                     "user " + user.getUserId() + " does not have read access to workspace " + workspaceId,


### PR DESCRIPTION
- [ ] @joeferner
- [ ] @srfarley @kunklejr
- [ ] @mwizeman @dsingley @EvanOxfeld 
- [ ] @joeybrk372 @sfeng88 @rygim @jharwig 

Fixes another variant of the bad authorizations error when the diff panel tries to diff a workspace the user no longer has access for.