### PR TITLE
Upgrade Vertexium from 2.4.4 to 2.4.5

### DIFF
--- a/root/pom.xml
+++ b/root/pom.xml
@@ -79,7 +79,7 @@
         <lesscss.version>1.3.3</lesscss.version>
         <log4j.version>1.2.17</log4j.version>
         <metrics.version>3.0.2</metrics.version>
-        <vertexium.version>2.4.4</vertexium.version>
+        <vertexium.version>2.4.5</vertexium.version>
         <simple-orm.version>1.2.0</simple-orm.version>
         <groovy.version>2.4.5</groovy.version>
         <zip4j.version>1.3.1</zip4j.version>


### PR DESCRIPTION
- [x] @joeferner
- [x] @kunklejr
- [x] @mwizeman @dsingley @EvanOxfeld 
- [x] @joeybrk372 @sfeng88 @rygim @jharwig 



CHANGELOG
Changed: version branch 2.2 depends on the vertexium 2.4.5
