### PR TITLE
Allow SystemUser to create global searches

### DIFF
--- a/core/core-test/src/main/java/org/visallo/core/model/properties/types/JsonArraySingleValueVisalloPropertyTest.java
+++ b/core/core-test/src/main/java/org/visallo/core/model/properties/types/JsonArraySingleValueVisalloPropertyTest.java
@@ -1,0 +1,16 @@
+package org.visallo.core.model.properties.types;
+
+import org.json.JSONArray;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class JsonArraySingleValueVisalloPropertyTest {
+    @Test
+    public void testEquals() {
+        JsonArraySingleValueVisalloProperty prop = new JsonArraySingleValueVisalloProperty("name");
+        assertTrue(prop.isEquals(new JSONArray("[1,2]"), new JSONArray("[1,2]")));
+        assertFalse(prop.isEquals(new JSONArray("[1,2]"), new JSONArray("[1,2,3]")));
+    }
+}

--- a/core/core-test/src/main/java/org/visallo/core/model/properties/types/JsonArrayVisalloPropertyTest.java
+++ b/core/core-test/src/main/java/org/visallo/core/model/properties/types/JsonArrayVisalloPropertyTest.java
@@ -1,0 +1,16 @@
+package org.visallo.core.model.properties.types;
+
+import org.json.JSONArray;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class JsonArrayVisalloPropertyTest {
+    @Test
+    public void testEquals() {
+        JsonArrayVisalloProperty prop = new JsonArrayVisalloProperty("name");
+        assertTrue(prop.isEquals(new JSONArray("[1,2]"), new JSONArray("[1,2]")));
+        assertFalse(prop.isEquals(new JSONArray("[1,2]"), new JSONArray("[1,2,3]")));
+    }
+}

--- a/core/core-test/src/main/java/org/visallo/core/model/properties/types/JsonSingleValueVisalloPropertyTest.java
+++ b/core/core-test/src/main/java/org/visallo/core/model/properties/types/JsonSingleValueVisalloPropertyTest.java
@@ -1,0 +1,16 @@
+package org.visallo.core.model.properties.types;
+
+import org.json.JSONObject;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class JsonSingleValueVisalloPropertyTest {
+    @Test
+    public void testEquals() {
+        JsonSingleValueVisalloProperty prop = new JsonSingleValueVisalloProperty("name");
+        assertTrue(prop.isEquals(new JSONObject("{a:1}"), new JSONObject("{a:1}")));
+        assertFalse(prop.isEquals(new JSONObject("{a:1}"), new JSONObject("{a:1,b:2}")));
+    }
+}

--- a/core/core-test/src/main/java/org/visallo/core/model/properties/types/JsonVisalloPropertyTest.java
+++ b/core/core-test/src/main/java/org/visallo/core/model/properties/types/JsonVisalloPropertyTest.java
@@ -1,0 +1,16 @@
+package org.visallo.core.model.properties.types;
+
+import org.json.JSONObject;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class JsonVisalloPropertyTest {
+    @Test
+    public void testEquals() {
+        JsonVisalloProperty prop = new JsonVisalloProperty("name");
+        assertTrue(prop.isEquals(new JSONObject("{a:1}"), new JSONObject("{a:1}")));
+        assertFalse(prop.isEquals(new JSONObject("{a:1}"), new JSONObject("{a:1,b:2}")));
+    }
+}

--- a/core/core/src/main/java/org/visallo/core/model/graph/ElementUpdateContext.java
+++ b/core/core/src/main/java/org/visallo/core/model/graph/ElementUpdateContext.java
@@ -38,6 +38,10 @@ public class ElementUpdateContext<T extends Element> {
         return this.element;
     }
 
+    public boolean isNewElement() {
+        return getElement() == null;
+    }
+
     public ElementMutation<T> getMutation() {
         return mutation;
     }

--- a/core/core/src/main/java/org/visallo/core/model/properties/types/JsonArraySingleValueVisalloProperty.java
+++ b/core/core/src/main/java/org/visallo/core/model/properties/types/JsonArraySingleValueVisalloProperty.java
@@ -1,7 +1,7 @@
 package org.visallo.core.model.properties.types;
 
-import org.visallo.core.util.JSONUtil;
 import org.json.JSONArray;
+import org.visallo.core.util.JSONUtil;
 
 public class JsonArraySingleValueVisalloProperty extends SingleValueVisalloProperty<JSONArray, String> {
     public JsonArraySingleValueVisalloProperty(String key) {
@@ -19,5 +19,10 @@ public class JsonArraySingleValueVisalloProperty extends SingleValueVisalloPrope
             return null;
         }
         return JSONUtil.parseArray(value.toString());
+    }
+
+    @Override
+    protected boolean isEquals(JSONArray newValue, JSONArray currentValue) {
+        return JSONUtil.areEqual(newValue, currentValue);
     }
 }

--- a/core/core/src/main/java/org/visallo/core/model/properties/types/JsonArrayVisalloProperty.java
+++ b/core/core/src/main/java/org/visallo/core/model/properties/types/JsonArrayVisalloProperty.java
@@ -1,7 +1,7 @@
 package org.visallo.core.model.properties.types;
 
-import org.visallo.core.util.JSONUtil;
 import org.json.JSONArray;
+import org.visallo.core.util.JSONUtil;
 
 public class JsonArrayVisalloProperty extends VisalloProperty<JSONArray, String> {
     public JsonArrayVisalloProperty(String key) {
@@ -19,5 +19,10 @@ public class JsonArrayVisalloProperty extends VisalloProperty<JSONArray, String>
             return null;
         }
         return JSONUtil.parseArray(value.toString());
+    }
+
+    @Override
+    protected boolean isEquals(JSONArray newValue, JSONArray currentValue) {
+        return JSONUtil.areEqual(newValue, currentValue);
     }
 }

--- a/core/core/src/main/java/org/visallo/core/model/properties/types/JsonSingleValueVisalloProperty.java
+++ b/core/core/src/main/java/org/visallo/core/model/properties/types/JsonSingleValueVisalloProperty.java
@@ -1,7 +1,7 @@
 package org.visallo.core.model.properties.types;
 
-import org.visallo.core.util.JSONUtil;
 import org.json.JSONObject;
+import org.visallo.core.util.JSONUtil;
 
 public class JsonSingleValueVisalloProperty extends SingleValueVisalloProperty<JSONObject, String> {
     public JsonSingleValueVisalloProperty(String key) {
@@ -19,5 +19,10 @@ public class JsonSingleValueVisalloProperty extends SingleValueVisalloProperty<J
             return null;
         }
         return JSONUtil.parse(value.toString());
+    }
+
+    @Override
+    protected boolean isEquals(JSONObject newValue, JSONObject currentValue) {
+        return JSONUtil.areEqual(newValue, currentValue);
     }
 }

--- a/core/core/src/main/java/org/visallo/core/model/properties/types/JsonVisalloProperty.java
+++ b/core/core/src/main/java/org/visallo/core/model/properties/types/JsonVisalloProperty.java
@@ -1,7 +1,7 @@
 package org.visallo.core.model.properties.types;
 
-import org.visallo.core.util.JSONUtil;
 import org.json.JSONObject;
+import org.visallo.core.util.JSONUtil;
 
 public class JsonVisalloProperty extends VisalloProperty<JSONObject, String> {
     public JsonVisalloProperty(String key) {
@@ -19,5 +19,10 @@ public class JsonVisalloProperty extends VisalloProperty<JSONObject, String> {
             return null;
         }
         return JSONUtil.parse(value.toString());
+    }
+
+    @Override
+    protected boolean isEquals(JSONObject newValue, JSONObject currentValue) {
+        return JSONUtil.areEqual(newValue, currentValue);
     }
 }

--- a/core/core/src/main/java/org/visallo/core/model/properties/types/SingleValueVisalloProperty.java
+++ b/core/core/src/main/java/org/visallo/core/model/properties/types/SingleValueVisalloProperty.java
@@ -237,11 +237,11 @@ public abstract class SingleValueVisalloProperty<TRaw, TGraph> extends VisalloPr
             LOGGER.error("passing an empty string value to updateProperty will not be allowed in the future: %s", this);
             return;
         }
-        Object currentValue = null;
+        TRaw currentValue = null;
         if (element != null) {
             currentValue = getPropertyValue(element);
         }
-        if (currentValue == null || !newValue.equals(currentValue)) {
+        if (currentValue == null || !isEquals(newValue, currentValue)) {
             setProperty(m, newValue, metadata, timestamp, visibility);
             changedPropertiesOut.add(new VisalloPropertyUpdate(this));
         }

--- a/core/core/src/main/java/org/visallo/core/model/properties/types/VisalloProperty.java
+++ b/core/core/src/main/java/org/visallo/core/model/properties/types/VisalloProperty.java
@@ -238,11 +238,11 @@ public abstract class VisalloProperty<TRaw, TGraph> extends VisalloPropertyBase<
             LOGGER.error("passing an empty string value to updateProperty will not be allowed in the future: %s", this);
             return;
         }
-        Object currentValue = null;
+        TRaw currentValue = null;
         if (element != null) {
             currentValue = getPropertyValue(element, propertyKey);
         }
-        if (currentValue == null || !newValue.equals(currentValue)) {
+        if (currentValue == null || !isEquals(newValue, currentValue)) {
             addPropertyValue(m, propertyKey, newValue, metadata, timestamp, visibility);
             changedPropertiesOut.add(new VisalloPropertyUpdate(this, propertyKey));
         }

--- a/core/core/src/main/java/org/visallo/core/model/properties/types/VisalloPropertyBase.java
+++ b/core/core/src/main/java/org/visallo/core/model/properties/types/VisalloPropertyBase.java
@@ -3,6 +3,8 @@ package org.visallo.core.model.properties.types;
 import com.google.common.base.Function;
 import org.vertexium.Property;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 /**
  * A VisalloProperty provides convenience methods for converting standard
  * property values to and from their raw types to the types required to
@@ -57,6 +59,12 @@ public abstract class VisalloPropertyBase<TRaw, TGraph> {
         public TRaw apply(final Object input) {
             return unwrap(input);
         }
+    }
+
+    protected boolean isEquals(TRaw newValue, TRaw currentValue) {
+        checkNotNull(newValue, "newValue cannot be null");
+        checkNotNull(currentValue, "currentValue cannot be null");
+        return newValue.equals(currentValue);
     }
 
     @Override

--- a/core/core/src/main/java/org/visallo/core/model/search/SearchOptions.java
+++ b/core/core/src/main/java/org/visallo/core/model/search/SearchOptions.java
@@ -44,6 +44,10 @@ public class SearchOptions {
     }
 
     private <T> T objectToType(Object obj, Class<T> resultType) {
+        if (obj != null && resultType == obj.getClass()) {
+            //noinspection unchecked
+            return (T) obj;
+        }
         if (resultType == Integer.class && obj instanceof String) {
             return resultType.cast(Integer.parseInt((String) obj));
         }
@@ -55,6 +59,9 @@ public class SearchOptions {
         }
         if (resultType == JSONArray.class && obj instanceof String) {
             return resultType.cast(new JSONArray((String) obj));
+        }
+        if (resultType == JSONArray.class && obj instanceof String[]) {
+            return resultType.cast(new JSONArray(obj));
         }
         return resultType.cast(obj);
     }

--- a/core/plugins/model-vertexium/src/main/java/org/visallo/vertexium/model/search/VertexiumSearchRepository.java
+++ b/core/plugins/model-vertexium/src/main/java/org/visallo/vertexium/model/search/VertexiumSearchRepository.java
@@ -7,14 +7,18 @@ import org.json.JSONObject;
 import org.vertexium.*;
 import org.visallo.core.config.Configuration;
 import org.visallo.core.exception.VisalloAccessDeniedException;
-import org.visallo.core.model.properties.VisalloProperties;
+import org.visallo.core.exception.VisalloException;
+import org.visallo.core.model.graph.GraphRepository;
+import org.visallo.core.model.graph.GraphUpdateContext;
 import org.visallo.core.model.search.SearchProperties;
 import org.visallo.core.model.search.SearchRepository;
 import org.visallo.core.model.user.AuthorizationRepository;
 import org.visallo.core.model.user.GraphAuthorizationRepository;
 import org.visallo.core.model.user.PrivilegeRepository;
 import org.visallo.core.model.user.UserRepository;
+import org.visallo.core.model.workQueue.Priority;
 import org.visallo.core.security.VisalloVisibility;
+import org.visallo.core.user.SystemUser;
 import org.visallo.core.user.User;
 import org.visallo.core.util.ClientApiConverter;
 import org.visallo.web.clientapi.model.ClientApiSearch;
@@ -31,6 +35,7 @@ public class VertexiumSearchRepository extends SearchRepository {
     public static final VisalloVisibility VISIBILITY = new VisalloVisibility(VISIBILITY_STRING);
     private static final String GLOBAL_SAVED_SEARCHES_ROOT_VERTEX_ID = "__visallo_globalSavedSearchesRoot";
     private final Graph graph;
+    private final GraphRepository graphRepository;
     private final UserRepository userRepository;
     private final AuthorizationRepository authorizationRepository;
     private final PrivilegeRepository privilegeRepository;
@@ -38,6 +43,7 @@ public class VertexiumSearchRepository extends SearchRepository {
     @Inject
     public VertexiumSearchRepository(
             Graph graph,
+            GraphRepository graphRepository,
             UserRepository userRepository,
             Configuration configuration,
             GraphAuthorizationRepository graphAuthorizationRepository,
@@ -46,6 +52,7 @@ public class VertexiumSearchRepository extends SearchRepository {
     ) {
         super(configuration);
         this.graph = graph;
+        this.graphRepository = graphRepository;
         this.userRepository = userRepository;
         this.authorizationRepository = authorizationRepository;
         this.privilegeRepository = privilegeRepository;
@@ -81,23 +88,27 @@ public class VertexiumSearchRepository extends SearchRepository {
             }
         }
 
-        Vertex searchVertex = saveSearchVertex(id, name, url, searchParameters, authorizations);
+        try (GraphUpdateContext ctx = graphRepository.beginGraphUpdate(Priority.LOW, user, authorizations)) {
+            Vertex searchVertex = saveSearchVertex(ctx, id, name, url, searchParameters, authorizations);
 
-        Vertex userVertex = graph.getVertex(user.getUserId(), authorizations);
-        checkNotNull(userVertex, "Could not find user vertex with id " + user.getUserId());
-        String edgeId = userVertex.getId() + "_" + SearchProperties.HAS_SAVED_SEARCH + "_" + searchVertex.getId();
-        graph.addEdge(
-                edgeId,
-                userVertex,
-                searchVertex,
-                SearchProperties.HAS_SAVED_SEARCH,
-                VISIBILITY.getVisibility(),
-                authorizations
-        );
+            Vertex userVertex = graph.getVertex(user.getUserId(), authorizations);
+            checkNotNull(userVertex, "Could not find user vertex with id " + user.getUserId());
+            String edgeId = userVertex.getId() + "_" + SearchProperties.HAS_SAVED_SEARCH + "_" + searchVertex.getId();
+            if (graph.getEdge(edgeId, authorizations) == null) {
+                graph.addEdge(
+                        edgeId,
+                        userVertex,
+                        searchVertex,
+                        SearchProperties.HAS_SAVED_SEARCH,
+                        VISIBILITY.getVisibility(),
+                        authorizations
+                );
+            }
 
-        graph.flush();
-
-        return searchVertex.getId();
+            return searchVertex.getId();
+        } catch (Exception ex) {
+            throw new VisalloException("Could not save search", ex);
+        }
     }
 
     @Override
@@ -108,7 +119,7 @@ public class VertexiumSearchRepository extends SearchRepository {
             JSONObject searchParameters,
             User user
     ) {
-        if (!privilegeRepository.hasPrivilege(user, Privilege.SEARCH_SAVE_GLOBAL)) {
+        if (!(user instanceof SystemUser) && !privilegeRepository.hasPrivilege(user, Privilege.SEARCH_SAVE_GLOBAL)) {
             throw new VisalloAccessDeniedException(
                     "User does not have the privilege to save a global search", user, id);
         }
@@ -124,42 +135,45 @@ public class VertexiumSearchRepository extends SearchRepository {
             deleteSearch(id, user);
         }
 
-        Vertex searchVertex = saveSearchVertex(id, name, url, searchParameters, authorizations);
+        try (GraphUpdateContext ctx = graphRepository.beginGraphUpdate(Priority.LOW, user, authorizations)) {
+            Vertex searchVertex = saveSearchVertex(ctx, id, name, url, searchParameters, authorizations);
 
-        String edgeId = String.format(
-                "%s_%s_%s",
-                GLOBAL_SAVED_SEARCHES_ROOT_VERTEX_ID, SearchProperties.HAS_SAVED_SEARCH, searchVertex.getId());
-        graph.addEdge(
-                edgeId,
-                getGlobalSavedSearchesRootVertex(),
-                searchVertex,
-                SearchProperties.HAS_SAVED_SEARCH,
-                VISIBILITY.getVisibility(),
-                authorizations
-        );
+            String edgeId = String.format(
+                    "%s_%s_%s",
+                    GLOBAL_SAVED_SEARCHES_ROOT_VERTEX_ID, SearchProperties.HAS_SAVED_SEARCH, searchVertex.getId()
+            );
+            if (graph.getEdge(edgeId, authorizations) == null) {
+                graph.addEdge(
+                        edgeId,
+                        getGlobalSavedSearchesRootVertex(),
+                        searchVertex,
+                        SearchProperties.HAS_SAVED_SEARCH,
+                        VISIBILITY.getVisibility(),
+                        authorizations
+                );
+            }
 
-        graph.flush();
-
-        return searchVertex.getId();
+            return searchVertex.getId();
+        } catch (Exception ex) {
+            throw new VisalloException("Could not save global search", ex);
+        }
     }
 
     private Vertex saveSearchVertex(
+            GraphUpdateContext ctx,
             String id,
             String name,
             String url,
             JSONObject searchParameters,
             Authorizations authorizations
     ) {
-        VertexBuilder searchVertexBuilder = graph.prepareVertex(id, VISIBILITY.getVisibility());
-        VisalloProperties.CONCEPT_TYPE.setProperty(
-                searchVertexBuilder,
-                SearchProperties.CONCEPT_TYPE_SAVED_SEARCH,
-                VISIBILITY.getVisibility()
-        );
-        SearchProperties.NAME.setProperty(searchVertexBuilder, name != null ? name : "", VISIBILITY.getVisibility());
-        SearchProperties.URL.setProperty(searchVertexBuilder, url, VISIBILITY.getVisibility());
-        SearchProperties.PARAMETERS.setProperty(searchVertexBuilder, searchParameters, VISIBILITY.getVisibility());
-        return searchVertexBuilder.save(authorizations);
+        Visibility visibility = VISIBILITY.getVisibility();
+        return ctx.getOrCreateVertexAndUpdate(id, visibility, elemCtx -> {
+            elemCtx.setConceptType(SearchProperties.CONCEPT_TYPE_SAVED_SEARCH);
+            SearchProperties.NAME.updateProperty(elemCtx, name != null ? name : "", visibility);
+            SearchProperties.URL.updateProperty(elemCtx, url, visibility);
+            SearchProperties.PARAMETERS.updateProperty(elemCtx, searchParameters, visibility);
+        });
     }
 
     @Override
@@ -264,8 +278,7 @@ public class VertexiumSearchRepository extends SearchRepository {
                 throw new VisalloAccessDeniedException(
                         "User does not have the privilege to delete a global search", user, id);
             }
-        }
-        else if (!isSearchPrivateToUser(id, user, authorizations)) {
+        } else if (!isSearchPrivateToUser(id, user, authorizations)) {
             throw new VisalloAccessDeniedException("User does not own this this search", user, id);
         }
 
@@ -288,6 +301,9 @@ public class VertexiumSearchRepository extends SearchRepository {
 
     @VisibleForTesting
     boolean isSearchPrivateToUser(String id, User user, Authorizations authorizations) {
+        if (user instanceof SystemUser) {
+            return false;
+        }
         Vertex userVertex = graph.getVertex(user.getUserId(), authorizations);
         checkNotNull(userVertex, "Could not find user vertex with id " + user.getUserId());
         Iterable<String> vertexIds = userVertex.getVertexIds(

--- a/core/plugins/model-vertexium/src/test/java/org/visallo/vertexium/model/search/VertexiumSearchRepositoryTest.java
+++ b/core/plugins/model-vertexium/src/test/java/org/visallo/vertexium/model/search/VertexiumSearchRepositoryTest.java
@@ -14,12 +14,16 @@ import org.visallo.core.bootstrap.InjectHelper;
 import org.visallo.core.config.Configuration;
 import org.visallo.core.exception.VisalloAccessDeniedException;
 import org.visallo.core.exception.VisalloException;
+import org.visallo.core.model.graph.GraphRepository;
 import org.visallo.core.model.properties.VisalloProperties;
 import org.visallo.core.model.search.SearchProperties;
 import org.visallo.core.model.user.AuthorizationRepository;
 import org.visallo.core.model.user.GraphAuthorizationRepository;
 import org.visallo.core.model.user.PrivilegeRepository;
 import org.visallo.core.model.user.UserRepository;
+import org.visallo.core.model.workQueue.WorkQueueRepository;
+import org.visallo.core.security.DirectVisibilityTranslator;
+import org.visallo.core.security.VisibilityTranslator;
 import org.visallo.core.user.User;
 import org.visallo.web.clientapi.model.ClientApiSearch;
 import org.visallo.web.clientapi.model.ClientApiSearchListResponse;
@@ -71,6 +75,9 @@ public class VertexiumSearchRepositoryTest {
     @Mock
     private PrivilegeRepository privilegeRepository;
 
+    @Mock
+    private WorkQueueRepository workQueueRepository;
+
     @Before
     public void setUp() {
         InjectHelper.setInjector(injector);
@@ -80,8 +87,11 @@ public class VertexiumSearchRepositoryTest {
                 VertexiumSearchRepository.VISIBILITY_STRING,
                 UserRepository.VISIBILITY_STRING
         );
+        VisibilityTranslator visibilityTranslator = new DirectVisibilityTranslator();
+        GraphRepository graphRepository = new GraphRepository(graph, visibilityTranslator, null, workQueueRepository);
         searchRepository = new VertexiumSearchRepository(
                 graph,
+                graphRepository,
                 userRepository,
                 configuration,
                 graphAuthorizationRepository,


### PR DESCRIPTION
- [x] @joeferner
- [x] @kunklejr @mwizeman @sfeng88 @diegogrz
- [ ] @dsingley @EvanOxfeld 
- [ ] @joeybrk372 @rygim @jharwig 

This PR has 4 commits all building on each other. See the commit messages for more details. Essentially this PR allows the SystemUser to create global searches. While adding the saved search I found a couple issues and optimizations.

CHANGELOG
Fixed: Avoid JSON updates being added to update list if they have not changed
Changed: VertexiumSearchRepository to allow the SystemUser to save global searches
Added: getOrCreateVertexAndUpdate helper method to GraphUpdateContext
Added: additional handling of conversions in SearchOptions#objectToType
