### PR TITLE
Display offline on network loss

### DIFF
--- a/web/war/src/main/webapp/js/data/withWebsocketLegacy.js
+++ b/web/war/src/main/webapp/js/data/withWebsocketLegacy.js
@@ -46,6 +46,8 @@ define([], function() {
                     });
                 });
 
+            this.trigger('websocketNotSupportedInWorker');
+
             this.around('pushSocket', function(push, message) {
                 atmospherePromise.then(function(socket) {
                     var string = JSON.stringify(_.extend({}, message, {


### PR DESCRIPTION
- [x] @joeferner
- [x] @kunklejr @mwizeman @sfeng88 @diegogrz
- [x] @dsingley @EvanOxfeld 
- [ ] @joeybrk372 @rygim @jharwig 

We show the offline overlay based on the websocket being closed. However, atmosphere triggers the close event by listening for the `offline` event on `window` which is not available inside a worker.

CHANGELOG
Fixed: Offline overlay not appearing when the browser loses network connection.

