### PR TITLE
Update archetype script + docs to fix errors

### DIFF
--- a/bin/generate-archetype-project.sh
+++ b/bin/generate-archetype-project.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-set -x
 
 DIR=$(cd $(dirname "$0") && pwd)
 VISALLO_DIR=${DIR}/..

--- a/bin/generate-archetype-project.sh
+++ b/bin/generate-archetype-project.sh
@@ -1,8 +1,16 @@
 #!/usr/bin/env bash
+set -x
 
 DIR=$(cd $(dirname "$0") && pwd)
+VISALLO_DIR=${DIR}/..
+ARCHETYPE_JAR_DIR=$VISALLO_DIR/archetype/target
 
-ARCHETYPE_JAR_DIR=${DIR}/../archetype/target
+cd ${VISALLO_DIR}
+
+mvn clean package -am -pl archetype
+
+cd ${DIR}
+
 VERSION=$(find "${ARCHETYPE_JAR_DIR}" -name "visallo-plugin-archetype-*.jar" | sed -e 's/.*visallo-plugin-archetype-//' -e 's/\.jar$//')
 
 mvn org.apache.maven.plugins:maven-install-plugin:2.5.2:install-file \

--- a/bin/generate-archetype-project.sh
+++ b/bin/generate-archetype-project.sh
@@ -14,3 +14,5 @@ mvn org.apache.maven.plugins:maven-install-plugin:2.5.2:install-file \
     -DgeneratePom=true
 
 mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:crawl
+
+mvn archetype:generate -DarchetypeGroupId=com.visallo -DarchetypeArtifactId=visallo-plugin-archetype -DarchetypeVersion=${VERSION}

--- a/docs/tutorials/starting.md
+++ b/docs/tutorials/starting.md
@@ -10,17 +10,15 @@ One of the major components of Visallo is the system of Graph Property Workers t
 
 ## Getting Started
 
-We will be using maven archetypes to do most of the bootstrapping of Visallo so that we can only focus on developing our graph property worker.
-
-You can either pull down a released Visallo archetype jar from Maven Central or build your own by running `mvn clean package -am -pl archetype` from the Visallo repository.
+We will be using maven archetypes to do most of the bootstrapping of Visallo so that we can focus on developing our graph property worker.
 
 * Run the following command from the Visallo repository:
 
 ```bash
-bin/install-plugin-archetype.sh
+bin/generate-archetype-project.sh
 ```
 
-Maven archetype will ask you a couple of questions:
+The project will be generated and will ask you a couple of questions before it finishes:
 
 * for groupId, put in ```com.visalloexample.helloworld```
 * for artifactId, put in ```visallo-helloworld```


### PR DESCRIPTION
- [x] @joeferner
- [ ] @kunklejr
- [x] @mwizeman @dsingley @EvanOxfeld 
- [x] @joeybrk372 @sfeng88 @rygim @jharwig 


CHANGELOG
Changed: Generate script now builds archetype jar to make sure it is in the correct spot beforehand
Changed: Can now generate project from archetype jar generate script
Documentation: Changed documentation in tutorials to reflect changed script

It was noticed that the recent changes to the archetype jar were
inconsistent with the documentation and there was a gap in the
documentation. I added the ability to generate the project from the
script (and renamed it to make more sense) and fixed the documentation
to address what the script now does