### PR TITLE
Changed: ACLProvider: support elements which cannot be found

### DIFF
--- a/core/core-test/src/test/java/org/visallo/core/security/ACLProviderTest.java
+++ b/core/core-test/src/test/java/org/visallo/core/security/ACLProviderTest.java
@@ -304,6 +304,20 @@ public class ACLProviderTest {
         when(aclProvider.canDeleteProperty(vertex, REGULAR_PROP_KEY, REGULAR_PROP_NAME, user2)).thenReturn(false);
     }
 
+    @Test
+    public void appendACLShouldNotFailIfElementCannotBeFound() {
+        ClientApiVertex apiElement = new ClientApiVertex();
+        apiElement.setId("notFoundId");
+
+        aclProvider.appendACL(apiElement, user1);
+
+        assertThat(apiElement.getUpdateable(), equalTo(false));
+        assertThat(apiElement.getDeleteable(), equalTo(false));
+        assertThat(apiElement.getAcl().isAddable(), equalTo(false));
+        assertThat(apiElement.getAcl().isUpdateable(), equalTo(false));
+        assertThat(apiElement.getAcl().isDeleteable(), equalTo(false));
+    }
+
     private void appendAclShouldPopulateClientApiElementAcl(Element element) {
         when(aclProvider.canUpdateElement(element, user1)).thenReturn(true);
         when(aclProvider.canDeleteElement(element, user1)).thenReturn(true);


### PR DESCRIPTION
- [x] @joeferner
- [x] @srfarley @kunklejr
- [x] @mwizeman @dsingley @EvanOxfeld 
- [x] @joeybrk372 @sfeng88 @rygim @jharwig 

If an element cannot be found for what ever reason return to the client
a readonly ClientApiElement. Element not found could be caused by a blind
write edge which does not yet have it's other side yet, without this
an exception is thrown and the UI becomes unusable.

CHANGELOG
Changed: ACLProvider: support elements which cannot be found