### PR TITLE
Changed: Speed up ACLProvider by caching the ontology property IRI

### DIFF
--- a/core/core/src/main/java/org/visallo/core/trace/Trace.java
+++ b/core/core/src/main/java/org/visallo/core/trace/Trace.java
@@ -26,7 +26,7 @@ public class Trace {
     private static TraceRepository traceRepository;
 
     public static void on(String description) {
-        getTraceRepository().on(description, new HashMap<String, String>());
+        getTraceRepository().on(description, new HashMap<>());
     }
 
     public static TraceSpan on(String description, Map<String, String> data) {

--- a/core/plugins/model-vertexium/src/main/java/org/visallo/vertexium/model/ontology/VertexiumOntologyProperty.java
+++ b/core/plugins/model-vertexium/src/main/java/org/visallo/vertexium/model/ontology/VertexiumOntologyProperty.java
@@ -16,11 +16,13 @@ import java.util.Map;
 
 public class VertexiumOntologyProperty extends OntologyProperty {
     private final Vertex vertex;
+    private final String iri;
     private ImmutableList<String> dependentPropertyIris;
 
     public VertexiumOntologyProperty(Vertex vertex, ImmutableList<String> dependentPropertyIris) {
         this.vertex = vertex;
         this.dependentPropertyIris = dependentPropertyIris;
+        this.iri = OntologyProperties.ONTOLOGY_TITLE.getPropertyValue(vertex);
     }
 
     @Override
@@ -29,7 +31,7 @@ public class VertexiumOntologyProperty extends OntologyProperty {
     }
 
     public String getTitle() {
-        return OntologyProperties.ONTOLOGY_TITLE.getPropertyValue(vertex);
+        return iri;
     }
 
     public String getDisplayName() {

--- a/web/web-base/src/main/java/org/visallo/web/VisalloDefaultResultWriterFactory.java
+++ b/web/web-base/src/main/java/org/visallo/web/VisalloDefaultResultWriterFactory.java
@@ -11,6 +11,8 @@ import org.visallo.core.config.Configuration;
 import org.visallo.core.exception.VisalloException;
 import org.visallo.core.model.user.UserRepository;
 import org.visallo.core.security.ACLProvider;
+import org.visallo.core.trace.Trace;
+import org.visallo.core.trace.TraceSpan;
 import org.visallo.core.user.User;
 import org.visallo.web.clientapi.model.ClientApiObject;
 import org.visallo.web.clientapi.util.ObjectMapperFactory;
@@ -80,7 +82,9 @@ public class VisalloDefaultResultWriterFactory implements ResultWriterFactory {
                     if (resultIsClientApiObject) {
                         ClientApiObject clientApiObject = (ClientApiObject) result;
                         User user = VisalloBaseParameterProvider.getUser(request, userRepository);
-                        clientApiObject = aclProvider.appendACL(clientApiObject, user);
+                        try (TraceSpan ignored = Trace.start("aclProvider.appendACL")) {
+                            clientApiObject = aclProvider.appendACL(clientApiObject, user);
+                        }
                         String jsonObject;
                         try {
                             jsonObject = ObjectMapperFactory.getInstance().writeValueAsString(clientApiObject);


### PR DESCRIPTION
- [x] @joeferner
- [x] @kunklejr @mwizeman @sfeng88 @diegogrz
- [ ] @dsingley @EvanOxfeld 
- [ ] @joeybrk372 @rygim @jharwig 

While applying the ACL getTitle of ontology property is called very many times
this change speeds that call up significatly reducing the overall time to
add the ACL

CHANGELOG
Changed: Speed up ACLProvider by caching the ontology property IRI