### PR TITLE
Fixed: UI date parsing of IE formatted strings

### DIFF
--- a/web/war/src/main/webapp/js/util/formatters.js
+++ b/web/war/src/main/webapp/js/util/formatters.js
@@ -482,8 +482,13 @@ define([
                             parsed += (isNegative ? '-' : '+') + hours + ':' + minutes;
                             dateInLocale = new Date(parsed);
                         } else {
-                            console.warn('Unable to parse date', numberOrString);
-                            return '';
+                            var m = moment(numberOrString, 'YYYY-MM-DDTHH:mm:ss.SSSZ', true);
+                            if (m.isValid()) {
+                                dateInLocale = m.local().toDate();
+                            } else {
+                                console.warn('Unable to parse date', numberOrString);
+                                return '';
+                            }
                         }
                     }
                 }

--- a/web/war/src/main/webapp/test/unit/spec/util/formattersTest.js
+++ b/web/war/src/main/webapp/test/unit/spec/util/formattersTest.js
@@ -224,11 +224,17 @@ define([
             it('should create local dates', function() {
                 var date = new Date('2015-06-23T13:16:00'),
                     offset = date.getTimezoneOffset(),
-                    dateLocal = new Date(date.getTime() + offset * 60 * 1000);
+                    dateLocal = new Date(date.getTime() + offset * 60 * 1000),
+                    isNegative = offset > 0,
+                    hours = '' + Math.floor(Math.abs(offset) / 60),
+                    minutes = '' + (Math.abs(offset) % 60);
 
-                f.date.local('2015-06-23T17:16:00.000+0000').getTime().should.equal(dateLocal.getTime());
-                f.date.local('2015-06-23T12:16:00.000-0500').getTime().should.equal(dateLocal.getTime());
-                f.date.local('2015-06-23 13:16 CDT').getTime().should.equal(dateLocal.getTime());
+                if (hours.length < 2) hours = '0' + hours;
+                if (minutes.length < 2) minutes = '0' + minutes;
+
+                var thisMachineTimezoneOffsetStr = (isNegative ? '-' : '+') + hours + ':' + minutes;
+                f.date.local('2015-06-23 13:16 ' + thisMachineTimezoneOffsetStr).getTime()
+                    .should.equal(dateLocal.getTime())
                 f.date.dateTimeString(dateLocal.getTime()).should.match(/^2015-06-23 13:16 .+$/)
             });
 

--- a/web/war/src/main/webapp/test/unit/spec/util/formattersTest.js
+++ b/web/war/src/main/webapp/test/unit/spec/util/formattersTest.js
@@ -226,9 +226,11 @@ define([
                     offset = date.getTimezoneOffset(),
                     dateLocal = new Date(date.getTime() + offset * 60 * 1000);
 
-                f.date.local('2015-06-23 13:16 CDT').getTime().should.equal(dateLocal.getTime())
+                f.date.local('2015-06-23T17:16:00.000+0000').getTime().should.equal(dateLocal.getTime());
+                f.date.local('2015-06-23T12:16:00.000-0500').getTime().should.equal(dateLocal.getTime());
+                f.date.local('2015-06-23 13:16 CDT').getTime().should.equal(dateLocal.getTime());
                 f.date.dateTimeString(dateLocal.getTime()).should.match(/^2015-06-23 13:16 .+$/)
-            })
+            });
 
             it('should format to preferred format', function() {
                 var now = new Date(),


### PR DESCRIPTION
- [x] @joeferner
- [x] @kunklejr @mwizeman @sfeng88 @diegogrz
- [x] @dsingley @EvanOxfeld 
- [x] @joeybrk372 @rygim @jharwig 

In some cases IE formats strings in 2016-10-24T22:12:13.012+0000 format
this commit fixes the parser to handle this format.
