### PR TITLE
Fix search property filters in IE

### DIFF
--- a/web/war/src/main/webapp/js/data/web-worker/services/ontology.js
+++ b/web/war/src/main/webapp/js/data/web-worker/services/ontology.js
@@ -79,7 +79,7 @@ define([
                             .flatten()
                             .uniq()
                             .map(function(propertyName) {
-                                return ontology.properties.find(function(property) {
+                                return _.find(ontology.properties, function(property) {
                                     return property.title === propertyName;
                                 });
                             })

--- a/web/war/src/main/webapp/js/search/filters/filters.js
+++ b/web/war/src/main/webapp/js/search/filters/filters.js
@@ -434,7 +434,7 @@ define([
                     matchType: this.matchType,
                     propertyFilters: _.chain(this.propertyFilters)
                         .map(function(filter) {
-                            var ontologyProperty = self.propertiesByDomainType[self.matchType].find(function(property) {
+                            var ontologyProperty = _.find(self.propertiesByDomainType[self.matchType], function(property) {
                                 return property.title === filter.propertyId;
                             });
 
@@ -642,7 +642,7 @@ define([
             var self = this,
                 $li = $('<li>').data('filterId', this.filterId++),
                 attributes = filter ? {
-                    property: this.propertiesByDomainType[this.matchType].find(function(property) {
+                    property: _.find(this.propertiesByDomainType[this.matchType], function(property) {
                         return property.title === filter.propertyId;
                     }),
                     predicate: filter.predicate,


### PR DESCRIPTION
Change search property filters to use `_.find` instead of `Array.prototype.find` which is not supported in IE

https://github.com/v5analytics/visallo/pull/620