### PR TITLE
Fix default open street map url for ol3

### DIFF
--- a/web/war/src/main/webapp/js/map/map.js
+++ b/web/war/src/main/webapp/js/map/map.js
@@ -845,10 +845,10 @@ define([
             if (provider === 'google' || provider === 'osm') {
                 // Legacy configs accepted csv urls, warn and pick first
                 var osmURL = config['map.provider.osm.url'];
-                if (osmURL && osmURL.indexOf(',')) {
+                if (osmURL && osmURL.indexOf(',') >= 0) {
                     console.warn('Comma-separated Urls not supported, using first url. Use urls with {a-c} for multiple CDNS');
-                    console.warn('For Example: https://{a-c}.tile.openstreetmap.org/${z}/${x}/${y}.png');
-                    config['map.provider.osm.url'] = osmURL.split(',')[0].trim()
+                    console.warn('For Example: https://{a-c}.tile.openstreetmap.org/{z}/{x}/{y}.png');
+                    config['map.provider.osm.url'] = osmURL.split(',')[0].trim().replace(/[$][{]/g, '{');
                 }
                 baseLayerSource = new ol.source.OSM(getOptions('osm'))
 

--- a/web/web-base/src/main/java/org/visallo/web/WebConfiguration.java
+++ b/web/web-base/src/main/java/org/visallo/web/WebConfiguration.java
@@ -114,7 +114,7 @@ public class WebConfiguration {
                 PROPERTY_METADATA_CONFIDENCE.getDataType()));
 
         DEFAULTS.put(MAP_PROVIDER, MapProvider.OSM.toString());
-        DEFAULTS.put(MAP_PROVIDER_OSM_URL, "https://{a-c}.tile.openstreetmap.org/${z}/${x}/${y}.png");
+        DEFAULTS.put(MAP_PROVIDER_OSM_URL, "https://{a-c}.tile.openstreetmap.org/{z}/{x}/{y}.png");
     }
 
     public static class PropertyMetadata {


### PR DESCRIPTION
- [x] @joeferner
- [x] @srfarley @kunklejr
- [x] @mwizeman @dsingley @EvanOxfeld 
- [x] @joeybrk372 @sfeng88 @rygim @jharwig 

CHANGELOG
Fixed: Default Open Street map tile URL is now valid for Openlayers 3
Fixed: Legacy Open Street map tile URLs with `$` now are translated to OpenLayers 3 valid URLs


