### PR TITLE
Make geolocation properties not sortable by default

### DIFF
--- a/core/core/src/main/java/org/visallo/core/model/ontology/OntologyRepositoryBase.java
+++ b/core/core/src/main/java/org/visallo/core/model/ontology/OntologyRepositoryBase.java
@@ -538,7 +538,7 @@ public abstract class OntologyRepositoryBase implements OntologyRepository {
             boolean userVisible = OWLOntologyUtil.getUserVisible(o, dataTypeProperty);
             boolean searchable = OWLOntologyUtil.getSearchable(o, dataTypeProperty);
             boolean addable = OWLOntologyUtil.getAddable(o, dataTypeProperty);
-            boolean sortable = OWLOntologyUtil.getSortable(o, dataTypeProperty);
+            boolean sortable = !propertyType.equals(PropertyType.GEO_LOCATION) && OWLOntologyUtil.getSortable(o, dataTypeProperty);
             String displayType = OWLOntologyUtil.getDisplayType(o, dataTypeProperty);
             String propertyGroup = OWLOntologyUtil.getPropertyGroup(o, dataTypeProperty);
             String validationFormula = OWLOntologyUtil.getValidationFormula(o, dataTypeProperty);


### PR DESCRIPTION
- [x] @joeferner
- [x] @kunklejr @mwizeman @sfeng88 @diegogrz
- [x] @dsingley @EvanOxfeld 
- [ ] @joeybrk372 @rygim @jharwig 

There is no sorting method for geolocation, so when the ui queried with a geolocation sort it would result in errors.

CHANGELOG
Changed: Geolocation properties are not sortable by default.


