### PR TITLE
Added: Support link title in properties with display type "link"

### DIFF
--- a/core/core/src/main/java/org/visallo/core/model/properties/VisalloProperties.java
+++ b/core/core/src/main/java/org/visallo/core/model/properties/VisalloProperties.java
@@ -15,6 +15,7 @@ public class VisalloProperties {
     public static final StringMetadataVisalloProperty TEXT_DESCRIPTION_METADATA = new StringMetadataVisalloProperty("http://visallo.org#textDescription");
     public static final StringMetadataVisalloProperty MIME_TYPE_METADATA = new StringMetadataVisalloProperty("http://visallo.org#mimeType");
     public static final StringMetadataVisalloProperty SOURCE_FILE_NAME_METADATA = new StringMetadataVisalloProperty("http://visallo.org#sourceFileName");
+    public static final StringMetadataVisalloProperty LINK_TITLE_METADATA = new StringMetadataVisalloProperty("http://visallo.org#linkTitle");
     public static final LongMetadataVisalloProperty SOURCE_FILE_OFFSET_METADATA = new LongMetadataVisalloProperty("http://visallo.org#sourceFileOffset");
 
     public static final DateSingleValueVisalloProperty MODIFIED_DATE = new DateSingleValueVisalloProperty("http://visallo.org#modifiedDate");

--- a/core/core/src/main/resources/org/visallo/core/model/ontology/base.owl
+++ b/core/core/src/main/resources/org/visallo/core/model/ontology/base.owl
@@ -543,6 +543,16 @@
     
 
 
+    <!-- http://visallo.org#linkTitle -->
+
+    <owl:DatatypeProperty rdf:about="http://visallo.org#linkTitle">
+        <userVisible>false</userVisible>
+        <textIndexHints>NONE</textIndexHints>
+        <rdfs:range rdf:resource="&xsd;string"/>
+    </owl:DatatypeProperty>
+    
+
+
     <!-- http://visallo.org#mappingJson -->
 
     <owl:DatatypeProperty rdf:about="http://visallo.org#mappingJson">

--- a/web/war/src/main/webapp/js/util/vertex/formatters.js
+++ b/web/war/src/main/webapp/js/util/vertex/formatters.js
@@ -168,7 +168,8 @@ define([
                 link: function(el, property, vertex) {
                     var anchor = document.createElement('a'),
                         value = V.prop(vertex, property.name),
-                        href = $.trim(value);
+                        href = $.trim(value),
+                        linkTitle = property.metadata['http://visallo.org#linkTitle'];
 
                     if (!(/^http/).test(href)) {
                         href = 'http://' + href;
@@ -176,7 +177,7 @@ define([
 
                     anchor.setAttribute('href', href);
                     anchor.setAttribute('target', '_blank');
-                    anchor.textContent = href;
+                    anchor.textContent = linkTitle || href;
 
                     el.appendChild(anchor);
                 },


### PR DESCRIPTION
- [x] @joeferner
- [ ] @srfarley @kunklejr
- [x] @mwizeman @dsingley @EvanOxfeld 
- [x] @joeybrk372 @sfeng88 @rygim @jharwig 

Currently links only display their href as the value. This commit
allows you to set property metadata which will be used as the text.

This PR does not address the UI to update the link title metadata. The title needs to be set in code which is probably the usual source of links anyway.

CHANGELOG
Added: Support link title in properties with display type "link"