### PR TITLE
Changed: formatters.js#currentTimezone to only be called once for performance

### DIFF
--- a/web/war/src/main/webapp/js/util/formatters.js
+++ b/web/war/src/main/webapp/js/util/formatters.js
@@ -660,9 +660,9 @@ define([
                 return $.extend({}, tz, tzInfo);
             },
 
-            currentTimezone: function() {
+            currentTimezone: _.once(function() {
                 return FORMATTERS.timezone.lookupTimezone(jstz.determine().name());
-            }
+            })
         }
     };
 


### PR DESCRIPTION
- [x] @joeferner
- [x] @kunklejr @mwizeman @sfeng88
- [ ] @dsingley @EvanOxfeld 
- [x] @joeybrk372 @rygim @jharwig 

On IE getting the current timezone is an expensive operation. This
change reduces that overhead by only getting your timezone once
which shouldn't change.