### PR TITLE
Changed: Cytoscape.js force directed layout from arbor to cose

### DIFF
--- a/web/war/src/main/webapp/js/graph/graph.ejs
+++ b/web/war/src/main/webapp/js/graph/graph.ejs
@@ -26,7 +26,7 @@
       <li><a data-func="layout" data-args='["circle"]' tabindex="-1" href="#"><%= i18n('graph.contextmenu.layout.circle') %></a></li>
       <li><a data-func="layout" data-args='["bettergrid"]' tabindex="-1" href="#"><%= i18n('graph.contextmenu.layout.grid') %></a></li>
       <li><a data-func="layout" data-args='["breadthfirst"]' tabindex="-1" href="#"><%= i18n('graph.contextmenu.layout.hierarchical') %></a></li>
-      <li><a data-func="layout" data-args='["arbor"]' tabindex="-1" href="#"><%= i18n('graph.contextmenu.layout.force_directed') %></a></li>
+      <li><a data-func="layout" data-args='["cose"]' tabindex="-1" href="#"><%= i18n('graph.contextmenu.layout.force_directed') %></a></li>
     </ul>
   </li>
 
@@ -36,7 +36,7 @@
       <li><a data-func="layout" data-args='["circle",{"onlySelected":true}]' tabindex="-1" href="#"><%= i18n('graph.contextmenu.layout.circle') %></a></li>
       <li><a data-func="layout" data-args='["bettergrid", {"onlySelected":true}]' tabindex="-1" href="#"><%= i18n('graph.contextmenu.layout.grid') %></a></li>
       <li><a data-func="layout" data-args='["breadthfirst", {"onlySelected":true}]' tabindex="-1" href="#"><%= i18n('graph.contextmenu.layout.hierarchical') %></a></li>
-      <li><a data-func="layout" data-args='["arbor", {"onlySelected":true}]' tabindex="-1" href="#"><%= i18n('graph.contextmenu.layout.force_directed') %></a></li>
+      <li><a data-func="layout" data-args='["cose", {"onlySelected":true}]' tabindex="-1" href="#"><%= i18n('graph.contextmenu.layout.force_directed') %></a></li>
     </ul>
   </li>
 

--- a/web/war/src/main/webapp/js/graph/graph.js
+++ b/web/war/src/main/webapp/js/graph/graph.js
@@ -2,8 +2,6 @@
 define([
     'flight/lib/component',
     'cytoscape',
-    'arbor',
-    'cytoscape-arbor',
     './stylesheet',
     './withControlDrag',
     './layouts/grid',
@@ -23,8 +21,6 @@ define([
 ], function(
     defineComponent,
     cytoscape,
-    arbor,
-    cyarbor,
     stylesheet,
     withControlDrag,
     BetterGrid,
@@ -42,8 +38,6 @@ define([
     registry,
     colorjs) {
     'use strict';
-
-    cyarbor(cytoscape, arbor);
 
         // Delay before showing hover effect on graph
     var HOVER_FOCUS_DELAY_SECONDS = 0.25,
@@ -77,7 +71,7 @@ define([
             LAYOUT_OPTIONS = {
                 // Customize layout options
                 random: { padding: 10 },
-                arbor: { friction: 0.6, repulsion: 5000 * retina.devicePixelRatio, targetFps: 60, stiffness: 300 },
+                cose: { animate: true, edgeElasticity: 10 },
                 breadthfirst: {
                     roots: function(nodes, options) {
                         if (options && options.onlySelected) {

--- a/web/war/src/main/webapp/js/require.config.js
+++ b/web/war/src/main/webapp/js/require.config.js
@@ -25,7 +25,6 @@
             }
         },
         paths: {
-            'arbor': '../libs/cytoscape-arbor/arbor',
             'async': '../libs/requirejs-plugins/src/async',
             'atmosphere': '../libs/atmosphere.js/lib/atmosphere',
             'beautify': '../libs/js-beautify/js/lib/beautify',
@@ -37,7 +36,6 @@
             'classnames': '../libs/classnames/index',
             'colorjs': '../libs/color-js/color',
             'cytoscape': '../libs/cytoscape/dist/cytoscape',
-            'cytoscape-arbor': '../libs/cytoscape-arbor/cytoscape-arbor',
             'd3': '../libs/d3/d3.min',
             'd3-tip': '../libs/d3-tip/index',
             'd3-plugins': '../libs/d3-plugins-dist/dist/mbostock',
@@ -80,7 +78,6 @@
             'videojs': '../libs/video.js/dist/video'
         },
         shim: {
-            'arbor': { exports: 'arbor', deps: ['jquery'] },
             'atmosphere': { init: function() { return $.atmosphere; }, deps: ['jquery'] },
             'bootstrap': { exports: 'window', deps: ['jquery', 'jquery-ui-bundle'] },
             'bootstrap-datepicker': { exports: 'window', deps: ['bootstrap'] },

--- a/web/war/src/main/webapp/npm-shrinkwrap.json
+++ b/web/war/src/main/webapp/npm-shrinkwrap.json
@@ -1229,11 +1229,6 @@
       "from": "cytoscape@2.6.6",
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-2.6.6.tgz"
     },
-    "cytoscape-arbor": {
-      "version": "1.2.0",
-      "from": "cytoscape-arbor@1.2.0",
-      "resolved": "https://registry.npmjs.org/cytoscape-arbor/-/cytoscape-arbor-1.2.0.tgz"
-    },
     "d": {
       "version": "0.1.1",
       "from": "d@>=0.1.1 <0.2.0",

--- a/web/war/src/main/webapp/package.json
+++ b/web/war/src/main/webapp/package.json
@@ -16,7 +16,6 @@
     "classnames": "2.2.5",
     "color-js": "1.0.3",
     "cytoscape": "2.6.6",
-    "cytoscape-arbor": "1.2.0",
     "d3": "3.5.12",
     "d3-plugins-dist": "3.1.4",
     "d3-tip": "0.6.7",


### PR DESCRIPTION
- [x] @joeferner
- [x] @kunklejr @mwizeman @sfeng88 @diegogrz
- [ ] @dsingley @EvanOxfeld 
- [ ] @joeybrk372 @rygim @jharwig 

According to https://github.com/cytoscape/cytoscape.js-arbor arbor is
not recommened in favor of cose, cose-bilkent, or cola. After trying
them I found cose to be the best for speed and layout balance. bilkent
was quite slow even on my machine. cola didn't offer much above cose.
I choose cose because it is now part of cytoscape which means one
less dependency and compatibility should remain high.

CHANGELOG
Changed: Cytoscape.js force directed layout from arbor to cose
