### PR TITLE
Fix: Add user admin privilges plugin to visallo-dev-jetty-server modu…

### DIFF
--- a/dev/jetty-server/pom.xml
+++ b/dev/jetty-server/pom.xml
@@ -58,6 +58,11 @@
         </dependency>
         <dependency>
             <groupId>org.visallo</groupId>
+            <artifactId>visallo-web-plugins-admin-user-property-privileges</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.visallo</groupId>
             <artifactId>visallo-web-admin-import-rdf</artifactId>
             <version>${project.version}</version>
         </dependency>


### PR DESCRIPTION
- [x] @joeferner
- [ ] @kunklejr
- [x] @mwizeman @dsingley @EvanOxfeld 
- [x] @joeybrk372 @sfeng88 @rygim @jharwig 

Cherry picked steves fix from release-2.2 to master as per his recommendation in https://github.com/v5analytics/visallo/pull/658 

CHANGELOG
Fixed: Add user admin privilges plugin to visallo-dev-jetty-server module

…le (#658)