### PR TITLE
Changed: GraphUpdateContext to return the saved element, also to allow not queueing item on the workqueue

### DIFF
--- a/core/core-test/src/test/java/org/visallo/core/model/graph/GraphRepositoryTest.java
+++ b/core/core-test/src/test/java/org/visallo/core/model/graph/GraphRepositoryTest.java
@@ -1,6 +1,7 @@
 package org.visallo.core.model.graph;
 
 import com.google.common.collect.ImmutableSet;
+import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -12,7 +13,11 @@ import org.vertexium.inmemory.InMemoryGraph;
 import org.vertexium.inmemory.InMemoryGraphConfiguration;
 import org.vertexium.mutation.ElementMutation;
 import org.vertexium.search.DefaultSearchIndex;
+import org.visallo.core.config.Configuration;
+import org.visallo.core.config.ConfigurationLoader;
+import org.visallo.core.config.HashMapConfigurationLoader;
 import org.visallo.core.exception.VisalloResourceNotFoundException;
+import org.visallo.core.model.WorkQueueNames;
 import org.visallo.core.model.properties.VisalloProperties;
 import org.visallo.core.model.properties.types.PropertyMetadata;
 import org.visallo.core.model.termMention.TermMentionRepository;
@@ -21,13 +26,11 @@ import org.visallo.core.model.workQueue.WorkQueueRepository;
 import org.visallo.core.security.DirectVisibilityTranslator;
 import org.visallo.core.security.VisalloVisibility;
 import org.visallo.core.user.User;
+import org.visallo.model.queue.inmemory.InMemoryWorkQueueRepository;
 import org.visallo.web.clientapi.model.ClientApiSourceInfo;
 import org.visallo.web.clientapi.model.VisibilityJson;
 
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 
 import static org.junit.Assert.*;
 import static org.vertexium.util.IterableUtils.toList;
@@ -51,7 +54,6 @@ public class GraphRepositoryTest {
     @Mock
     private TermMentionRepository termMentionRepository;
 
-    @Mock
     private WorkQueueRepository workQueueRepository;
 
     private Authorizations defaultAuthorizations;
@@ -59,11 +61,17 @@ public class GraphRepositoryTest {
 
     @Before
     public void setup() throws Exception {
-        InMemoryGraphConfiguration config = new InMemoryGraphConfiguration(new HashMap<>());
+        Map config = new HashMap();
+        ConfigurationLoader hashMapConfigurationLoader = new HashMapConfigurationLoader(config);
+        Configuration configuration = new Configuration(hashMapConfigurationLoader, new HashMap<>());
+
+        InMemoryGraphConfiguration graphConfig = new InMemoryGraphConfiguration(new HashMap<>());
         QueueIdGenerator idGenerator = new QueueIdGenerator();
         visibilityTranslator = new DirectVisibilityTranslator();
-        graph = InMemoryGraph.create(config, idGenerator, new DefaultSearchIndex(config));
+        graph = InMemoryGraph.create(graphConfig, idGenerator, new DefaultSearchIndex(graphConfig));
         defaultAuthorizations = graph.createAuthorizations();
+        WorkQueueNames workQueueNames = new WorkQueueNames(configuration);
+        workQueueRepository = new InMemoryWorkQueueRepository(graph, workQueueNames, configuration);
 
         graphRepository = new GraphRepository(
                 graph,
@@ -297,17 +305,30 @@ public class GraphRepositoryTest {
 
         try (GraphUpdateContext ctx = graphRepository.beginGraphUpdate(Priority.NORMAL, user1, defaultAuthorizations)) {
             ElementMutation<Vertex> m = graph.prepareVertex("v1", new Visibility(""));
-            ctx.update(m, modifiedDate, visibilityJson, "http://visallo.org/text#concept1", updateContext -> {
+            Vertex v1 = ctx.update(m, modifiedDate, visibilityJson, "http://visallo.org/text#concept1", updateContext -> {
                 VisalloProperties.FILE_NAME.updateProperty(updateContext, "k1", "test1.txt", metadata, new Visibility(""));
             });
+            assertNotNull(v1);
 
             m = graph.prepareVertex("v2", new Visibility(""));
-            ctx.update(m, updateContext -> {
+            Vertex v2 = ctx.update(m, updateContext -> {
                 updateContext.updateBuiltInProperties(modifiedDate, visibilityJson);
                 updateContext.setConceptType("http://visallo.org/text#concept1");
                 VisalloProperties.FILE_NAME.updateProperty(updateContext, "k1", "test2.txt", metadata, new Visibility(""));
             });
+            assertNotNull(v2);
         }
+
+        List<JSONObject> queue = InMemoryWorkQueueRepository.getQueue("graphProperty");
+        assertEquals(8, queue.size());
+        assertWorkQueueContains(queue, "v1", "", VisalloProperties.MODIFIED_DATE.getPropertyName());
+        assertWorkQueueContains(queue, "v1", "", VisalloProperties.VISIBILITY_JSON.getPropertyName());
+        assertWorkQueueContains(queue, "v1", "", VisalloProperties.CONCEPT_TYPE.getPropertyName());
+        assertWorkQueueContains(queue, "v1", "k1", VisalloProperties.FILE_NAME.getPropertyName());
+        assertWorkQueueContains(queue, "v2", "", VisalloProperties.MODIFIED_DATE.getPropertyName());
+        assertWorkQueueContains(queue, "v2", "", VisalloProperties.VISIBILITY_JSON.getPropertyName());
+        assertWorkQueueContains(queue, "v2", "", VisalloProperties.CONCEPT_TYPE.getPropertyName());
+        assertWorkQueueContains(queue, "v2", "k1", VisalloProperties.FILE_NAME.getPropertyName());
 
         Vertex v1 = graph.getVertex("v1", defaultAuthorizations);
         assertEquals("test1.txt", VisalloProperties.FILE_NAME.getFirstPropertyValue(v1));
@@ -315,6 +336,17 @@ public class GraphRepositoryTest {
         assertEquals(modifiedDate, VisalloProperties.MODIFIED_DATE.getPropertyValue(v1));
         assertEquals(user1.getUserId(), VisalloProperties.MODIFIED_BY.getPropertyValue(v1));
         assertEquals(visibilityJson, VisalloProperties.VISIBILITY_JSON.getPropertyValue(v1));
+    }
+
+    private void assertWorkQueueContains(List<JSONObject> queue, String vertexId, String propertyKey, String propertyName) {
+        for (JSONObject item : queue) {
+            if (item.getString("graphVertexId").equals(vertexId)
+                    && item.getString("propertyKey").equals(propertyKey)
+                    && item.getString("propertyName").equals(propertyName)) {
+                return;
+            }
+        }
+        fail("Could not find queue item " + vertexId + ", " + propertyKey + ", " + propertyName);
     }
 
     private void setProperty(Vertex vertex, String value, String workspaceId, Authorizations workspaceAuthorizations) {

--- a/core/core/src/main/java/org/visallo/core/model/graph/ElementUpdateContext.java
+++ b/core/core/src/main/java/org/visallo/core/model/graph/ElementUpdateContext.java
@@ -33,8 +33,9 @@ public class ElementUpdateContext<T extends Element> {
         }
     }
 
-    public void save(Authorizations authorizations) {
+    public T save(Authorizations authorizations) {
         this.element = this.mutation.save(authorizations);
+        return this.element;
     }
 
     public ElementMutation<T> getMutation() {


### PR DESCRIPTION
- [x] @joeferner
- [x] @kunklejr @mwizeman @sfeng88
- [ ] @dsingley @EvanOxfeld 
- [ ] @joeybrk372 @rygim @jharwig 

No changelog necessary, minor change.

Getting the element back after update is a convenience.

Under some conditions such as doing bulk ingest you may not want to queue
items on the work queue.