### PR TITLE
Changed: Remove Exception from GraphUpdateContext#close to avoid needing to catch

### DIFF
--- a/core/core/src/main/java/org/visallo/core/model/graph/GraphUpdateContext.java
+++ b/core/core/src/main/java/org/visallo/core/model/graph/GraphUpdateContext.java
@@ -63,7 +63,7 @@ public abstract class GraphUpdateContext implements AutoCloseable {
      */
     @SuppressWarnings("unchecked")
     @Override
-    public void close() throws Exception {
+    public void close() {
         pushToWorkQueueRepository();
     }
 


### PR DESCRIPTION
- [x] @joeferner
- [x] @kunklejr @mwizeman @sfeng88 @diegogrz
- [x] @dsingley @EvanOxfeld 
- [ ] @joeybrk372 @rygim @jharwig 

GraphUpdateContext#close only throws RuntimeExceptions so declaring the Exception
is not necessary. This will allow users of this code to not provide a catch statement.