### PR TITLE
Added: Configurable graph decoration padding

### DIFF
--- a/docs/extension-points/front-end/graphDecorations/index.md
+++ b/docs/extension-points/front-end/graphDecorations/index.md
@@ -17,6 +17,13 @@ Graph decorations are additional detail to display around a vertex when displaye
     * `h`: Horizontal alignment must be one of: `left`, `center`, `right`.
     * `v`: Vertical alignment must be one of: `top`, `center`, `bottom`.
 
+* `padding` _(optional)_ `[Object]`
+    
+    Specifies the padding between the decoration and the vertex.
+
+    * `x`: Horizontal padding.
+    * `y`: Vertical padding.
+
 * `classes` _(optional)_ `[String|Array|Function]`
 
     Class names to add to cytoscape node. This is most used with an [`org.visallo.graph.style`](../graphStyle) extension.

--- a/web/war/src/main/webapp/js/graph/decorations.js
+++ b/web/war/src/main/webapp/js/graph/decorations.js
@@ -311,7 +311,8 @@ define(['configuration/plugins/registry'], function(registry) {
                 decBBoxLabels = decorationNode ?
                     decorationNode.boundingBox({ includeLabels: true }) :
                     { w: 0, h: 0 },
-                padding = 8;
+                paddingX = (extension.padding && extension.padding.hasOwnProperty('x')) ? extension.padding.x : 8,
+                paddingY = (extension.padding && extension.padding.hasOwnProperty('y')) ? extension.padding.y : 8;
 
             switch (extension.alignment.h) {
               case 'center':
@@ -327,7 +328,7 @@ define(['configuration/plugins/registry'], function(registry) {
                 } else {
                     x = specs.position.x + specs.w / 2 + decBBox.w / 2;
                 }
-                x += padding
+                x += paddingX;
                 break;
 
               case 'left':
@@ -340,7 +341,7 @@ define(['configuration/plugins/registry'], function(registry) {
                 } else {
                     x = specs.position.x - specs.w / 2 - decBBox.w / 2;
                 }
-                x -= padding
+                x -= paddingX;
             }
             switch (extension.alignment.v) {
               case 'center':
@@ -349,22 +350,22 @@ define(['configuration/plugins/registry'], function(registry) {
 
               case 'bottom':
                 if (specs.textVAlign === extension.alignment.v && extension.alignment.h === 'center') {
-                    y = specs.position.y - specs.h / 2 + specs.bboxLabels.h + decBBoxLabels.h / 2 + padding;
+                    y = specs.position.y - specs.h / 2 + specs.bboxLabels.h + decBBoxLabels.h / 2 + paddingY;
                 } else if (specs.textVAlign === extension.alignment.v) {
-                    y = specs.position.y + specs.h / 2 + padding + (specs.bboxLabels.h - specs.h - padding) / 2;
+                    y = specs.position.y + specs.h / 2 + paddingY + (specs.bboxLabels.h - specs.h - paddingY) / 2;
                 } else {
-                    y = specs.position.y + specs.h / 2 + decBBoxLabels.h / 2 + padding;
+                    y = specs.position.y + specs.h / 2 + decBBoxLabels.h / 2 + paddingY;
                 }
                 break;
 
               case 'top':
               default:
                 if (specs.textVAlign === extension.alignment.v && extension.alignment.h === 'center') {
-                    y = specs.position.y + specs.h / 2 - specs.bboxLabels.h - decBBoxLabels.h / 2 - padding;
+                    y = specs.position.y + specs.h / 2 - specs.bboxLabels.h - decBBoxLabels.h / 2 - paddingY;
                 } else if (specs.textVAlign === extension.alignment.v) {
-                    y = specs.position.y - specs.h / 2 - padding - (specs.bboxLabels.h - specs.h - padding) / 2;
+                    y = specs.position.y - specs.h / 2 - paddingY - (specs.bboxLabels.h - specs.h - paddingY) / 2;
                 } else {
-                    y = specs.position.y - specs.h / 2 - decBBoxLabels.h / 2 - padding
+                    y = specs.position.y - specs.h / 2 - decBBoxLabels.h / 2 - paddingY
                 }
             }
 


### PR DESCRIPTION
- [x] @joeferner
- [ ] @kunklejr
- [x] @mwizeman @dsingley @EvanOxfeld 
- [ ] @joeybrk372 @sfeng88 @rygim @jharwig 

Before this commit the padding between the node graphic and
the decoration was locked in at 8. This commit adds the ability
to modify the default padding.

CHANGELOG
Added: Configurable graph decoration padding