### PR TITLE
Search filters accidentally overwriting the ontology property title (2.1)

### DIFF
--- a/web/war/src/main/webapp/js/search/filters/filters.js
+++ b/web/war/src/main/webapp/js/search/filters/filters.js
@@ -435,7 +435,7 @@ define([
                     propertyFilters: _.chain(this.propertyFilters)
                         .map(function(filter) {
                             var ontologyProperty = self.propertiesByDomainType[self.matchType].find(function(property) {
-                                return property.title = filter.propertyId;
+                                return property.title === filter.propertyId;
                             });
 
                             if (ontologyProperty && ontologyProperty.dependentPropertyIris) {


### PR DESCRIPTION
- [x] @joeferner
- [x] @srfarley @kunklejr
- [x] @mwizeman @dsingley @EvanOxfeld 
- [x] @joeybrk372 @sfeng88 @rygim @jharwig 



CHANGELOG
Fixed: Search filters had a bug due to using a single equals rather than comparing with triple equals.