### PR TITLE
Fixes: Link formatter when multiple links exist

### DIFF
--- a/web/war/src/main/webapp/js/util/vertex/formatters.js
+++ b/web/war/src/main/webapp/js/util/vertex/formatters.js
@@ -167,7 +167,7 @@ define([
 
                 link: function(el, property, vertex) {
                     var anchor = document.createElement('a'),
-                        value = V.prop(vertex, property.name),
+                        value = V.prop(vertex, property.name, property.key),
                         href = $.trim(value),
                         linkTitle = property.metadata['http://visallo.org#linkTitle'];
 


### PR DESCRIPTION
- [x] @joeferner
- [ ] @kunklejr @mwizeman @sfeng88
- [ ] @dsingley @EvanOxfeld 
- [ ] @joeybrk372 @rygim @jharwig 

The property key was not being passed in to get the value
causing the first value to be returned each time