### PR TITLE
Fixed: Histogram animation duration

### DIFF
--- a/web/war/src/main/webapp/js/detail/properties/histograms.js
+++ b/web/war/src/main/webapp/js/detail/properties/histograms.js
@@ -78,7 +78,7 @@ define([
             var self = this,
                 opacityScale = d3.scale.linear().domain([0, 100]).range(SCALE_OPACITY_BASED_ON_WIDTH_RANGE),
                 colorScale = d3.scale.linear().domain([0, 100]).range(SCALE_COLOR_BASED_ON_WIDTH_RANGE),
-                animationDuration = (options && _.isNumber(options.duration)) || ANIMATION_DURATION;
+                animationDuration = (options && _.isNumber(options.duration)) ? options.duration : ANIMATION_DURATION;
 
             var propertySections = _.chain(elements)
                     .map(function(element) {


### PR DESCRIPTION
- [x] @joeferner
- [x] @kunklejr @mwizeman @sfeng88 @diegogrz
- [ ] @dsingley @EvanOxfeld 
- [x] @joeybrk372 @rygim @jharwig 

Before this commit `animationDuration` was being set to true if the option is set.
This commit addresses this.