### PR TITLE
Added: Search related from related entities in detail pane

### DIFF
--- a/core/core/src/main/resources/MessageBundle.properties
+++ b/core/core/src/main/resources/MessageBundle.properties
@@ -122,6 +122,7 @@ detail.entity.relationships.paging=Page {0} of {1}
 detail.entity.relationships.has_entity=Referenced In
 detail.entity.relationships.has_entity.artifact=References
 detail.entity.relationships.none_found=No Relationships Found
+detail.entity.relationships.open_in_search=Open in Search...
 detail.entity.relationships.error=Unable to Load Relationships
 detail.entity.sandboxStatus=Status
 detail.edge.type=Type

--- a/web/war/src/main/webapp/js/data/web-worker/services/vertex.js
+++ b/web/war/src/main/webapp/js/data/web-worker/services/vertex.js
@@ -19,7 +19,8 @@ define([
             if (options.conceptFilter && matchType === 'vertex') {
                 params.conceptType = options.conceptFilter;
             }
-            if (options.edgeLabelFilter && matchType === 'edge') {
+            if (options.edgeLabelFilter
+                && (matchType === 'edge' || (options.otherFilters && options.otherFilters.relatedToVertexIds))) {
                 params.edgeLabel = options.edgeLabelFilter;
             }
             if (options.paging) {

--- a/web/war/src/main/webapp/js/detail/relationships/relationships.js
+++ b/web/war/src/main/webapp/js/detail/relationships/relationships.js
@@ -22,6 +22,7 @@ define([
 
         this.defaultAttrs({
             relationshipsHeaderSelector: 'section.collapsible h1',
+            relationshipsSearchRelatedSelector: 'section.collapsible .search-related',
             relationshipsPagingButtonsSelector: 'section.collapsible .paging button'
         });
 
@@ -30,6 +31,7 @@ define([
 
             this.on('click', {
                 relationshipsHeaderSelector: this.onToggleRelationships,
+                relationshipsSearchRelatedSelector: this.onSearchRelated,
                 relationshipsPagingButtonsSelector: this.onPageRelationships
             });
 
@@ -52,6 +54,10 @@ define([
         };
 
         this.onToggleRelationships = function(event) {
+            if ($(event.target).hasClass('search-related')) {
+                return;
+            }
+
             var $section = $(event.target).closest('.collapsible');
 
             if ($section.hasClass('expanded')) {
@@ -62,6 +68,16 @@ define([
                 offset: 0,
                 size: MAX_RELATIONS_TO_DISPLAY
             }));
+        };
+
+        this.onSearchRelated = function(event) {
+            var $target = $(event.target),
+                $section = $target.closest('section');
+
+            this.trigger(document, 'searchByRelatedEntity', {
+                vertexIds: [this.data.id],
+                edgeLabel: $section.data('label')
+            });
         };
 
         this.requestRelationships = function($section) {
@@ -91,7 +107,8 @@ define([
                         return;
                     }
 
-                    var node = $content.empty().append('<div>').find('div');
+                    var node = $content.empty()
+                        .append('<div>').find('div');
 
                     node.teardownComponent(ElementList);
                     ElementList.attachTo(node, {
@@ -188,6 +205,9 @@ define([
                                 this.append('h1')
                                     .call(function() {
                                         this.append('strong');
+                                        this.append('s')
+                                            .attr('class', 'search-related')
+                                            .attr('title', i18n('detail.entity.relationships.open_in_search'));
                                         this.append('span').attr('class', 'badge');
                                     });
                                 this.append('div');

--- a/web/war/src/main/webapp/js/search/filters/filters.js
+++ b/web/war/src/main/webapp/js/search/filters/filters.js
@@ -229,6 +229,7 @@ define([
             this.disableNotify = true;
             Promise.resolve(this.clearFilters({ triggerUpdates: false }))
                 .then(this.setConceptFilter.bind(this, data.conceptId))
+                .then(this.setEdgeTypeFilter.bind(this, data.edgeLabel))
                 .then(this.setRelatedToEntityFilter.bind(this, data.vertexIds))
                 .then(function() {
                     self.disableNotify = false;
@@ -246,6 +247,7 @@ define([
                         title = vertices.length > 1 ? i18n('search.filters.title_multiple', vertices.length)
                                                     : single && F.vertex.title(single) || single.id;
 
+                    self.select('edgeLabelFilterSelector').show();
                     self.otherFilters.relatedToVertexIds = _.pluck(vertices, 'id');
                     self.$node.find('.entity-filters')
                         .append(entityItemTemplate({title: title})).show();
@@ -301,7 +303,7 @@ define([
             this.$node.find('.match-type-edge').closest('label').andSelf()
                 .prop('disabled', this.disableMatchEdges === true);
             this.select('conceptFilterSelector').toggle(type === 'vertex');
-            this.select('edgeLabelFilterSelector').toggle(type === 'edge');
+            this.select('edgeLabelFilterSelector').toggle(type === 'edge' || self.otherFilters.relatedToVertexIds);
             if (this.matchType === 'vertex') {
                 this.setConceptFilter(this.conceptFilter);
             } else {

--- a/web/war/src/main/webapp/less/detail/detail.less
+++ b/web/war/src/main/webapp/less/detail/detail.less
@@ -608,6 +608,34 @@
     background-color: red;
   }
 
+  .org-visallo-relationships {
+    .collapsible > h1 {
+      strong {
+        display: inline;
+        padding-right: 0.75em
+      }
+
+      .search-related {
+        display: inline-block;
+        visibility: hidden;
+        opacity: 0.4;
+        width: 10px;
+        height: 10px;
+        background-image: url(../img/glyphicons/glyphicons_027_search@2x.png);
+        background-repeat: no-repeat;
+        background-size: auto 100%;
+
+        &:hover {
+          opacity: 0.6;
+        }
+      }
+
+      &:hover .search-related {
+        visibility: visible;
+      }
+    }
+  }
+
   .org-visallo-texts {
     .vertex, .artifact {
       cursor: pointer;


### PR DESCRIPTION
- [x] @joeferner
- [x] @kunklejr @mwizeman @sfeng88
- [x] @dsingley @EvanOxfeld 
- [x] @joeybrk372 @rygim @jharwig 

Thanks @jharwig and @joeybrk372 for the help.

If the related items in the details pane is very large it
might be nice to search those related entities and filter them
down. This commit adds a link to the related entities in the
details pane to open in search.

CHANGELOG
Added: Search realted from related entities in detail pane

![image](https://cloud.githubusercontent.com/assets/808857/19010082/e5474eae-8748-11e6-88d3-792a7f120bea.png)
