### PR TITLE
Add ability to use non-JKS format key and trust stores

### DIFF
--- a/web/server/jetty-server/src/main/java/org/visallo/web/JettyWebServer.java
+++ b/web/server/jetty-server/src/main/java/org/visallo/web/JettyWebServer.java
@@ -48,11 +48,13 @@ public class JettyWebServer extends WebServer {
         httpConnector.setPort(getHttpPort());
 
         SslContextFactory sslContextFactory = new SslContextFactory();
+        sslContextFactory.setKeyStoreType(getKeyStoreType());
         sslContextFactory.setKeyStorePath(getKeyStorePath().getAbsolutePath());
-        sslContextFactory.setKeyStorePassword(super.getKeyStorePassword());
+        sslContextFactory.setKeyStorePassword(getKeyStorePassword());
+        sslContextFactory.setTrustStoreType(getTrustStoreType());
         sslContextFactory.setTrustStorePath(getTrustStorePath().getAbsolutePath());
-        sslContextFactory.setTrustStorePassword(super.getTrustStorePassword());
-        sslContextFactory.setNeedClientAuth(super.getRequireClientCert());
+        sslContextFactory.setTrustStorePassword(getTrustStorePassword());
+        sslContextFactory.setNeedClientAuth(getRequireClientCert());
 
         HttpConfiguration https_config = new HttpConfiguration(http_config);
         https_config.addCustomizer(new SecureRequestCustomizer());

--- a/web/server/server-base/src/main/java/org/visallo/web/WebServer.java
+++ b/web/server/server-base/src/main/java/org/visallo/web/WebServer.java
@@ -11,6 +11,7 @@ public abstract class WebServer extends CommandLineTool {
     public static final int DEFAULT_HTTPS_SERVER_PORT = 8443;
     public static final String DEFAULT_CONTEXT_PATH = "/";
     public static final int DEFAULT_SESSION_TIMEOUT = 30;
+    public static final String DEFAULT_KEYSTORE_TYPE = "JKS";
 
     @Parameter(names = {"--port"}, arity = 1, description = "The port to run the HTTP connector on")
     private int httpPort = DEFAULT_SERVER_PORT;
@@ -18,16 +19,22 @@ public abstract class WebServer extends CommandLineTool {
     @Parameter(names = {"--httpsPort"}, arity = 1, description = "The port to run the HTTPS connector on")
     private int httpsPort = DEFAULT_HTTPS_SERVER_PORT;
 
-    @Parameter(names = {"--keyStorePath"}, required = true, arity = 1, converter = FileConverter.class, description = "Path to the JKS keystore used for SSL")
+    @Parameter(names = {"--keyStoreType"}, arity = 1, description = "Keystore type (JKS, PKCS12)")
+    private String keyStoreType = DEFAULT_KEYSTORE_TYPE;
+
+    @Parameter(names = {"--keyStorePath"}, required = true, arity = 1, converter = FileConverter.class, description = "Path to the keystore used for SSL")
     private File keyStorePath;
 
-    @Parameter(names = {"--keyStorePassword"}, required = true, arity = 1, description = "JKS keystore password")
+    @Parameter(names = {"--keyStorePassword"}, required = true, arity = 1, description = "Keystore password")
     private String keyStorePassword;
 
-    @Parameter(names = {"--trustStorePath"}, arity = 1, converter = FileConverter.class, description = "Path to the JKS truststore used for SSL")
+    @Parameter(names = {"--trustStoreType"}, arity = 1, description = "Truststore type (JKS, PKCS12)")
+    private String trustStoreType = DEFAULT_KEYSTORE_TYPE;
+
+    @Parameter(names = {"--trustStorePath"}, arity = 1, converter = FileConverter.class, description = "Path to the truststore used for SSL")
     private File trustStorePath;
 
-    @Parameter(names = {"--trustStorePassword"}, arity = 1, description = "JKS truststore password")
+    @Parameter(names = {"--trustStorePassword"}, arity = 1, description = "Truststore password")
     private String trustStorePassword;
 
     @Parameter(names = {"--requireClientCert"}, description = "require client certificate")
@@ -50,12 +57,20 @@ public abstract class WebServer extends CommandLineTool {
         return httpsPort;
     }
 
+    public String getKeyStoreType() {
+        return keyStoreType;
+    }
+
     public File getKeyStorePath() {
         return keyStorePath;
     }
 
     public String getKeyStorePassword() {
         return keyStorePassword;
+    }
+
+    public String getTrustStoreType() {
+        return trustStoreType;
     }
 
     public File getTrustStorePath() {


### PR DESCRIPTION
- [x] @joeferner
- [x] @srfarley @kunklejr
- [x] @mwizeman @dsingley @EvanOxfeld 
- [x] @joeybrk372 @sfeng88 @rygim @jharwig 

The JKS key store format is very Java-centric. PKCS12-formatted key stores are much more common in the wild. This change allows you to specify the key store format to use with embedded web servers.

CHANGELOG
Changed: Added the ability to use non-JKS format key and trust stores with the embedded web server