### PR TITLE
Fixed: graph.flush calls on ontology update methods to prevent race conditions

### DIFF
--- a/core/plugins/model-vertexium/src/main/java/org/visallo/vertexium/model/ontology/VertexiumConcept.java
+++ b/core/plugins/model-vertexium/src/main/java/org/visallo/vertexium/model/ontology/VertexiumConcept.java
@@ -131,11 +131,13 @@ public class VertexiumConcept extends Concept {
     @Override
     public void addIntent(String intent, Authorizations authorizations) {
         OntologyProperties.INTENT.addPropertyValue(vertex, intent, intent, OntologyRepository.VISIBILITY.getVisibility(), authorizations);
+        getVertex().getGraph().flush();
     }
 
     @Override
     public void removeIntent(String intent, Authorizations authorizations) {
         OntologyProperties.INTENT.removeProperty(vertex, intent, authorizations);
+        getVertex().getGraph().flush();
     }
 
     @Override
@@ -162,15 +164,18 @@ public class VertexiumConcept extends Concept {
     @Override
     public void setProperty(String name, Object value, Authorizations authorizations) {
         getVertex().setProperty(name, value, OntologyRepository.VISIBILITY.getVisibility(), authorizations);
+        getVertex().getGraph().flush();
     }
 
     public void removeProperty(String key, String name, Authorizations authorizations) {
         getVertex().softDeleteProperty(key, name, authorizations);
+        getVertex().getGraph().flush();
     }
 
     @Override
     public void removeProperty(String name, Authorizations authorizations) {
         removeProperty(ElementMutation.DEFAULT_KEY, name, authorizations);
+        getVertex().getGraph().flush();
     }
 
     @Override

--- a/core/plugins/model-vertexium/src/main/java/org/visallo/vertexium/model/ontology/VertexiumOntologyProperty.java
+++ b/core/plugins/model-vertexium/src/main/java/org/visallo/vertexium/model/ontology/VertexiumOntologyProperty.java
@@ -26,6 +26,7 @@ public class VertexiumOntologyProperty extends OntologyProperty {
     @Override
     public void setProperty(String name, Object value, Authorizations authorizations) {
         getVertex().setProperty(name, value, OntologyRepository.VISIBILITY.getVisibility(), authorizations);
+        getVertex().getGraph().flush();
     }
 
     public String getTitle() {
@@ -67,16 +68,19 @@ public class VertexiumOntologyProperty extends OntologyProperty {
     @Override
     public void addTextIndexHints(String textIndexHints, Authorizations authorizations) {
         OntologyProperties.TEXT_INDEX_HINTS.addPropertyValue(vertex, textIndexHints, textIndexHints, OntologyRepository.VISIBILITY.getVisibility(), authorizations);
+        getVertex().getGraph().flush();
     }
 
     @Override
     public void addIntent(String intent, Authorizations authorizations) {
         OntologyProperties.INTENT.addPropertyValue(vertex, intent, intent, OntologyRepository.VISIBILITY.getVisibility(), authorizations);
+        getVertex().getGraph().flush();
     }
 
     @Override
     public void removeIntent(String intent, Authorizations authorizations) {
         OntologyProperties.INTENT.removeProperty(vertex, intent, authorizations);
+        getVertex().getGraph().flush();
     }
 
     public boolean getUserVisible() {

--- a/core/plugins/model-vertexium/src/main/java/org/visallo/vertexium/model/ontology/VertexiumRelationship.java
+++ b/core/plugins/model-vertexium/src/main/java/org/visallo/vertexium/model/ontology/VertexiumRelationship.java
@@ -37,21 +37,25 @@ public class VertexiumRelationship extends Relationship {
     @Override
     public void addIntent(String intent, Authorizations authorizations) {
         OntologyProperties.INTENT.addPropertyValue(vertex, intent, intent, OntologyRepository.VISIBILITY.getVisibility(), authorizations);
+        vertex.getGraph().flush();
     }
 
     @Override
     public void removeIntent(String intent, Authorizations authorizations) {
         OntologyProperties.INTENT.removeProperty(vertex, intent, authorizations);
+        vertex.getGraph().flush();
     }
 
     @Override
     public void setProperty(String name, Object value, Authorizations authorizations) {
         getVertex().setProperty(name, value, OntologyRepository.VISIBILITY.getVisibility(), authorizations);
+        vertex.getGraph().flush();
     }
 
     @Override
     public void removeProperty(String name, Authorizations authorizations) {
         getVertex().softDeleteProperty(ElementMutation.DEFAULT_KEY, name, authorizations);
+        vertex.getGraph().flush();
     }
 
     @Override


### PR DESCRIPTION
- [x] @joeferner
- [x] @kunklejr @mwizeman @sfeng88 @diegogrz
- [x] @dsingley @EvanOxfeld 
- [x] @joeybrk372 @rygim @jharwig 

This commit solves races conditions while updating the ontology.
The ontology code should be refactored to wrap all updates in a
graph update context so that we don't need to delete and re-add
everytime the ontology is loaded, but this is a much larger task.

CHANGELOG
Fixed: graph.flush calls on ontology update methods to prevent race conditions