### PR TITLE
deprecate getRemoteAddr

### DIFF
--- a/web/web-base/src/main/java/org/visallo/web/AuthenticationHandler.java
+++ b/web/web-base/src/main/java/org/visallo/web/AuthenticationHandler.java
@@ -2,6 +2,7 @@ package org.visallo.web;
 
 import com.v5analytics.webster.HandlerChain;
 import com.v5analytics.webster.RequestResponseHandler;
+import org.visallo.web.util.RemoteAddressUtil;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -17,5 +18,15 @@ public class AuthenticationHandler implements RequestResponseHandler {
         } else {
             response.sendError(HttpServletResponse.SC_FORBIDDEN);
         }
+    }
+
+    /**
+     * @Deprecated
+     *
+     * Use RemoteAddressUtil.getClientIpAddr for future calls to get client IP addresses.
+     */
+    @Deprecated
+    public static String getRemoteAddr(HttpServletRequest request) {
+        return RemoteAddressUtil.getClientIpAddr(request);
     }
 }


### PR DESCRIPTION

CHANGELOG
Deprecated: getRemoteAddr to provide a more consistent way of retrieving the client IP address. Use RemoteAddressUtil.getClientIpAddr to get the client IP address in the future.

