### PR TITLE
Changed: Deprecate property methods taking PropertyMetadata and Visibility

### DIFF
--- a/core/core-test/src/test/java/org/visallo/core/model/graph/GraphRepositoryTest.java
+++ b/core/core-test/src/test/java/org/visallo/core/model/graph/GraphRepositoryTest.java
@@ -306,7 +306,7 @@ public class GraphRepositoryTest {
         try (GraphUpdateContext ctx = graphRepository.beginGraphUpdate(Priority.NORMAL, user1, defaultAuthorizations)) {
             ElementMutation<Vertex> m = graph.prepareVertex("v1", new Visibility(""));
             Vertex v1 = ctx.update(m, modifiedDate, visibilityJson, "http://visallo.org/text#concept1", updateContext -> {
-                VisalloProperties.FILE_NAME.updateProperty(updateContext, "k1", "test1.txt", metadata, new Visibility(""));
+                VisalloProperties.FILE_NAME.updateProperty(updateContext, "k1", "test1.txt", metadata);
             });
             assertNotNull(v1);
 
@@ -314,7 +314,7 @@ public class GraphRepositoryTest {
             Vertex v2 = ctx.update(m, updateContext -> {
                 updateContext.updateBuiltInProperties(modifiedDate, visibilityJson);
                 updateContext.setConceptType("http://visallo.org/text#concept1");
-                VisalloProperties.FILE_NAME.updateProperty(updateContext, "k1", "test2.txt", metadata, new Visibility(""));
+                VisalloProperties.FILE_NAME.updateProperty(updateContext, "k1", "test2.txt", metadata);
             });
             assertNotNull(v2);
         }

--- a/core/core/src/main/java/org/visallo/core/ingest/FileImport.java
+++ b/core/core/src/main/java/org/visallo/core/ingest/FileImport.java
@@ -243,7 +243,7 @@ public class FileImport {
             VisalloVisibility visalloVisibility = this.visibilityTranslator.toVisibility(visibilityJson);
             Visibility visibility = visalloVisibility.getVisibility();
             Visibility defaultVisibility = visibilityTranslator.getDefaultVisibility();
-            PropertyMetadata propertyMetadata = new PropertyMetadata(user, visibilityJson, visibilityTranslator.getDefaultVisibility());
+            PropertyMetadata propertyMetadata = new PropertyMetadata(user, visibilityJson, visibility);
             VisalloProperties.CONFIDENCE_METADATA.setMetadata(propertyMetadata, 0.1, visibilityTranslator.getDefaultVisibility());
 
             VertexBuilder vertexBuilder;
@@ -253,9 +253,9 @@ public class FileImport {
                 vertexBuilder = this.graph.prepareVertex(predefinedId, visibility);
             }
             List<VisalloPropertyUpdate> changedProperties = new ArrayList<>();
-            VisalloProperties.RAW.updateProperty(changedProperties, null, vertexBuilder, rawValue, propertyMetadata, visibility);
-            VisalloProperties.CONTENT_HASH.updateProperty(changedProperties, null, vertexBuilder, MULTI_VALUE_KEY, hash, propertyMetadata, visibility);
-            VisalloProperties.FILE_NAME.updateProperty(changedProperties, null, vertexBuilder, MULTI_VALUE_KEY, f.getName(), propertyMetadata, visibility);
+            VisalloProperties.RAW.updateProperty(changedProperties, null, vertexBuilder, rawValue, propertyMetadata);
+            VisalloProperties.CONTENT_HASH.updateProperty(changedProperties, null, vertexBuilder, MULTI_VALUE_KEY, hash, propertyMetadata);
+            VisalloProperties.FILE_NAME.updateProperty(changedProperties, null, vertexBuilder, MULTI_VALUE_KEY, f.getName(), propertyMetadata);
             VisalloProperties.MODIFIED_DATE.updateProperty(
                     changedProperties,
                     null,
@@ -342,12 +342,12 @@ public class FileImport {
             VisalloProperty prop = ontologyProperty.getVisalloProperty();
             VisibilityJson propertyVisibilityJson = VisibilityJson.updateVisibilitySourceAndAddWorkspaceId(null, property.getVisibilitySource(), workspace == null ? null : workspace.getWorkspaceId());
             VisalloVisibility propertyVisibility = visibilityTranslator.toVisibility(propertyVisibilityJson);
-            PropertyMetadata propMetadata = new PropertyMetadata(user, visibilityJson, visibilityTranslator.getDefaultVisibility());
+            PropertyMetadata propMetadata = new PropertyMetadata(user, visibilityJson, propertyVisibility.getVisibility());
             for (Map.Entry<String, Object> metadataEntry : property.getMetadata().entrySet()) {
                 propMetadata.add(metadataEntry.getKey(), metadataEntry.getValue(), propertyVisibility.getVisibility());
             }
             //noinspection unchecked
-            prop.updateProperty(changedProperties, null, vertexBuilder, property.getKey(), value, propMetadata, propertyVisibility.getVisibility());
+            prop.updateProperty(changedProperties, null, vertexBuilder, property.getKey(), value, propMetadata);
         }
     }
 

--- a/core/core/src/main/java/org/visallo/core/model/graph/ElementUpdateContext.java
+++ b/core/core/src/main/java/org/visallo/core/model/graph/ElementUpdateContext.java
@@ -8,6 +8,7 @@ import org.vertexium.mutation.EdgeMutation;
 import org.vertexium.mutation.ElementMutation;
 import org.vertexium.mutation.ExistingElementMutation;
 import org.visallo.core.model.properties.VisalloProperties;
+import org.visallo.core.model.properties.types.PropertyMetadata;
 import org.visallo.core.model.properties.types.VisalloPropertyUpdate;
 import org.visallo.core.security.VisibilityTranslator;
 import org.visallo.core.user.User;
@@ -58,6 +59,10 @@ public class ElementUpdateContext<T extends Element> {
         VisalloProperties.MODIFIED_BY.updateProperty(this, user.getUserId(), defaultVisibility);
         VisalloProperties.MODIFIED_DATE.updateProperty(this, modifiedDate, defaultVisibility);
         VisalloProperties.VISIBILITY_JSON.updateProperty(this, visibilityJson, defaultVisibility);
+    }
+
+    public void updateBuiltInProperties(PropertyMetadata propertyMetadata) {
+        updateBuiltInProperties(propertyMetadata.getModifiedDate(), propertyMetadata.getVisibilityJson());
     }
 
     public void setConceptType(String conceptType) {

--- a/core/core/src/main/java/org/visallo/core/model/properties/types/PropertyMetadata.java
+++ b/core/core/src/main/java/org/visallo/core/model/properties/types/PropertyMetadata.java
@@ -40,6 +40,19 @@ public class PropertyMetadata {
         this.visibility = visibility;
     }
 
+    public PropertyMetadata(PropertyMetadata metadata) {
+        this(
+                metadata.getModifiedDate(),
+                metadata.getModifiedBy(),
+                metadata.getConfidence(),
+                metadata.getVisibilityJson(),
+                metadata.getVisibility()
+        );
+        for (AdditionalMetadataItem item : metadata.getAdditionalMetadataItems()) {
+            add(item.getKey(), item.getValue(), item.getVisibility());
+        }
+    }
+
     public Metadata createMetadata() {
         Metadata metadata = new Metadata();
         VisalloProperties.MODIFIED_DATE_METADATA.setMetadata(metadata, modifiedDate, visibility);

--- a/core/core/src/main/java/org/visallo/core/model/properties/types/SingleValueVisalloProperty.java
+++ b/core/core/src/main/java/org/visallo/core/model/properties/types/SingleValueVisalloProperty.java
@@ -143,12 +143,15 @@ public abstract class SingleValueVisalloProperty<TRaw, TGraph> extends VisalloPr
             TRaw newValue,
             Visibility visibility
     ) {
-        updateProperty(ctx.getProperties(), ctx.getElement(), ctx.getMutation(), newValue, (PropertyMetadata) null, null, visibility);
+        updateProperty(ctx.getProperties(), ctx.getElement(), ctx.getMutation(), newValue, (Metadata) null, null, visibility);
     }
 
     /**
      * @param changedPropertiesOut Adds the property to this list if the property value changed
+     * @deprecated Use {@link #updateProperty(List, Element, ElementMutation, Object, PropertyMetadata)}
      */
+    @SuppressWarnings("deprecation")
+    @Deprecated
     public void updateProperty(
             List<VisalloPropertyUpdate> changedPropertiesOut,
             Element element,
@@ -160,18 +163,30 @@ public abstract class SingleValueVisalloProperty<TRaw, TGraph> extends VisalloPr
         updateProperty(changedPropertiesOut, element, m, newValue, metadata, null, visibility);
     }
 
+    public void updateProperty(
+            List<VisalloPropertyUpdate> changedPropertiesOut,
+            Element element,
+            ElementMutation m,
+            TRaw newValue,
+            PropertyMetadata metadata
+    ) {
+        checkNotNull(metadata, "metadata cannot be null");
+        updateProperty(changedPropertiesOut, element, m, newValue, metadata.createMetadata(), null, metadata.getVisibility());
+    }
+
     public <T extends Element> void updateProperty(
             ElementUpdateContext<T> ctx,
             TRaw newValue,
-            PropertyMetadata metadata,
-            Visibility visibility
+            PropertyMetadata metadata
     ) {
-        updateProperty(ctx.getProperties(), ctx.getElement(), ctx.getMutation(), newValue, metadata, null, visibility);
+        updateProperty(ctx.getProperties(), ctx.getElement(), ctx.getMutation(), newValue, metadata.createMetadata(), null, metadata.getVisibility());
     }
 
     /**
      * @param changedPropertiesOut Adds the property to this list if the property value changed
+     * @deprecated Use {@link #updateProperty(List, Element, ElementMutation, Object, PropertyMetadata, Long)}
      */
+    @Deprecated
     public void updateProperty(
             List<VisalloPropertyUpdate> changedPropertiesOut,
             Element element,
@@ -184,14 +199,25 @@ public abstract class SingleValueVisalloProperty<TRaw, TGraph> extends VisalloPr
         updateProperty(changedPropertiesOut, element, m, newValue, metadata == null ? null : metadata.createMetadata(), timestamp, visibility);
     }
 
+    public void updateProperty(
+            List<VisalloPropertyUpdate> changedPropertiesOut,
+            Element element,
+            ElementMutation m,
+            TRaw newValue,
+            PropertyMetadata metadata,
+            Long timestamp
+    ) {
+        checkNotNull(metadata, "metadata cannot be null");
+        updateProperty(changedPropertiesOut, element, m, newValue, metadata.createMetadata(), timestamp, metadata.getVisibility());
+    }
+
     public <T extends Element> void updateProperty(
             ElementUpdateContext<T> ctx,
             TRaw newValue,
             PropertyMetadata metadata,
-            Long timestamp,
-            Visibility visibility
+            Long timestamp
     ) {
-        updateProperty(ctx.getProperties(), ctx.getElement(), ctx.getMutation(), newValue, metadata.createMetadata(), timestamp, visibility);
+        updateProperty(ctx.getProperties(), ctx.getElement(), ctx.getMutation(), newValue, metadata.createMetadata(), timestamp, metadata.getVisibility());
     }
 
     /**

--- a/core/core/src/main/java/org/visallo/core/model/properties/types/VisalloProperty.java
+++ b/core/core/src/main/java/org/visallo/core/model/properties/types/VisalloProperty.java
@@ -10,6 +10,7 @@ import org.visallo.core.util.VisalloLoggerFactory;
 import java.util.Collections;
 import java.util.List;
 
+import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Iterables.*;
 
 public abstract class VisalloProperty<TRaw, TGraph> extends VisalloPropertyBase<TRaw, TGraph> {
@@ -142,7 +143,10 @@ public abstract class VisalloProperty<TRaw, TGraph> extends VisalloPropertyBase<
 
     /**
      * @param changedPropertiesOut Adds the property to this list if the property value changed
+     * @deprecated Use {@link #updateProperty(List, Element, ElementMutation, String, Object, PropertyMetadata)}
      */
+    @SuppressWarnings("deprecation")
+    @Deprecated
     public void updateProperty(
             List<VisalloPropertyUpdate> changedPropertiesOut,
             Element element,
@@ -155,19 +159,36 @@ public abstract class VisalloProperty<TRaw, TGraph> extends VisalloPropertyBase<
         updateProperty(changedPropertiesOut, element, m, propertyKey, newValue, metadata, null, visibility);
     }
 
+    /**
+     * @param changedPropertiesOut Adds the property to this list if the property value changed
+     */
+    public void updateProperty(
+            List<VisalloPropertyUpdate> changedPropertiesOut,
+            Element element,
+            ElementMutation m,
+            String propertyKey,
+            TRaw newValue,
+            PropertyMetadata metadata
+    ) {
+        checkNotNull(metadata, "metadata is required");
+        updateProperty(changedPropertiesOut, element, m, propertyKey, newValue, metadata.createMetadata(), null, metadata.getVisibility());
+    }
+
     public <T extends Element> void updateProperty(
             ElementUpdateContext<T> ctx,
             String propertyKey,
             TRaw newValue,
-            PropertyMetadata metadata,
-            Visibility visibility
+            PropertyMetadata metadata
     ) {
-        updateProperty(ctx.getProperties(), ctx.getElement(), ctx.getMutation(), propertyKey, newValue, metadata, null, visibility);
+        checkNotNull(metadata, "metadata is required");
+        updateProperty(ctx.getProperties(), ctx.getElement(), ctx.getMutation(), propertyKey, newValue, metadata.createMetadata(), null, metadata.getVisibility());
     }
 
     /**
      * @param changedPropertiesOut Adds the property to this list if the property value changed
+     * @deprecated Use {@link #updateProperty(List, Element, ElementMutation, String, Object, PropertyMetadata, Long)}
      */
+    @Deprecated
     public void updateProperty(
             List<VisalloPropertyUpdate> changedPropertiesOut,
             Element element,
@@ -181,15 +202,31 @@ public abstract class VisalloProperty<TRaw, TGraph> extends VisalloPropertyBase<
         updateProperty(changedPropertiesOut, element, m, propertyKey, newValue, metadata.createMetadata(), timestamp, visibility);
     }
 
+    /**
+     * @param changedPropertiesOut Adds the property to this list if the property value changed
+     */
+    public void updateProperty(
+            List<VisalloPropertyUpdate> changedPropertiesOut,
+            Element element,
+            ElementMutation m,
+            String propertyKey,
+            TRaw newValue,
+            PropertyMetadata metadata,
+            Long timestamp
+    ) {
+        checkNotNull(metadata, "metadata is required");
+        updateProperty(changedPropertiesOut, element, m, propertyKey, newValue, metadata.createMetadata(), timestamp, metadata.getVisibility());
+    }
+
     public <T extends Element> void updateProperty(
             ElementUpdateContext<T> ctx,
             String propertyKey,
             TRaw newValue,
             PropertyMetadata metadata,
-            Long timestamp,
-            Visibility visibility
+            Long timestamp
     ) {
-        updateProperty(ctx.getProperties(), ctx.getElement(), ctx.getMutation(), propertyKey, newValue, metadata.createMetadata(), timestamp, visibility);
+        checkNotNull(metadata, "metadata is required");
+        updateProperty(ctx.getProperties(), ctx.getElement(), ctx.getMutation(), propertyKey, newValue, metadata.createMetadata(), timestamp, metadata.getVisibility());
     }
 
     /**


### PR DESCRIPTION
- [x] @joeferner
- [x] @kunklejr @mwizeman @sfeng88 @diegogrz
- [ ] @dsingley @EvanOxfeld 
- [ ] @joeybrk372 @rygim @jharwig 

PropertyMetadata has visibility as a field the visibility argument is
duplicative information.

CHANGELOG
Deprecated: property methods taking PropertyMetadata and Visibility