### PR TITLE
Changed: Getting elements from the server no longer returns all acl if they are the default

### DIFF
--- a/core/core-test/src/test/java/org/visallo/core/security/ACLProviderTest.java
+++ b/core/core-test/src/test/java/org/visallo/core/security/ACLProviderTest.java
@@ -275,13 +275,13 @@ public class ACLProviderTest {
         when(user1CommentProperty.getMetadata()).thenReturn(user1CommentMetadata);
         when(vertex.getProperty(COMMENT_PROP_KEY, COMMENT.getPropertyName())).thenReturn(user1CommentProperty);
 
-        when(aclProvider.canUpdateElement(eq(vertex), any(User.class)))
+        when(aclProvider.canUpdateElement(eq(vertex), any(), any(User.class)))
                 .thenReturn(true);
-        when(aclProvider.canUpdateProperty(eq(vertex), eq(COMMENT_PROP_KEY), eq(COMMENT_PROP_NAME), any(User.class)))
+        when(aclProvider.canUpdateProperty(eq(vertex), any(), eq(COMMENT_PROP_KEY), eq(COMMENT_PROP_NAME), any(User.class)))
                 .thenReturn(true);
-        when(aclProvider.canAddProperty(eq(vertex), eq(COMMENT_PROP_KEY), eq(COMMENT_PROP_NAME), any(User.class)))
+        when(aclProvider.canAddProperty(eq(vertex), any(), eq(COMMENT_PROP_KEY), eq(COMMENT_PROP_NAME), any(User.class)))
                 .thenReturn(true);
-        when(aclProvider.canDeleteProperty(eq(vertex), eq(COMMENT_PROP_KEY), eq(COMMENT_PROP_NAME), any(User.class)))
+        when(aclProvider.canDeleteProperty(eq(vertex), any(), eq(COMMENT_PROP_KEY), eq(COMMENT_PROP_NAME), any(User.class)))
                 .thenReturn(true);
     }
 
@@ -297,15 +297,15 @@ public class ACLProviderTest {
         when(user1RegularProperty.getMetadata()).thenReturn(user1PropertyMetadata);
         when(vertex.getProperty(REGULAR_PROP_KEY, REGULAR_PROP_NAME)).thenReturn(user1RegularProperty);
 
-        when(aclProvider.canUpdateElement(vertex, user1)).thenReturn(true);
-        when(aclProvider.canUpdateProperty(vertex, REGULAR_PROP_KEY, REGULAR_PROP_NAME, user1)).thenReturn(true);
-        when(aclProvider.canAddProperty(vertex, REGULAR_PROP_KEY, REGULAR_PROP_NAME, user1)).thenReturn(true);
-        when(aclProvider.canDeleteProperty(vertex, REGULAR_PROP_KEY, REGULAR_PROP_NAME, user1)).thenReturn(true);
+        when(aclProvider.canUpdateElement(eq(vertex), any(), eq(user1))).thenReturn(true);
+        when(aclProvider.canUpdateProperty(eq(vertex), any(), eq(REGULAR_PROP_KEY), eq(REGULAR_PROP_NAME), eq(user1))).thenReturn(true);
+        when(aclProvider.canAddProperty(eq(vertex), any(), eq(REGULAR_PROP_KEY), eq(REGULAR_PROP_NAME), eq(user1))).thenReturn(true);
+        when(aclProvider.canDeleteProperty(eq(vertex), any(), eq(REGULAR_PROP_KEY), eq(REGULAR_PROP_NAME), eq(user1))).thenReturn(true);
 
-        when(aclProvider.canUpdateElement(vertex, user2)).thenReturn(true);
-        when(aclProvider.canUpdateProperty(vertex, REGULAR_PROP_KEY, REGULAR_PROP_NAME, user2)).thenReturn(false);
-        when(aclProvider.canAddProperty(vertex, REGULAR_PROP_KEY, REGULAR_PROP_NAME, user2)).thenReturn(false);
-        when(aclProvider.canDeleteProperty(vertex, REGULAR_PROP_KEY, REGULAR_PROP_NAME, user2)).thenReturn(false);
+        when(aclProvider.canUpdateElement(eq(vertex), any(), eq(user2))).thenReturn(true);
+        when(aclProvider.canUpdateProperty(eq(vertex), any(), eq(REGULAR_PROP_KEY), eq(REGULAR_PROP_NAME), eq(user2))).thenReturn(false);
+        when(aclProvider.canAddProperty(eq(vertex), any(), eq(REGULAR_PROP_KEY), eq(REGULAR_PROP_NAME), eq(user2))).thenReturn(false);
+        when(aclProvider.canDeleteProperty(eq(vertex), any(), eq(REGULAR_PROP_KEY), eq(REGULAR_PROP_NAME), eq(user2))).thenReturn(false);
     }
 
     @Test
@@ -330,28 +330,28 @@ public class ACLProviderTest {
             apiElement = ClientApiConverter.toClientApiEdge((Edge) element, null);
         }
 
-        when(aclProvider.canUpdateElement(apiElement, user1)).thenReturn(true);
-        when(aclProvider.canDeleteElement(apiElement, user1)).thenReturn(true);
+        when(aclProvider.canUpdateElement(eq(apiElement), any(), eq(user1))).thenReturn(true);
+        when(aclProvider.canDeleteElement(eq(apiElement), any(), eq(user1))).thenReturn(true);
 
-        when(aclProvider.canAddProperty(apiElement, "keyA", "prop1", user1)).thenReturn(true);
-        when(aclProvider.canUpdateProperty(apiElement, "keyA", "prop1", user1)).thenReturn(false);
-        when(aclProvider.canDeleteProperty(apiElement, "keyA", "prop1", user1)).thenReturn(true);
+        when(aclProvider.canAddProperty(eq(apiElement), any(), eq("keyA"), eq("prop1"), eq(user1))).thenReturn(true);
+        when(aclProvider.canUpdateProperty(eq(apiElement), any(), eq("keyA"), eq("prop1"), eq(user1))).thenReturn(false);
+        when(aclProvider.canDeleteProperty(eq(apiElement), any(), eq("keyA"), eq("prop1"), eq(user1))).thenReturn(true);
 
-        when(aclProvider.canAddProperty(apiElement, "keyA", "prop2", user1)).thenReturn(false);
-        when(aclProvider.canUpdateProperty(apiElement, "keyA", "prop2", user1)).thenReturn(true);
-        when(aclProvider.canDeleteProperty(apiElement, "keyA", "prop2", user1)).thenReturn(false);
+        when(aclProvider.canAddProperty(eq(apiElement), any(), eq("keyA"), eq("prop2"), eq(user1))).thenReturn(false);
+        when(aclProvider.canUpdateProperty(eq(apiElement), any(), eq("keyA"), eq("prop2"), eq(user1))).thenReturn(true);
+        when(aclProvider.canDeleteProperty(eq(apiElement), any(), eq("keyA"), eq("prop2"), eq(user1))).thenReturn(false);
 
-        when(aclProvider.canAddProperty(apiElement, "keyB", "prop2", user1)).thenReturn(true);
-        when(aclProvider.canUpdateProperty(apiElement, "keyB", "prop2", user1)).thenReturn(false);
-        when(aclProvider.canDeleteProperty(apiElement, "keyB", "prop2", user1)).thenReturn(true);
+        when(aclProvider.canAddProperty(eq(apiElement), any(), eq("keyB"), eq("prop2"), eq(user1))).thenReturn(true);
+        when(aclProvider.canUpdateProperty(eq(apiElement), any(), eq("keyB"), eq("prop2"), eq(user1))).thenReturn(false);
+        when(aclProvider.canDeleteProperty(eq(apiElement), any(), eq("keyB"), eq("prop2"), eq(user1))).thenReturn(true);
 
-        when(aclProvider.canAddProperty(apiElement, "keyA", "prop3", user1)).thenReturn(false);
-        when(aclProvider.canUpdateProperty(apiElement, "keyA", "prop3", user1)).thenReturn(true);
-        when(aclProvider.canDeleteProperty(apiElement, "keyA", "prop3", user1)).thenReturn(false);
+        when(aclProvider.canAddProperty(eq(apiElement), any(), eq("keyA"), eq("prop3"), eq(user1))).thenReturn(false);
+        when(aclProvider.canUpdateProperty(eq(apiElement), any(), eq("keyA"), eq("prop3"), eq(user1))).thenReturn(true);
+        when(aclProvider.canDeleteProperty(eq(apiElement), any(), eq("keyA"), eq("prop3"), eq(user1))).thenReturn(false);
 
-        when(aclProvider.canAddProperty(apiElement, null, "prop4", user1)).thenReturn(false);
-        when(aclProvider.canUpdateProperty(apiElement, null, "prop4", user1)).thenReturn(true);
-        when(aclProvider.canDeleteProperty(apiElement, null, "prop4", user1)).thenReturn(true);
+        when(aclProvider.canAddProperty(eq(apiElement), any(), eq(null), eq("prop4"), eq(user1))).thenReturn(false);
+        when(aclProvider.canUpdateProperty(eq(apiElement), any(), eq(null), eq("prop4"), eq(user1))).thenReturn(true);
+        when(aclProvider.canDeleteProperty(eq(apiElement), any(), eq(null), eq("prop4"), eq(user1))).thenReturn(true);
 
         apiElement = (ClientApiElement) aclProvider.appendACL(apiElement, user1);
 

--- a/core/core/src/main/java/org/visallo/core/model/ontology/Concept.java
+++ b/core/core/src/main/java/org/visallo/core/model/ontology/Concept.java
@@ -10,7 +10,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.*;
 
-public abstract class Concept implements HasOntologyProperties {
+public abstract class Concept implements OntologyElement, HasOntologyProperties {
     private final String parentConceptIRI;
     private final Collection<OntologyProperty> properties;
 
@@ -39,10 +39,13 @@ public abstract class Concept implements HasOntologyProperties {
 
     public abstract String getTimeFormula();
 
+    @Override
     public abstract boolean getUserVisible();
 
+    @Override
     public abstract boolean getDeleteable();
 
+    @Override
     public abstract boolean getUpdateable();
 
     public abstract Map<String, String> getMetadata();

--- a/core/core/src/main/java/org/visallo/core/model/ontology/OntologyElement.java
+++ b/core/core/src/main/java/org/visallo/core/model/ontology/OntologyElement.java
@@ -1,0 +1,9 @@
+package org.visallo.core.model.ontology;
+
+public interface OntologyElement {
+    boolean getUserVisible();
+
+    boolean getDeleteable();
+
+    boolean getUpdateable();
+}

--- a/core/core/src/main/java/org/visallo/core/model/ontology/Relationship.java
+++ b/core/core/src/main/java/org/visallo/core/model/ontology/Relationship.java
@@ -10,7 +10,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
-public abstract class Relationship implements HasOntologyProperties {
+public abstract class Relationship implements OntologyElement, HasOntologyProperties {
     private final String parentIRI;
     private final List<String> domainConceptIRIs;
     private final List<String> rangeConceptIRIs;
@@ -52,10 +52,13 @@ public abstract class Relationship implements HasOntologyProperties {
         return rangeConceptIRIs;
     }
 
+    @Override
     public abstract boolean getUserVisible();
 
+    @Override
     public abstract boolean getDeleteable();
 
+    @Override
     public abstract boolean getUpdateable();
 
     public abstract String[] getIntents();

--- a/core/core/src/main/java/org/visallo/core/security/AllowAllAclProvider.java
+++ b/core/core/src/main/java/org/visallo/core/security/AllowAllAclProvider.java
@@ -3,6 +3,7 @@ package org.visallo.core.security;
 import com.google.inject.Inject;
 import org.vertexium.Element;
 import org.vertexium.Graph;
+import org.visallo.core.model.ontology.OntologyElement;
 import org.visallo.core.model.ontology.OntologyRepository;
 import org.visallo.core.model.user.PrivilegeRepository;
 import org.visallo.core.model.user.UserRepository;
@@ -21,52 +22,52 @@ public class AllowAllAclProvider extends ACLProvider {
     }
 
     @Override
-    public boolean canDeleteElement(Element element, User user) {
+    public boolean canDeleteElement(Element element, OntologyElement ontologyElement, User user) {
         return true;
     }
 
     @Override
-    public boolean canDeleteElement(ClientApiElement clientApiElement, User user) {
+    public boolean canDeleteElement(ClientApiElement clientApiElement, OntologyElement ontologyElement, User user) {
         return true;
     }
 
     @Override
-    public boolean canDeleteProperty(Element element, String propertyKey, String propertyName, User user) {
+    public boolean canDeleteProperty(Element element, OntologyElement ontologyElement, String propertyKey, String propertyName, User user) {
         return true;
     }
 
     @Override
-    public boolean canDeleteProperty(ClientApiElement clientApiElement, String propertyKey, String propertyName, User user) {
+    public boolean canDeleteProperty(ClientApiElement clientApiElement, OntologyElement ontologyElement, String propertyKey, String propertyName, User user) {
         return true;
     }
 
     @Override
-    public boolean canUpdateElement(Element element, User user) {
+    public boolean canUpdateElement(Element element, OntologyElement ontologyElement, User user) {
         return true;
     }
 
     @Override
-    public boolean canUpdateElement(ClientApiElement clientApiElement, User user) {
+    public boolean canUpdateElement(ClientApiElement clientApiElement, OntologyElement ontologyElement, User user) {
         return true;
     }
 
     @Override
-    public boolean canUpdateProperty(Element element, String propertyKey, String propertyName, User user) {
+    public boolean canUpdateProperty(Element element, OntologyElement ontologyElement, String propertyKey, String propertyName, User user) {
         return true;
     }
 
     @Override
-    public boolean canUpdateProperty(ClientApiElement clientApiElement, String propertyKey, String propertyName, User user) {
+    public boolean canUpdateProperty(ClientApiElement clientApiElement, OntologyElement ontologyElement, String propertyKey, String propertyName, User user) {
         return true;
     }
 
     @Override
-    public boolean canAddProperty(Element element, String propertyKey, String propertyName, User user) {
+    public boolean canAddProperty(Element element, OntologyElement ontologyElement, String propertyKey, String propertyName, User user) {
         return true;
     }
 
     @Override
-    public boolean canAddProperty(ClientApiElement clientApiElement, String propertyKey, String propertyName, User user) {
+    public boolean canAddProperty(ClientApiElement clientApiElement, OntologyElement ontologyElement, String propertyKey, String propertyName, User user) {
         return true;
     }
 }

--- a/core/core/src/main/java/org/visallo/core/security/AllowNoneAclProvider.java
+++ b/core/core/src/main/java/org/visallo/core/security/AllowNoneAclProvider.java
@@ -3,6 +3,7 @@ package org.visallo.core.security;
 import com.google.inject.Inject;
 import org.vertexium.Element;
 import org.vertexium.Graph;
+import org.visallo.core.model.ontology.OntologyElement;
 import org.visallo.core.model.ontology.OntologyRepository;
 import org.visallo.core.model.user.PrivilegeRepository;
 import org.visallo.core.model.user.UserRepository;
@@ -21,52 +22,52 @@ public class AllowNoneAclProvider extends ACLProvider {
     }
 
     @Override
-    public boolean canDeleteElement(Element element, User user) {
+    public boolean canDeleteElement(Element element, OntologyElement ontologyElement, User user) {
         return false;
     }
 
     @Override
-    public boolean canDeleteElement(ClientApiElement clientApiElement, User user) {
+    public boolean canDeleteElement(ClientApiElement clientApiElement, OntologyElement ontologyElement, User user) {
         return false;
     }
 
     @Override
-    public boolean canDeleteProperty(Element element, String propertyKey, String propertyName, User user) {
+    public boolean canDeleteProperty(Element element, OntologyElement ontologyElement, String propertyKey, String propertyName, User user) {
         return false;
     }
 
     @Override
-    public boolean canDeleteProperty(ClientApiElement clientApiElement, String propertyKey, String propertyName, User user) {
+    public boolean canDeleteProperty(ClientApiElement clientApiElement, OntologyElement ontologyElement, String propertyKey, String propertyName, User user) {
         return false;
     }
 
     @Override
-    public boolean canUpdateElement(Element element, User user) {
+    public boolean canUpdateElement(Element element, OntologyElement ontologyElement, User user) {
         return false;
     }
 
     @Override
-    public boolean canUpdateElement(ClientApiElement clientApiElement, User user) {
+    public boolean canUpdateElement(ClientApiElement clientApiElement, OntologyElement ontologyElement, User user) {
         return false;
     }
 
     @Override
-    public boolean canUpdateProperty(Element element, String propertyKey, String propertyName, User user) {
+    public boolean canUpdateProperty(Element element, OntologyElement ontologyElement, String propertyKey, String propertyName, User user) {
         return false;
     }
 
     @Override
-    public boolean canUpdateProperty(ClientApiElement clientApiElement, String propertyKey, String propertyName, User user) {
+    public boolean canUpdateProperty(ClientApiElement clientApiElement, OntologyElement ontologyElement, String propertyKey, String propertyName, User user) {
         return false;
     }
 
     @Override
-    public boolean canAddProperty(Element element, String propertyKey, String propertyName, User user) {
+    public boolean canAddProperty(Element element, OntologyElement ontologyElement, String propertyKey, String propertyName, User user) {
         return false;
     }
 
     @Override
-    public boolean canAddProperty(ClientApiElement clientApiElement, String propertyKey, String propertyName, User user) {
+    public boolean canAddProperty(ClientApiElement clientApiElement, OntologyElement ontologyElement, String propertyKey, String propertyName, User user) {
         return false;
     }
 }

--- a/web/client-api/src/main/java/org/visallo/web/clientapi/model/ClientApiAcl.java
+++ b/web/client-api/src/main/java/org/visallo/web/clientapi/model/ClientApiAcl.java
@@ -35,4 +35,36 @@ public abstract class ClientApiAcl implements ClientApiObject {
     public String toString() {
         return ClientApiConverter.clientApiToString(this);
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        ClientApiAcl that = (ClientApiAcl) o;
+
+        if (addable != that.addable) {
+            return false;
+        }
+        if (updateable != that.updateable) {
+            return false;
+        }
+        if (deleteable != that.deleteable) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = (addable ? 1 : 0);
+        result = 31 * result + (updateable ? 1 : 0);
+        result = 31 * result + (deleteable ? 1 : 0);
+        return result;
+    }
 }

--- a/web/client-api/src/main/java/org/visallo/web/clientapi/model/ClientApiElementAcl.java
+++ b/web/client-api/src/main/java/org/visallo/web/clientapi/model/ClientApiElementAcl.java
@@ -13,4 +13,34 @@ public class ClientApiElementAcl extends ClientApiAcl {
     public void setPropertyAcls(List<ClientApiPropertyAcl> propertyAcls) {
         this.propertyAcls = propertyAcls;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        ClientApiElementAcl that = (ClientApiElementAcl) o;
+
+        if (this.propertyAcls.size() != that.propertyAcls.size()) {
+            return false;
+        }
+
+        for (int i = 0; i < this.propertyAcls.size(); i++) {
+            ClientApiPropertyAcl thisPropertyAcl = this.propertyAcls.get(i);
+            ClientApiPropertyAcl thatPropertyAcl = that.propertyAcls.get(i);
+            if (!thisPropertyAcl.equals(thatPropertyAcl)) {
+                return false;
+            }
+        }
+
+
+        return true;
+    }
 }

--- a/web/client-api/src/main/java/org/visallo/web/clientapi/model/ClientApiPropertyAcl.java
+++ b/web/client-api/src/main/java/org/visallo/web/clientapi/model/ClientApiPropertyAcl.java
@@ -19,4 +19,36 @@ public class ClientApiPropertyAcl extends ClientApiAcl {
     public void setName(String name) {
         this.name = name;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        ClientApiPropertyAcl that = (ClientApiPropertyAcl) o;
+
+        if (key != null ? !key.equals(that.key) : that.key != null) {
+            return false;
+        }
+        if (name != null ? !name.equals(that.name) : that.name != null) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (key != null ? key.hashCode() : 0);
+        result = 31 * result + (name != null ? name.hashCode() : 0);
+        return result;
+    }
 }

--- a/web/war/src/main/webapp/js/detail/dropdowns/propertyForm/propForm.js
+++ b/web/war/src/main/webapp/js/detail/dropdowns/propertyForm/propForm.js
@@ -8,7 +8,8 @@ define([
     'util/withTeardown',
     'util/vertex/vertexSelect',
     'util/vertex/formatters',
-    'util/withDataRequest'
+    'util/withDataRequest',
+    'util/acl'
 ], function(
     require,
     defineComponent,
@@ -19,7 +20,8 @@ define([
     withTeardown,
     VertexSelector,
     F,
-    withDataRequest
+    withDataRequest,
+    acl
 ) {
     'use strict';
 
@@ -117,11 +119,12 @@ define([
             }
 
             ontologyRequest.then(function(ontologyProperties) {
+                var propertyAcls = acl.getPropertyAcls(self.attr.data);
                 FieldSelection.attachTo(self.select('propertyListSelector'), {
                     properties: ontologyProperties.list,
                     focus: true,
                     placeholder: i18n('property.form.field.selection.placeholder'),
-                    unsupportedProperties: _.pluck(_.where(self.attr.data.acl.propertyAcls, { addable: false }), 'name')
+                    unsupportedProperties: _.pluck(_.where(propertyAcls, {addable: false}), 'name')
                 });
                 self.manualOpen();
             });

--- a/web/war/src/main/webapp/js/util/acl.js
+++ b/web/war/src/main/webapp/js/util/acl.js
@@ -1,0 +1,57 @@
+define([
+    './requirejs/promise!./service/ontologyPromise'
+], function(ontology) {
+    'use strict';
+
+    return {
+        getPropertyAcls: function(element) {
+            return mergeElementPropertyAcls(
+                ontologyPropertiesToAclProperties(ontology.properties)
+            );
+
+            function ontologyPropertiesToAclProperties(properties) {
+                return properties.list.map(function(property) {
+                    return {
+                        key: null,
+                        name: property.title,
+                        addable: property.addable,
+                        updateable: property.updateable,
+                        deleteable: property.deleteable
+                    };
+                });
+            }
+
+            function mergeElementPropertyAcls(propertyAcls) {
+                _.each(element.acl.propertyAcls, function(elementPropertyAcl) {
+                    var matches = _.where(propertyAcls, {
+                        name: elementPropertyAcl.name,
+                        key: elementPropertyAcl.keys || null
+                    });
+                    if (matches.length === 0) {
+                        propertyAcls.push(elementPropertyAcl);
+                    } else {
+                        _.each(matches, function(r) {
+                            _.extend(r, elementPropertyAcl);
+                        });
+                    }
+                });
+                return propertyAcls;
+            }
+        },
+
+        findPropertyAcl: function(propertiesAcl, propName, propKey) {
+            var props = _.where(propertiesAcl, {name: propName, key: propKey});
+            if (props.length === 0) {
+                var propsByName = _.where(propertiesAcl, {name: propName});
+                if (propsByName.length === 0) {
+                    throw new Error('no ACL property defined "' + propName + ':' + propKey + '"');
+                }
+                props = propsByName;
+            }
+            if (props.length !== 1) {
+                throw new Error('more than one ACL property with the same name defined "' + propName + ':' + propKey + '" lenght: ' + props.length);
+            }
+            return props[0];
+        }
+    };
+});

--- a/web/war/src/main/webapp/js/util/popovers/propertyInfo/propertyInfo.js
+++ b/web/war/src/main/webapp/js/util/popovers/propertyInfo/propertyInfo.js
@@ -6,6 +6,7 @@ define([
     'util/withDataRequest',
     'util/privileges',
     'util/visibility/view',
+    'util/acl',
     'd3'
 ], function(
     defineComponent,
@@ -14,6 +15,7 @@ define([
     withDataRequest,
     Privileges,
     VisibilityViewer,
+    acl,
     d3) {
     'use strict';
 
@@ -31,31 +33,15 @@ define([
         });
 
         this.before('initialize', function(node, config) {
-            var findPropertyAcl = function(propertiesAcl, propName, propKey) {
-                var props = _.where(propertiesAcl, { name: propName, key: propKey });
-                if (props.length === 0) {
-                    var propsByName = _.where(propertiesAcl, { name: propName });
-                    if (propsByName.length === 0) {
-                        console.error(propName, propKey)
-                        throw new Error('no ACL property defined');
-                    }
-                    props = propsByName;
-                }
-                if (props.length !== 1) {
-                    console.error(propName, propKey, props)
-                    throw new Error('more than one ACL property with the same name defined');
-                }
-                return props[0];
-            };
-
             config.template = 'propertyInfo/template';
             config.isFullscreen = visalloData.isFullscreen;
             if (config.property) {
 
                 config.isComment = config.property.name === 'http://visallo.org/comment#entry';
                 config.canAdd = config.canEdit = config.canDelete = false;
-                var allPropertyAcls = config.data.acl.propertyAcls;
-                var propertyAcl = findPropertyAcl(allPropertyAcls, config.property.name, config.property.key);
+
+                var allPropertyAcls = acl.getPropertyAcls(config.data);
+                var propertyAcl = acl.findPropertyAcl(allPropertyAcls, config.property.name, config.property.key);
 
                 if (config.isComment && visalloData.currentWorkspaceCommentable) {
                     config.canAdd = config.property.addable !== undefined ? config.property.addable !== false : propertyAcl.addable !== false;


### PR DESCRIPTION
- [x] @joeferner
- [x] @kunklejr @mwizeman @sfeng88 @diegogrz
- [ ] @dsingley @EvanOxfeld 
- [x] @joeybrk372 @rygim @jharwig 

Before this commit the server would return all the property acls for
each element returned which created excess data returned to the client.
This commit solves this by only returning the properties that are different
from the ontology.

CHANGELOG
Changed: Getting elements from the server no longer returns all acl if they are the default
