### PR TITLE
Fixed: security exception being thrown instead of returning null when authorization does not exist

### DIFF
--- a/core/plugins/model-vertexium-inmemory/src/test/java/model/workspace/VertexiumWorkspaceRepositoryTest.java
+++ b/core/plugins/model-vertexium-inmemory/src/test/java/model/workspace/VertexiumWorkspaceRepositoryTest.java
@@ -59,6 +59,12 @@ public class VertexiumWorkspaceRepositoryTest extends VertexiumWorkspaceReposito
     }
 
     @Test
+    public void testFindByIdNotExists() {
+        Workspace ws = workspaceRepository.findById("workspaceNotExists", false, user1);
+        assertEquals(null, ws);
+    }
+
+    @Test
     public void testAccessControl() {
         Authorizations allAuths = graph.createAuthorizations(
                 WorkspaceRepository.VISIBILITY_STRING,

--- a/core/plugins/model-vertexium/src/main/java/org/visallo/vertexium/model/workspace/VertexiumWorkspaceRepository.java
+++ b/core/plugins/model-vertexium/src/main/java/org/visallo/vertexium/model/workspace/VertexiumWorkspaceRepository.java
@@ -201,8 +201,14 @@ public class VertexiumWorkspaceRepository extends WorkspaceRepository {
                     authorizations
             );
         } catch (SecurityVertexiumException e) {
+            if (!graphAuthorizationRepository.getGraphAuthorizations().contains(workspaceId)) {
+                return null;
+            }
+
+            String message = String.format("user %s does not have read access to workspace %s", user.getUserId(), workspaceId);
+            LOGGER.warn("%s", message, e);
             throw new VisalloAccessDeniedException(
-                    "user " + user.getUserId() + " does not have read access to workspace " + workspaceId,
+                    message,
                     user,
                     workspaceId
             );


### PR DESCRIPTION
- [x] @joeferner
- [x] @kunklejr @mwizeman @sfeng88
- [ ] @dsingley @EvanOxfeld 
- [ ] @joeybrk372 @rygim @jharwig 

If a Vertexium authorization does not exist a SecurityException is thrown.
This was not being handled properly and should return null