### PR TITLE
Fixed: Dashboard pie chart infinite loop

### DIFF
--- a/web/war/src/main/webapp/js/dashboard/reportRenderers/pie.js
+++ b/web/war/src/main/webapp/js/dashboard/reportRenderers/pie.js
@@ -268,7 +268,7 @@ define([
                     gLegend.selectAll('g:not(.hidden) > text').each(function(d) {
                         var d3Self = d3.select(this),
                             text = d3.select(this).text();
-                        while (this.getBBox().width > availableLegendTextWidth) {
+                        while (text.length > 0 && this.getBBox().width > availableLegendTextWidth) {
                             text = text.substring(0, text.length - 1);
                             d3Self.text(text + '...');
                         }


### PR DESCRIPTION
- [x] @joeferner
- [x] @srfarley @kunklejr
- [x] @mwizeman @dsingley @EvanOxfeld 
- [x] @joeybrk372 @sfeng88 @rygim @jharwig 

While resizing the browser windows on Firefox if the size of the
browser is just right an infinite loop occurs because the length
of the string cannot be less than 0 yet the width is greater
than the available legend width.

CHANGELOG
Fixed: Dashboard pie chart infinite loop