### PR TITLE
Remove forward slash shortcut key.

### DIFF
--- a/web/war/src/main/webapp/js/search/search.js
+++ b/web/war/src/main/webapp/js/search/search.js
@@ -411,12 +411,6 @@ define([
                         this.select('querySelector').blur();
                     }
                 }
-            } else if (event.keyCode === 191 /* FORWARD SLASH */) {
-                event.preventDefault();
-                event.stopPropagation();
-                if (event.type === 'keyup') {
-                    this.switchSearchType(this.otherSearchType);
-                }
             } else {
                 this.updateClearSearch();
                 this.triggerQueryUpdated();


### PR DESCRIPTION
- [x] @joeferner
- [x] @kunklejr @mwizeman @sfeng88 @diegogrz
- [ ] @dsingley @EvanOxfeld 
- [x] @joeybrk372 @rygim @jharwig 


Forward slash shortcut key prevents users from typing a slash in the
search box.