### PR TITLE
Admin: Allow extensions to request a sort within a section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 #v2.2.0
 ==================
   * Include babel polyfill https://babeljs.io/docs/usage/polyfill/
-
   * Add methods which take timestamps to SingleValueVisalloProperty and VisalloProperty
   * Allow ACLProvider to continue even if a concept or relationship cannot be found
+  * Allow admin extensions to request a sort within a section
 
 #v2.1.1
 ==================

--- a/docs/extension-points/front-end/admin/index.md
+++ b/docs/extension-points/front-end/admin/index.md
@@ -24,6 +24,9 @@ require(['configuration/plugins/registry'], function(registry) {
 * `requiredPrivilege`: _(optional)_ `[String|function]` A string containing the privilege required to view
    this extension. Or, a function which will be executed, if function returns true the extension will be
    visible. The default for this property is `'ADMIN'`.
+* `options`: _(optional)_ `[Object]`
+  * `sortHint`: `[Number]` A number indicating the admin tool's position within the section. If not
+    included, admin items will be sorted within a section by name.
 * Exactly one of: `componentPath` or `Component`, or `url` _(required)_
 
     * `componentPath`: `[String]` requirejs or react component path

--- a/web/war/src/main/webapp/js/admin/admin.js
+++ b/web/war/src/main/webapp/js/admin/admin.js
@@ -162,12 +162,13 @@ define([
                             return d[0];
                         })
                         .each(function(d) {
-                            const [sorted, toSort] = _.partition(d[1], ({ options }) => options && Number.isInteger(options.sortHint));
-                            d[1] = _.sortBy(toSort, 'name');
-                            sorted.forEach(ext => {
-                                const { sortHint } = ext.options;
-                                d[1].splice(sortHint, 0, ext);
-                            });
+                            d[1] = _.chain(d[1])
+                                .sortBy('name')
+                                .sortBy(function sortHint({ options }) {
+                                    return options && Number.isInteger(options.sortHint) ?
+                                        options.sortHint : Number.MAX_VALUE;
+                                })
+                                .value();
                         })
                         .flatten()
                         .value()

--- a/web/war/src/main/webapp/js/admin/admin.js
+++ b/web/war/src/main/webapp/js/admin/admin.js
@@ -162,7 +162,12 @@ define([
                             return d[0];
                         })
                         .each(function(d) {
-                            d[1] = _.sortBy(d[1], 'name');
+                            const [sorted, toSort] = _.partition(d[1], ({ options }) => options && Number.isInteger(options.sortHint));
+                            d[1] = _.sortBy(toSort, 'name');
+                            sorted.forEach(ext => {
+                                const { sortHint } = ext.options;
+                                d[1].splice(sortHint, 0, ext);
+                            });
                         })
                         .flatten()
                         .value()

--- a/web/war/src/main/webapp/karma.conf.js
+++ b/web/war/src/main/webapp/karma.conf.js
@@ -16,6 +16,9 @@ module.exports = function(config) {
             // list of files / patterns to load in the browser
             files: [
 
+                // Babel polyfill
+                'libs/babel-polyfill/dist/polyfill.min.js',
+
                 // Source
                 {pattern: 'js/**/*.js', included: false},
 
@@ -99,6 +102,7 @@ module.exports = function(config) {
             singleRun: false,
 
             preprocessors: {
+                'js/**/*.js': ['babel'],
                 'js/**/*.jsx': ['babel'],
                 'test/**/*.jsx': ['babel']
             },


### PR DESCRIPTION
- [x] @joeferner
- [x] @srfarley @kunklejr
- [x] @mwizeman @dsingley @EvanOxfeld 
- [x] @joeybrk372 @sfeng88 @rygim @jharwig 

Enables admin items to request an exact position within a section of the admin pane.

Depends on #585 (polyfills `Number.isInteger` in IE)