### PR TITLE
Refactor web visibility validation to VisibilityValidator class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 #v2.2.0
 ==================
 
+  * Refactor web visibility validation to VisibilityValidator class
+
 #v2.1
 ==================
 

--- a/web/web-base/src/main/java/org/visallo/web/routes/SetPropertyBase.java
+++ b/web/web-base/src/main/java/org/visallo/web/routes/SetPropertyBase.java
@@ -1,19 +1,15 @@
 package org.visallo.web.routes;
 
-import org.vertexium.Authorizations;
 import org.vertexium.Graph;
 import org.visallo.core.exception.VisalloException;
 import org.visallo.core.model.properties.VisalloProperties;
 import org.visallo.core.security.VisibilityTranslator;
-import org.visallo.core.user.User;
 import org.visallo.core.util.VisalloLogger;
 import org.visallo.core.util.VisalloLoggerFactory;
-import org.visallo.web.BadRequestException;
 
 import javax.servlet.http.HttpServletRequest;
 import java.text.SimpleDateFormat;
 import java.util.Date;
-import java.util.ResourceBundle;
 import java.util.TimeZone;
 
 public abstract class SetPropertyBase {
@@ -33,14 +29,6 @@ public abstract class SetPropertyBase {
 
     protected String createPropertyKey(String propertyName, Graph graph) {
         return isCommentProperty(propertyName) ? createCommentPropertyKey() : graph.getIdGenerator().nextId();
-    }
-
-    protected void checkVisibilityParameter(
-            String visibilitySource, Authorizations authorizations, User user, ResourceBundle resourceBundle) {
-        if (!graph.isVisibilityValid(visibilityTranslator.toVisibility(visibilitySource).getVisibility(), authorizations)) {
-            LOGGER.warn("%s is not a valid visibility for %s user", visibilitySource, user.getDisplayName());
-            throw new BadRequestException("visibilitySource", resourceBundle.getString("visibility.invalid"));
-        }
     }
 
     protected void checkRoutePath(String entityType, String propertyName, HttpServletRequest request) {

--- a/web/web-base/src/main/java/org/visallo/web/routes/edge/EdgeCreate.java
+++ b/web/web-base/src/main/java/org/visallo/web/routes/edge/EdgeCreate.java
@@ -5,7 +5,10 @@ import com.v5analytics.webster.ParameterizedHandler;
 import com.v5analytics.webster.annotations.Handle;
 import com.v5analytics.webster.annotations.Optional;
 import com.v5analytics.webster.annotations.Required;
-import org.vertexium.*;
+import org.vertexium.Authorizations;
+import org.vertexium.Edge;
+import org.vertexium.Graph;
+import org.vertexium.Vertex;
 import org.visallo.core.model.graph.GraphRepository;
 import org.visallo.core.model.workQueue.Priority;
 import org.visallo.core.model.workQueue.WorkQueueRepository;
@@ -15,11 +18,11 @@ import org.visallo.core.util.ClientApiConverter;
 import org.visallo.core.util.JsonSerializer;
 import org.visallo.core.util.VisalloLogger;
 import org.visallo.core.util.VisalloLoggerFactory;
-import org.visallo.web.BadRequestException;
 import org.visallo.web.clientapi.model.ClientApiElement;
 import org.visallo.web.clientapi.model.ClientApiSourceInfo;
 import org.visallo.web.parameterProviders.ActiveWorkspaceId;
 import org.visallo.web.parameterProviders.JustificationText;
+import org.visallo.web.util.VisibilityValidator;
 
 import java.util.ResourceBundle;
 
@@ -61,10 +64,7 @@ public class EdgeCreate implements ParameterizedHandler {
         Vertex inVertex = graph.getVertex(inVertexId, authorizations);
         Vertex outVertex = graph.getVertex(outVertexId, authorizations);
 
-        if (!graph.isVisibilityValid(visibilityTranslator.toVisibility(visibilitySource).getVisibility(), authorizations)) {
-            LOGGER.warn("%s is not a valid visibility for %s user", visibilitySource, user.getDisplayName());
-            throw new BadRequestException("visibilitySource", resourceBundle.getString("visibility.invalid"));
-        }
+        VisibilityValidator.validate(graph, visibilityTranslator, resourceBundle, visibilitySource, user, authorizations);
 
         Edge edge = graphRepository.addEdge(
                 edgeId,

--- a/web/web-base/src/main/java/org/visallo/web/routes/edge/EdgePropertyDetails.java
+++ b/web/web-base/src/main/java/org/visallo/web/routes/edge/EdgePropertyDetails.java
@@ -15,9 +15,9 @@ import org.visallo.core.security.VisibilityTranslator;
 import org.visallo.core.user.User;
 import org.visallo.core.util.VisalloLogger;
 import org.visallo.core.util.VisalloLoggerFactory;
-import org.visallo.web.BadRequestException;
 import org.visallo.web.clientapi.model.ClientApiEdgePropertyDetails;
 import org.visallo.web.clientapi.model.ClientApiSourceInfo;
+import org.visallo.web.util.VisibilityValidator;
 
 import java.util.ResourceBundle;
 
@@ -48,11 +48,14 @@ public class EdgePropertyDetails implements ParameterizedHandler {
             User user,
             Authorizations authorizations
     ) throws Exception {
-        Visibility visibility = visibilityTranslator.toVisibility(visibilitySource).getVisibility();
-        if (!graph.isVisibilityValid(visibility, authorizations)) {
-            LOGGER.warn("%s is not a valid visibility for %s user", visibilitySource, user.getDisplayName());
-            throw new BadRequestException("visibilitySource", resourceBundle.getString("visibility.invalid"));
-        }
+        Visibility visibility = VisibilityValidator.validate(
+                graph,
+                visibilityTranslator,
+                resourceBundle,
+                visibilitySource,
+                user,
+                authorizations
+        );
 
         Edge edge = this.graph.getEdge(edgeId, authorizations);
         if (edge == null) {

--- a/web/web-base/src/main/java/org/visallo/web/routes/edge/EdgeSetProperty.java
+++ b/web/web-base/src/main/java/org/visallo/web/routes/edge/EdgeSetProperty.java
@@ -27,6 +27,7 @@ import org.visallo.web.clientapi.model.ClientApiSourceInfo;
 import org.visallo.web.clientapi.model.ClientApiSuccess;
 import org.visallo.web.parameterProviders.ActiveWorkspaceId;
 import org.visallo.web.parameterProviders.JustificationText;
+import org.visallo.web.util.VisibilityValidator;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.ResourceBundle;
@@ -78,7 +79,7 @@ public class EdgeSetProperty extends SetPropertyBase implements ParameterizedHan
             User user,
             Authorizations authorizations
     ) throws Exception {
-        checkVisibilityParameter(visibilitySource, authorizations, user, resourceBundle);
+        VisibilityValidator.validate(graph, visibilityTranslator, resourceBundle, visibilitySource, user, authorizations);
         checkRoutePath("edge", propertyName, request);
 
         boolean isComment = isCommentProperty(propertyName);

--- a/web/web-base/src/main/java/org/visallo/web/routes/edge/EdgeSetPropertyVisibility.java
+++ b/web/web-base/src/main/java/org/visallo/web/routes/edge/EdgeSetPropertyVisibility.java
@@ -15,10 +15,10 @@ import org.visallo.core.security.VisibilityTranslator;
 import org.visallo.core.user.User;
 import org.visallo.core.util.VisalloLogger;
 import org.visallo.core.util.VisalloLoggerFactory;
-import org.visallo.web.BadRequestException;
 import org.visallo.web.VisalloResponse;
 import org.visallo.web.clientapi.model.ClientApiSuccess;
 import org.visallo.web.parameterProviders.ActiveWorkspaceId;
+import org.visallo.web.util.VisibilityValidator;
 
 import java.util.ResourceBundle;
 
@@ -62,13 +62,7 @@ public class EdgeSetPropertyVisibility implements ParameterizedHandler {
             throw new VisalloResourceNotFoundException("Could not find edge: " + graphEdgeId, graphEdgeId);
         }
 
-        if (!graph.isVisibilityValid(
-                visibilityTranslator.toVisibility(newVisibilitySource).getVisibility(),
-                authorizations
-        )) {
-            LOGGER.warn("%s is not a valid visibility for %s user", newVisibilitySource, user.getDisplayName());
-            throw new BadRequestException("visibilitySource", resourceBundle.getString("visibility.invalid"));
-        }
+        VisibilityValidator.validate(graph, visibilityTranslator, resourceBundle, newVisibilitySource, user, authorizations);
 
         // add the vertex to the workspace so that the changes show up in the diff panel
         workspaceRepository.updateEntityOnWorkspace(workspaceId, edge.getVertexId(Direction.IN), null, null, user);

--- a/web/web-base/src/main/java/org/visallo/web/routes/edge/EdgeSetVisibility.java
+++ b/web/web-base/src/main/java/org/visallo/web/routes/edge/EdgeSetVisibility.java
@@ -20,9 +20,9 @@ import org.visallo.core.util.ClientApiConverter;
 import org.visallo.core.util.SandboxStatusUtil;
 import org.visallo.core.util.VisalloLogger;
 import org.visallo.core.util.VisalloLoggerFactory;
-import org.visallo.web.BadRequestException;
 import org.visallo.web.clientapi.model.ClientApiElement;
 import org.visallo.web.parameterProviders.ActiveWorkspaceId;
+import org.visallo.web.util.VisibilityValidator;
 
 import java.util.ResourceBundle;
 
@@ -63,10 +63,7 @@ public class EdgeSetVisibility implements ParameterizedHandler {
             throw new VisalloResourceNotFoundException("Could not find edge: " + graphEdgeId);
         }
 
-        if (!graph.isVisibilityValid(visibilityTranslator.toVisibility(visibilitySource).getVisibility(), authorizations)) {
-            LOGGER.warn("%s is not a valid visibility for %s user", visibilitySource, user.getDisplayName());
-            throw new BadRequestException("visibilitySource", resourceBundle.getString("visibility.invalid"));
-        }
+        VisibilityValidator.validate(graph, visibilityTranslator, resourceBundle, visibilitySource, user, authorizations);
 
         // add the vertex to the workspace so that the changes show up in the diff panel
         workspaceRepository.updateEntityOnWorkspace(workspaceId, graphEdge.getVertexId(Direction.IN), null, null, user);

--- a/web/web-base/src/main/java/org/visallo/web/routes/vertex/ResolveDetectedObject.java
+++ b/web/web-base/src/main/java/org/visallo/web/routes/vertex/ResolveDetectedObject.java
@@ -22,12 +22,12 @@ import org.visallo.core.user.User;
 import org.visallo.core.util.ClientApiConverter;
 import org.visallo.core.util.VisalloLogger;
 import org.visallo.core.util.VisalloLoggerFactory;
-import org.visallo.web.BadRequestException;
 import org.visallo.web.clientapi.model.ClientApiElement;
 import org.visallo.web.clientapi.model.ClientApiSourceInfo;
 import org.visallo.web.clientapi.model.VisibilityJson;
 import org.visallo.web.parameterProviders.ActiveWorkspaceId;
 import org.visallo.web.parameterProviders.JustificationText;
+import org.visallo.web.util.VisibilityValidator;
 
 import java.util.Date;
 import java.util.ResourceBundle;
@@ -91,10 +91,7 @@ public class ResolveDetectedObject implements ParameterizedHandler {
 
         Workspace workspace = workspaceRepository.findById(workspaceId, user);
 
-        if (!graph.isVisibilityValid(visibilityTranslator.toVisibility(visibilitySource).getVisibility(), authorizations)) {
-            LOGGER.warn("%s is not a valid visibility for %s user", visibilitySource, user.getDisplayName());
-            throw new BadRequestException("visibilitySource", resourceBundle.getString("visibility.invalid"));
-        }
+        VisibilityValidator.validate(graph, visibilityTranslator, resourceBundle, visibilitySource, user, authorizations);
 
         VisibilityJson visibilityJson = VisibilityJson.updateVisibilitySourceAndAddWorkspaceId(null, visibilitySource, workspaceId);
         VisalloVisibility visalloVisibility = visibilityTranslator.toVisibility(visibilityJson);
@@ -148,7 +145,8 @@ public class ResolveDetectedObject implements ParameterizedHandler {
                 "user",
                 edge.getId(),
                 resolvedVertex.getId(),
-                originalPropertyKey);
+                originalPropertyKey
+        );
         String propertyKey = artifactDetectedObject.getMultivalueKey(MULTI_VALUE_KEY_PREFIX);
         VisalloProperties.DETECTED_OBJECT.addPropertyValue(artifactVertex, propertyKey, artifactDetectedObject, visalloVisibility.getVisibility(), authorizations);
 

--- a/web/web-base/src/main/java/org/visallo/web/routes/vertex/ResolveTermEntity.java
+++ b/web/web-base/src/main/java/org/visallo/web/routes/vertex/ResolveTermEntity.java
@@ -21,13 +21,13 @@ import org.visallo.core.security.VisibilityTranslator;
 import org.visallo.core.user.User;
 import org.visallo.core.util.VisalloLogger;
 import org.visallo.core.util.VisalloLoggerFactory;
-import org.visallo.web.BadRequestException;
 import org.visallo.web.VisalloResponse;
 import org.visallo.web.clientapi.model.ClientApiSourceInfo;
 import org.visallo.web.clientapi.model.ClientApiSuccess;
 import org.visallo.web.clientapi.model.VisibilityJson;
 import org.visallo.web.parameterProviders.ActiveWorkspaceId;
 import org.visallo.web.parameterProviders.JustificationText;
+import org.visallo.web.util.VisibilityValidator;
 
 import java.util.Date;
 import java.util.ResourceBundle;
@@ -86,11 +86,7 @@ public class ResolveTermEntity implements ParameterizedHandler {
         Workspace workspace = workspaceRepository.findById(workspaceId, user);
 
         VisibilityJson visibilityJson = VisibilityJson.updateVisibilitySourceAndAddWorkspaceId(null, visibilitySource, workspaceId);
-        VisalloVisibility visibility = this.visibilityTranslator.toVisibility(visibilityJson);
-        if (!graph.isVisibilityValid(visibility.getVisibility(), authorizations)) {
-            LOGGER.warn("%s is not a valid visibility for %s user", visibilitySource, user.getDisplayName());
-            throw new BadRequestException("visibilitySource", resourceBundle.getString("visibility.invalid"));
-        }
+        VisibilityValidator.validate(graph, visibilityTranslator, resourceBundle, visibilityJson, user, authorizations);
 
         String id = resolvedVertexId == null ? graph.getIdGenerator().nextId() : resolvedVertexId;
 

--- a/web/web-base/src/main/java/org/visallo/web/routes/vertex/VertexImport.java
+++ b/web/web-base/src/main/java/org/visallo/web/routes/vertex/VertexImport.java
@@ -15,6 +15,7 @@ import org.json.JSONException;
 import org.vertexium.Authorizations;
 import org.vertexium.Graph;
 import org.vertexium.Vertex;
+import org.vertexium.Visibility;
 import org.visallo.core.exception.VisalloException;
 import org.visallo.core.ingest.FileImport;
 import org.visallo.core.model.workQueue.Priority;
@@ -172,10 +173,8 @@ public class VertexImport implements ParameterizedHandler {
                 addPropertiesToFilesList(files, propertiesIndex.getAndIncrement(), properties);
             } else if (part.getName().equals("visibilitySource")) {
                 String visibilitySource = IOUtils.toString(part.getInputStream(), "UTF8");
-                if (!graph.isVisibilityValid(
-                        visibilityTranslator.toVisibility(visibilitySource).getVisibility(),
-                        authorizations
-                )) {
+                Visibility visibility = visibilityTranslator.toVisibility(visibilitySource).getVisibility();
+                if (!graph.isVisibilityValid(visibility, authorizations)) {
                     invalidVisibilities.add(visibilitySource);
                 }
                 addVisibilityToFilesList(files, visibilitySourceIndex.getAndIncrement(), visibilitySource);

--- a/web/web-base/src/main/java/org/visallo/web/routes/vertex/VertexNew.java
+++ b/web/web-base/src/main/java/org/visallo/web/routes/vertex/VertexNew.java
@@ -5,10 +5,7 @@ import com.v5analytics.webster.ParameterizedHandler;
 import com.v5analytics.webster.annotations.Handle;
 import com.v5analytics.webster.annotations.Optional;
 import com.v5analytics.webster.annotations.Required;
-import org.vertexium.Authorizations;
-import org.vertexium.Graph;
-import org.vertexium.Metadata;
-import org.vertexium.Vertex;
+import org.vertexium.*;
 import org.visallo.core.model.graph.GraphRepository;
 import org.visallo.core.model.graph.VisibilityAndElementMutation;
 import org.visallo.core.model.ontology.OntologyProperty;
@@ -25,12 +22,12 @@ import org.visallo.core.util.ClientApiConverter;
 import org.visallo.core.util.VertexiumMetadataUtil;
 import org.visallo.core.util.VisalloLogger;
 import org.visallo.core.util.VisalloLoggerFactory;
-import org.visallo.web.BadRequestException;
 import org.visallo.web.clientapi.model.ClientApiAddElementProperties;
 import org.visallo.web.clientapi.model.ClientApiElement;
 import org.visallo.web.clientapi.model.ClientApiSourceInfo;
 import org.visallo.web.parameterProviders.ActiveWorkspaceId;
 import org.visallo.web.parameterProviders.JustificationText;
+import org.visallo.web.util.VisibilityValidator;
 
 import java.util.ResourceBundle;
 
@@ -80,13 +77,7 @@ public class VertexNew implements ParameterizedHandler {
             User user,
             Authorizations authorizations
     ) throws Exception {
-        if (!graph.isVisibilityValid(
-                visibilityTranslator.toVisibility(visibilitySource).getVisibility(),
-                authorizations
-        )) {
-            LOGGER.warn("%s is not a valid visibility for %s user", visibilitySource, user.getDisplayName());
-            throw new BadRequestException("visibilitySource", resourceBundle.getString("visibility.invalid"));
-        }
+        VisibilityValidator.validate(graph, visibilityTranslator, resourceBundle, visibilitySource, user, authorizations);
 
         workspaceId = workspaceHelper.getWorkspaceIdOrNullIfPublish(workspaceId, shouldPublish, user);
 

--- a/web/web-base/src/main/java/org/visallo/web/routes/vertex/VertexPropertyDetails.java
+++ b/web/web-base/src/main/java/org/visallo/web/routes/vertex/VertexPropertyDetails.java
@@ -13,12 +13,11 @@ import org.visallo.core.security.VisibilityTranslator;
 import org.visallo.core.user.User;
 import org.visallo.core.util.VisalloLogger;
 import org.visallo.core.util.VisalloLoggerFactory;
-import org.visallo.web.BadRequestException;
-import org.visallo.web.VisalloResponse;
 import org.visallo.web.clientapi.model.ClientApiSourceInfo;
 import org.visallo.web.clientapi.model.ClientApiVertexPropertyDetails;
 import org.visallo.web.clientapi.model.VisibilityJson;
 import org.visallo.web.parameterProviders.ActiveWorkspaceId;
+import org.visallo.web.util.VisibilityValidator;
 
 import java.util.ResourceBundle;
 
@@ -48,14 +47,16 @@ public class VertexPropertyDetails implements ParameterizedHandler {
             @ActiveWorkspaceId String workspaceId,
             ResourceBundle resourceBundle,
             User user,
-            Authorizations authorizations,
-            VisalloResponse response
+            Authorizations authorizations
     ) throws Exception {
-        Visibility visibility = visibilityTranslator.toVisibility(visibilitySource).getVisibility();
-        if (!graph.isVisibilityValid(visibility, authorizations)) {
-            LOGGER.warn("%s is not a valid visibility for %s user", visibilitySource, user.getDisplayName());
-            throw new BadRequestException("visibilitySource", resourceBundle.getString("visibility.invalid"));
-        }
+        Visibility visibility = VisibilityValidator.validate(
+                graph,
+                visibilityTranslator,
+                resourceBundle,
+                visibilitySource,
+                user,
+                authorizations
+        );
 
         Vertex vertex = this.graph.getVertex(vertexId, authorizations);
         if (vertex == null) {

--- a/web/web-base/src/main/java/org/visallo/web/routes/vertex/VertexSetProperty.java
+++ b/web/web-base/src/main/java/org/visallo/web/routes/vertex/VertexSetProperty.java
@@ -26,11 +26,12 @@ import org.visallo.core.util.ClientApiConverter;
 import org.visallo.core.util.VertexiumMetadataUtil;
 import org.visallo.core.util.VisalloLogger;
 import org.visallo.core.util.VisalloLoggerFactory;
-import org.visallo.web.routes.SetPropertyBase;
 import org.visallo.web.clientapi.model.ClientApiElement;
 import org.visallo.web.clientapi.model.ClientApiSourceInfo;
 import org.visallo.web.parameterProviders.ActiveWorkspaceId;
 import org.visallo.web.parameterProviders.JustificationText;
+import org.visallo.web.routes.SetPropertyBase;
+import org.visallo.web.util.VisibilityValidator;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.ArrayList;
@@ -56,15 +57,18 @@ public class VertexSetProperty extends SetPropertyBase implements ParameterizedH
             final WorkQueueRepository workQueueRepository,
             final GraphRepository graphRepository,
             final ACLProvider aclProvider,
-            final Configuration configuration) {
+            final Configuration configuration
+    ) {
         super(graph, visibilityTranslator);
         this.ontologyRepository = ontologyRepository;
         this.workspaceRepository = workspaceRepository;
         this.workQueueRepository = workQueueRepository;
         this.graphRepository = graphRepository;
         this.aclProvider = aclProvider;
-        this.autoPublishComments = configuration.getBoolean(Configuration.COMMENTS_AUTO_PUBLISH,
-                Configuration.DEFAULT_COMMENTS_AUTO_PUBLISH);
+        this.autoPublishComments = configuration.getBoolean(
+                Configuration.COMMENTS_AUTO_PUBLISH,
+                Configuration.DEFAULT_COMMENTS_AUTO_PUBLISH
+        );
     }
 
     @Handle
@@ -89,7 +93,7 @@ public class VertexSetProperty extends SetPropertyBase implements ParameterizedH
             throw new VisalloException("Parameter: 'value' or 'value[]' is required in the request");
         }
 
-        checkVisibilityParameter(visibilitySource, authorizations, user, resourceBundle);
+        VisibilityValidator.validate(graph, visibilityTranslator, resourceBundle, visibilitySource, user, authorizations);
         checkRoutePath("vertex", propertyName, request);
 
         boolean isComment = isCommentProperty(propertyName);

--- a/web/web-base/src/main/java/org/visallo/web/routes/vertex/VertexSetPropertyVisibility.java
+++ b/web/web-base/src/main/java/org/visallo/web/routes/vertex/VertexSetPropertyVisibility.java
@@ -18,10 +18,10 @@ import org.visallo.core.security.VisibilityTranslator;
 import org.visallo.core.user.User;
 import org.visallo.core.util.VisalloLogger;
 import org.visallo.core.util.VisalloLoggerFactory;
-import org.visallo.web.BadRequestException;
 import org.visallo.web.VisalloResponse;
 import org.visallo.web.clientapi.model.ClientApiSuccess;
 import org.visallo.web.parameterProviders.ActiveWorkspaceId;
+import org.visallo.web.util.VisibilityValidator;
 
 import java.util.ResourceBundle;
 
@@ -65,13 +65,7 @@ public class VertexSetPropertyVisibility implements ParameterizedHandler {
             throw new VisalloResourceNotFoundException("Could not find vertex: " + graphVertexId, graphVertexId);
         }
 
-        if (!graph.isVisibilityValid(
-                visibilityTranslator.toVisibility(newVisibilitySource).getVisibility(),
-                authorizations
-        )) {
-            LOGGER.warn("%s is not a valid visibility for %s user", newVisibilitySource, user.getDisplayName());
-            throw new BadRequestException("newVisibilitySource", resourceBundle.getString("visibility.invalid"));
-        }
+        VisibilityValidator.validate(graph, visibilityTranslator, resourceBundle, newVisibilitySource, user, authorizations);
 
         // add the vertex to the workspace so that the changes show up in the diff panel
         workspaceRepository.updateEntityOnWorkspace(workspaceId, graphVertexId, null, null, user);

--- a/web/web-base/src/main/java/org/visallo/web/routes/vertex/VertexSetVisibility.java
+++ b/web/web-base/src/main/java/org/visallo/web/routes/vertex/VertexSetVisibility.java
@@ -20,11 +20,11 @@ import org.visallo.core.util.ClientApiConverter;
 import org.visallo.core.util.SandboxStatusUtil;
 import org.visallo.core.util.VisalloLogger;
 import org.visallo.core.util.VisalloLoggerFactory;
-import org.visallo.web.BadRequestException;
 import org.visallo.web.clientapi.model.ClientApiElement;
 import org.visallo.web.clientapi.model.ClientApiWorkspace;
 import org.visallo.web.parameterProviders.ActiveWorkspaceId;
 import org.visallo.web.parameterProviders.SourceGuid;
+import org.visallo.web.util.VisibilityValidator;
 
 import java.util.ResourceBundle;
 
@@ -61,10 +61,7 @@ public class VertexSetVisibility implements ParameterizedHandler {
             User user,
             Authorizations authorizations
     ) throws Exception {
-        if (!graph.isVisibilityValid(visibilityTranslator.toVisibility(visibilitySource).getVisibility(), authorizations)) {
-            LOGGER.warn("%s is not a valid visibility for %s user", visibilitySource, user.getDisplayName());
-            throw new BadRequestException("visibilitySource", resourceBundle.getString("visibility.invalid"));
-        }
+        VisibilityValidator.validate(graph, visibilityTranslator, resourceBundle, visibilitySource, user, authorizations);
 
         Vertex graphVertex = graph.getVertex(graphVertexId, authorizations);
         if (graphVertex == null) {

--- a/web/web-base/src/main/java/org/visallo/web/util/VisibilityValidator.java
+++ b/web/web-base/src/main/java/org/visallo/web/util/VisibilityValidator.java
@@ -1,0 +1,55 @@
+package org.visallo.web.util;
+
+import org.vertexium.Authorizations;
+import org.vertexium.Graph;
+import org.vertexium.Visibility;
+import org.visallo.core.security.VisibilityTranslator;
+import org.visallo.core.user.User;
+import org.visallo.core.util.VisalloLogger;
+import org.visallo.core.util.VisalloLoggerFactory;
+import org.visallo.web.BadRequestException;
+import org.visallo.web.clientapi.model.VisibilityJson;
+
+import java.util.ResourceBundle;
+
+public class VisibilityValidator {
+    private static final VisalloLogger LOGGER = VisalloLoggerFactory.getLogger(VisibilityValidator.class);
+
+    public static Visibility validate(
+            Graph graph,
+            VisibilityTranslator visibilityTranslator,
+            ResourceBundle resourceBundle,
+            String visibilitySource,
+            User user,
+            Authorizations authorizations
+    ) throws BadRequestException {
+        Visibility visibility = visibilityTranslator.toVisibility(visibilitySource).getVisibility();
+        return validate(graph, resourceBundle, visibility, user, authorizations);
+    }
+
+    public static Visibility validate(
+            Graph graph,
+            VisibilityTranslator visibilityTranslator,
+            ResourceBundle resourceBundle,
+            VisibilityJson visibilityJson,
+            User user,
+            Authorizations authorizations
+    ) throws BadRequestException {
+        Visibility visibility = visibilityTranslator.toVisibility(visibilityJson).getVisibility();
+        return validate(graph, resourceBundle, visibility, user, authorizations);
+    }
+
+    public static Visibility validate(
+            Graph graph,
+            ResourceBundle resourceBundle,
+            Visibility visibility,
+            User user,
+            Authorizations authorizations
+    ) {
+        if (!graph.isVisibilityValid(visibility, authorizations)) {
+            LOGGER.warn("%s is not a valid visibility for %s user", visibility, user.getDisplayName());
+            throw new BadRequestException("visibilitySource", resourceBundle.getString("visibility.invalid"));
+        }
+        return visibility;
+    }
+}


### PR DESCRIPTION
- [x] @joeferner
- [x] @srfarley @kunklejr
- [x] @mwizeman @dsingley @EvanOxfeld 
- [x] @joeybrk372 @sfeng88 @rygim @jharwig 

The primary reason for this change is to alter the warning message.
Instead of printing the visibility source the message prints the
resulting visibility string. This allows the admin to narrow down
which authorizations are required.