### PR TITLE
Changed: Move visibility in the details pane into the info box

### DIFF
--- a/core/core/src/main/resources/MessageBundle.properties
+++ b/core/core/src/main/resources/MessageBundle.properties
@@ -603,6 +603,7 @@ properties.metadata.label.modified_date=Modified
 properties.metadata.label.modified_by=By
 properties.metadata.label.status=Status
 properties.metadata.label.confidence=Confidence
+properties.metadata.label.visibility=Visibility
 properties.button.add_property=Add Property
 properties.button.show_more=Show {0} More ({1})
 properties.button.hide_more=Hide {0} ({1})

--- a/web/war/src/main/webapp/js/detail/properties/properties.js
+++ b/web/war/src/main/webapp/js/detail/properties/properties.js
@@ -722,7 +722,7 @@ define([
 
                         if (visibility) {
                             dataType = 'visibility';
-                        } else if (property.hideVisibility !== true) {
+                        } else if (config['showVisibilityInDetailsPane'] !== 'false' && property.hideVisibility !== true) {
                             F.vertex.properties.visibility(
                                 visibilitySpan,
                                 { value: property.metadata && property.metadata[VISIBILITY_NAME] },

--- a/web/war/src/main/webapp/js/util/popovers/propertyInfo/propertyInfo.js
+++ b/web/war/src/main/webapp/js/util/popovers/propertyInfo/propertyInfo.js
@@ -209,7 +209,8 @@ define([
                                 d3.select(this).text(i18n('popovers.property_info.loading'));
                             } else if (typeName === 'visibility') {
                                 VisibilityViewer.attachTo(this, {
-                                    value: value && value.source
+                                    value: value && value.source,
+                                    property: property
                                 });
                             } else {
                                 console.warn('No metadata type formatter: ' + typeName);

--- a/web/war/src/main/webapp/less/detail/properties.less
+++ b/web/war/src/main/webapp/less/detail/properties.less
@@ -3,7 +3,7 @@
 .org-visallo-comments {
   .visibility {
     display:block;
-    color: #666; 
+    color: #666;
     font-style: italic;
     font-size: 90%;
     &:empty { display: none; }

--- a/web/web-base/src/main/java/org/visallo/web/WebConfiguration.java
+++ b/web/web-base/src/main/java/org/visallo/web/WebConfiguration.java
@@ -38,6 +38,7 @@ public class WebConfiguration {
     public static final String MAP_PROVIDER_OSM_URL = PREFIX + "map.provider.osm.url";
     public static final String LOGIN_SHOW_POWERED_BY = PREFIX + "login.showPoweredBy";
     public static final String SHOW_VERSION_COMMENTS = PREFIX + "showVersionComments";
+    public static final String SHOW_VISIBILITY_IN_DETAILS_PANE = PREFIX + "showVisibilityInDetailsPane";
     public static final PropertyMetadata PROPERTY_METADATA_SOURCE_TIMEZONE = new PropertyMetadata("http://visallo.org#sourceTimezone",
             "properties.metadata.label.source_timezone",
             "timezone");
@@ -59,6 +60,8 @@ public class WebConfiguration {
     static {
         DEFAULTS.put(LOGIN_SHOW_POWERED_BY, "false");
         DEFAULTS.put(SHOW_VERSION_COMMENTS, "true");
+
+        DEFAULTS.put(SHOW_VISIBILITY_IN_DETAILS_PANE, "true");
 
         DEFAULTS.put(THROTTLE_MESSAGING_SECONDS, "2");
 
@@ -97,21 +100,27 @@ public class WebConfiguration {
         DEFAULTS.put(PROPERTIES_MULTIVALUE_DEFAULT_VISIBLE_COUNT, "2");
 
         // Property Metadata shown in info popover
-        DEFAULTS.put(PROPERTIES_METADATA_PROPERTY_NAMES, Joiner.on(',').join(PROPERTY_METADATA_SOURCE_TIMEZONE.getName(),
+        DEFAULTS.put(PROPERTIES_METADATA_PROPERTY_NAMES, Joiner.on(',').join(
+                PROPERTY_METADATA_SOURCE_TIMEZONE.getName(),
                 PROPERTY_METADATA_MODIFIED_DATE.getName(),
                 PROPERTY_METADATA_MODIFIED_BY.getName(),
                 PROPERTY_METADATA_STATUS.getName(),
-                PROPERTY_METADATA_CONFIDENCE.getName()));
-        DEFAULTS.put(PROPERTIES_METADATA_PROPERTY_NAMES_DISPLAY, Joiner.on(',').join(PROPERTY_METADATA_SOURCE_TIMEZONE.getMessageKey(),
+                PROPERTY_METADATA_CONFIDENCE.getName()
+        ));
+        DEFAULTS.put(PROPERTIES_METADATA_PROPERTY_NAMES_DISPLAY, Joiner.on(',').join(
+                PROPERTY_METADATA_SOURCE_TIMEZONE.getMessageKey(),
                 PROPERTY_METADATA_MODIFIED_DATE.getMessageKey(),
                 PROPERTY_METADATA_MODIFIED_BY.getMessageKey(),
                 PROPERTY_METADATA_STATUS.getMessageKey(),
-                PROPERTY_METADATA_CONFIDENCE.getMessageKey()));
-        DEFAULTS.put(PROPERTIES_METADATA_PROPERTY_NAMES_TYPE, Joiner.on(',').join(PROPERTY_METADATA_SOURCE_TIMEZONE.getDataType(),
+                PROPERTY_METADATA_CONFIDENCE.getMessageKey()
+        ));
+        DEFAULTS.put(PROPERTIES_METADATA_PROPERTY_NAMES_TYPE, Joiner.on(',').join(
+                PROPERTY_METADATA_SOURCE_TIMEZONE.getDataType(),
                 PROPERTY_METADATA_MODIFIED_DATE.getDataType(),
                 PROPERTY_METADATA_MODIFIED_BY.getDataType(),
                 PROPERTY_METADATA_STATUS.getDataType(),
-                PROPERTY_METADATA_CONFIDENCE.getDataType()));
+                PROPERTY_METADATA_CONFIDENCE.getDataType()
+        ));
 
         DEFAULTS.put(MAP_PROVIDER, MapProvider.OSM.toString());
         DEFAULTS.put(MAP_PROVIDER_OSM_URL, "https://{a-c}.tile.openstreetmap.org/${z}/${x}/${y}.png");


### PR DESCRIPTION
- [x] @joeferner
- [x] @srfarley @kunklejr
- [x] @mwizeman @dsingley @EvanOxfeld 
- [x] @joeybrk372 @sfeng88 @rygim @jharwig 

This commit moves the visibility in the details pane for both
properties and comments from below the value to the popup info
box.

When using long visibility strings the details pane can become
cluttered quite fast. This addresses this by moving what most
users will not not typically use to get the job down into the
info box which is just one click away.

CHANGELOG
Changed: Move visibility in the details pane into the info box