### PR TITLE
Disable statistics aggregation

### DIFF
--- a/web/war/src/main/webapp/js/search/dashboard/aggregation.js
+++ b/web/war/src/main/webapp/js/search/dashboard/aggregation.js
@@ -23,8 +23,7 @@ define([
                 return _.filter(properties, function(p) {
                     return p.dataType.toLowerCase() === 'geolocation';
                 });
-            }},
-            { value: 'statistics', name: 'Statistics' }
+            }}
         ],
         AGGREGATIONS_NO_GEOHASH = _.reject(AGGREGATIONS, function(a) {
             return a.value === 'geohash';
@@ -402,9 +401,6 @@ define([
                     break;
 
                 case 'term':
-                    break;
-
-                case 'statistics':
                     break;
 
                 default:


### PR DESCRIPTION
- [x] @joeferner
- [x] @kunklejr @mwizeman @sfeng88 @diegogrz
- [x] @dsingley @EvanOxfeld 
- [ ] @joeybrk372 @rygim @jharwig 



CHANGELOG
Removed: Statistics aggregation option in saved search dashboard cards. This aggregation type will be reworked in a future release.


