### PR TITLE
Search filters accidentally overwriting the ontology property title

### DIFF
--- a/web/war/src/main/webapp/js/search/filters/filters.js
+++ b/web/war/src/main/webapp/js/search/filters/filters.js
@@ -435,7 +435,7 @@ define([
                     propertyFilters: _.chain(this.propertyFilters)
                         .map(function(filter) {
                             var ontologyProperty = self.propertiesByDomainType[self.matchType].find(function(property) {
-                                return property.title = filter.propertyId;
+                                return property.title === filter.propertyId;
                             });
 
                             if (ontologyProperty && ontologyProperty.dependentPropertyIris) {


### PR DESCRIPTION
2.1 pull request: https://github.com/v5analytics/visallo/pull/618

CHANGELOG
Fixed: Search filters had a bug due to using a single equals rather than comparing with triple equals.