### PR TITLE
Fix: Vertexium user property map not being updated through Proxy User (2.1 branch)

### DIFF
--- a/core/plugins/model-vertexium/src/main/java/org/visallo/vertexium/model/user/VertexiumUserRepository.java
+++ b/core/plugins/model-vertexium/src/main/java/org/visallo/vertexium/model/user/VertexiumUserRepository.java
@@ -22,6 +22,7 @@ import org.visallo.core.model.user.*;
 import org.visallo.core.model.workQueue.WorkQueueRepository;
 import org.visallo.core.security.VisalloVisibility;
 import org.visallo.core.trace.Traced;
+import org.visallo.core.user.ProxyUser;
 import org.visallo.core.user.SystemUser;
 import org.visallo.core.user.User;
 import org.visallo.core.util.VisalloLogger;
@@ -385,6 +386,12 @@ public class VertexiumUserRepository extends UserRepository {
         if (!value.equals(user.getCustomProperties().get(propertyName))) {
             Vertex userVertex = findByIdUserVertex(user.getUserId());
             userVertex.setProperty(propertyName, value, VISIBILITY.getVisibility(), authorizations);
+            if (user instanceof ProxyUser){
+                User proxiedUser = ((ProxyUser) user).getProxiedUser();
+                if (proxiedUser instanceof VertexiumUser) {
+                    user = proxiedUser;
+                }
+            }
             if (user instanceof VertexiumUser) {
                 ((VertexiumUser) user).setProperty(propertyName, value);
             }


### PR DESCRIPTION
- [x] @joeferner
- [ ] @srfarley @kunklejr
- [x] @mwizeman @dsingley @EvanOxfeld 
- [x] @joeybrk372 @sfeng88 @rygim @jharwig 

You will run into this issue when you have a web plugin that sets properties for new users on login.

CHANGELOG
Fixed: Vertexium user property map not being updated through Proxy User

