### PR TITLE
Changed: Webstart version from v2.2.0 to v2.2.1

### DIFF
--- a/root/pom.xml
+++ b/root/pom.xml
@@ -91,7 +91,7 @@
         <xerces.version>2.9.1</xerces.version>
         <xalan.version>2.7.1</xalan.version>
         <owlapi.version>4.0.2</owlapi.version>
-        <webster.version>2.2.0</webster.version>
+        <webster.version>2.2.1</webster.version>
         <drewnoakes.version>2.8.1</drewnoakes.version>
         <jai-imageio.version>1.3.1</jai-imageio.version>
         <rhino.version>1.7R4</rhino.version>


### PR DESCRIPTION
- [x] @joeferner
- [x] @kunklejr @mwizeman @sfeng88 @diegogrz
- [ ] @dsingley @EvanOxfeld 
- [ ] @joeybrk372 @rygim @jharwig 
- add additional HTTP methods HEAD, OPTIONS, TRACE, CONNECT
- Fix: route runner on older versions of Firefox that do not support innerText
- Fix: FF event target/srcElement

CHANGELOG
Changed: Webstart version from v2.2.0 to v2.2.1
