### PR TITLE
Changed: Moved threading logic for GPW/LRP from initializers to runners

### DIFF
--- a/core/core/src/main/java/org/visallo/core/config/Configuration.java
+++ b/core/core/src/main/java/org/visallo/core/config/Configuration.java
@@ -178,12 +178,12 @@ public class Configuration {
         return subset;
     }
 
-    public void setConfigurables(Object o, String keyPrefix) {
+    public <T> T setConfigurables(T o, String keyPrefix) {
         Map<String, String> subset = getSubset(keyPrefix);
-        setConfigurables(o, subset);
+        return setConfigurables(o, subset);
     }
 
-    public static void setConfigurables(Object o, Map<String, String> config) {
+    public static <T> T setConfigurables(T o, Map<String, String> config) {
         ConvertUtilsBean convertUtilsBean = new ConvertUtilsBean();
         Map<Method, PostConfigurationValidator> validatorMap = new HashMap<>();
 
@@ -220,6 +220,8 @@ public class Configuration {
                 throw new VisalloException("IllegalAccessException invoking validator " + o.getClass().getName() + "." + postConfigurationValidatorMethod.getName(), e);
             }
         }
+
+        return o;
     }
 
     private static List<Field> getAllFields(Object o) {
@@ -388,7 +390,7 @@ public class Configuration {
 
         PrivilegeRepository privilegeRepository = getPrivilegeRepository();
         Set<String> allPrivileges = privilegeRepository.getAllPrivileges().stream()
-                .map(p -> p.getName())
+                .map(Privilege::getName)
                 .collect(Collectors.toSet());
         properties.put("privileges", Privilege.toJson(allPrivileges));
 
@@ -460,7 +462,7 @@ public class Configuration {
         Map<String, Map<String, String>> multiValues = getMultiValue(prefix);
         Map<String, T> results = new HashMap<>();
         for (Map.Entry<String, Map<String, String>> entry : multiValues.entrySet()) {
-            T o = null;
+            T o;
             try {
                 o = configurableType.newInstance();
             } catch (Exception e) {

--- a/core/core/src/main/java/org/visallo/core/ingest/graphProperty/GraphPropertyThreadedWrapper.java
+++ b/core/core/src/main/java/org/visallo/core/ingest/graphProperty/GraphPropertyThreadedWrapper.java
@@ -125,7 +125,7 @@ public class GraphPropertyThreadedWrapper implements Runnable {
                 long startTime = new Date().getTime();
                 while (workResults.size() == 0 && (waitForever || (new Date().getTime() - startTime < 10 * 1000))) {
                     try {
-                        if (new Date().getTime() - startTime > 5 * 1000) {
+                        if (new Date().getTime() - startTime > 60 * 1000) {
                             LOGGER.warn("worker has zero results. sleeping waiting for results.");
                         } else {
                             LOGGER.debug("worker has zero results. sleeping waiting for results.");


### PR DESCRIPTION
- [x] @joeferner
- [ ] @kunklejr
- [ ] @mwizeman @dsingley @EvanOxfeld 
- [x] @joeybrk372 @sfeng88 @rygim @jharwig 

By moving the logic of starting threads from the initializer to the runner
we are able to make standalone applications which start GPW and LRP processing
threads.

CHANGELOG
Changed: Moved threading logic for GPW/LRP from initializers to runners. Allows for making standalone application which start GPW and LRP processing threads.