### PR TITLE
Give default authorizations to all users, not just users without auths

### DIFF
--- a/core/core-test/src/test/java/org/visallo/core/model/user/UserPropertyAuthorizationRepositoryTest.java
+++ b/core/core-test/src/test/java/org/visallo/core/model/user/UserPropertyAuthorizationRepositoryTest.java
@@ -77,7 +77,7 @@ public class UserPropertyAuthorizationRepositoryTest {
 
     @Test
     public void testGetAuthorizationsForExisting() {
-        String[] authorizationsArray = {"userAuthorization1", "userAuthorization2"};
+        String[] authorizationsArray = {"userAuthorization1", "userAuthorization2", "userRepositoryAuthorization1", "userRepositoryAuthorization2"};
         when(user.getProperty(eq(UserPropertyAuthorizationRepository.AUTHORIZATIONS_PROPERTY_IRI)))
                 .thenReturn("userAuthorization1,userAuthorization2");
 

--- a/core/core/src/main/java/org/visallo/core/model/user/UserPropertyAuthorizationRepositoryBase.java
+++ b/core/core/src/main/java/org/visallo/core/model/user/UserPropertyAuthorizationRepositoryBase.java
@@ -86,11 +86,12 @@ public abstract class UserPropertyAuthorizationRepositoryBase extends Authorizat
         if (user instanceof SystemUser) {
             return Sets.newHashSet(VisalloVisibility.SUPER_USER_VISIBILITY_STRING);
         }
+        HashSet<String> authSet = new HashSet<>(getDefaultAuthorizations());
         String authorizations = (String) user.getProperty(AUTHORIZATIONS_PROPERTY_IRI);
-        if (authorizations == null) {
-            return new HashSet<>(getDefaultAuthorizations());
+        if (authorizations != null) {
+            authSet.addAll(parseAuthorizations(authorizations));
         }
-        return Sets.newHashSet(parseAuthorizations(authorizations));
+        return authSet;
     }
 
     protected ImmutableSet<String> getDefaultAuthorizations() {


### PR DESCRIPTION
Currently, the default authorizations only get returned if the user doesn't have any existing authorizations. The default authorizations should apply to all users, regardless of other authorizations they might have.
- [x] @joeferner 
- [x] @kunklejr @mwizeman @sfeng88 @diegogrz
- [ ] @dsingley @EvanOxfeld 
- [ ] @joeybrk372 @rygim @jharwig 

CHANGELOG
Changed: Default authorizations will be given to all users, not just users without any existing authorizations.
