### PR TITLE
Add map options extension point that mirrors the graph.options

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -49,6 +49,7 @@
         * [Layout Component](extension-points/front-end/layout/component.md)
         * [Layout Type](extension-points/front-end/layout/type.md)
         * [Logout](extension-points/front-end/logout/index.md)
+        * [Map Options](extension-points/front-end/mapOptions/index.md)
         * [Menubar](extension-points/front-end/menubar/index.md)
         * [Search Filters](extension-points/front-end/searchFilters/index.md)
         * [Search Toolbar](extension-points/front-end/searchToolbar/index.md)

--- a/docs/extension-points/front-end/mapOptions/index.md
+++ b/docs/extension-points/front-end/mapOptions/index.md
@@ -1,0 +1,79 @@
+Map Options Plugin
+=================
+
+Plugin to add custom options components (Flight or React) which display in the map options menu (next to Fit).
+
+All registered components will be passed:
+
+* `ol` `[Object]`: [Openlayers Api](http://openlayers.org/en/latest/apidoc/)
+* `map` [`[ol.Map]`](http://openlayers.org/en/latest/apidoc/ol.Map.html): Openlayers map instance
+* `cluster` `[Object]`: Object with keys:
+    * `clusterSource` [`[MultiPointCluster]`](https://github.com/v5analytics/visallo/blob/master/web/plugins/map-product/src/main/resources/org/visallo/web/product/map/multiPointCluster.js): Implements the [`ol.source.Cluster`](http://openlayers.org/en/latest/apidoc/ol.source.Cluster.html) interface to cluster the `source` features.
+    * `source` [`[ol.source.Vector]`](http://openlayers.org/en/latest/apidoc/ol.source.Vector.html): The source of all map pins before clustering. 
+    * `layer` [`[ol.layer.Vector]`](http://openlayers.org/en/latest/apidoc/ol.layer.Vector.html): The pin vector layer
+
+To register an option:
+
+## React
+
+```js
+// Create a MyOption.jsx and use registerJavaScriptComponent in your WebAppPlugin.
+require(['react', 'public/v1/api'], function(React, visalloApi) {
+    const MyOption = React.createClass({
+        render() {
+            const { ol, map, cluster } = this.props;
+
+            const myOptionDefault = visalloData.currentUser.uiPreferences['my-option-value'];
+            return (
+                <label>My Setting
+                    <input onChange={this.onChange} type="checkbox" defaultChecked={myOptionDefault} />
+                </label>
+            );
+        },
+        onChange(event) {
+            visalloData.currentUser.uiPreferences['my-option-value'] = event.target.checked;
+            // Save
+            visalloApi.dataRequest('user', 'preference', 'my-option-value', event.target.checked);
+        }
+    })
+    return MyOption;
+});
+
+// Create plugin.js and use registerJavaScript("plugin.js", true) in your WebAppPlugin
+require(['configuration/plugins/registry'], function(registry) {
+
+    // Register the component path,
+    registry.registerExtension('org.visallo.map.options', {
+        identifier: 'myOption',
+        optionComponentPath: 'myplugins/MyOption'
+    });
+});
+```
+
+## Flight
+
+```js
+require(['configuration/plugins/registry'], function(registry) {
+
+    // Define a custom Flight component
+    define('myplugins/hello_world', ['flight/lib/component'], function(defineComponent) {
+        return defineComponent(HelloWorld);
+
+        function HelloWorld() {
+            this.after('initialize', function() {
+                // this.attr.ol
+                // this.attr.map
+                // this.attr.cluster
+                this.$node.html('Hello World!!');
+            })
+        }
+    });
+
+    // Register the component path,
+    registry.registerExtension('org.visallo.map.options', {
+        identifier: 'helloWorld',
+        optionComponentPath: 'myplugins/hello_world'
+    });
+});
+```
+

--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/Cytoscape.jsx
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/Cytoscape.jsx
@@ -262,7 +262,7 @@ define([
                     {this.state.cy ? (
                         <NavigationControls
                             rightOffset={this.props.panelPadding.right}
-                            tools={this.props.tools}
+                            tools={this.injectToolProps()}
                             onFit={this.onControlsFit}
                             onZoom={this.onControlsZoom}
                             onPan={this.onControlsPan} />
@@ -737,6 +737,17 @@ define([
                     classes: 'drawEdgeToMouse'
                 })
             }
+        },
+
+        injectToolProps() {
+            const { cy } = this.state;
+            if (cy) {
+                return this.props.tools.map(tool => ({
+                    ...tool,
+                    props: { cy }
+                }))
+            }
+            return [];
         }
     })
 

--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/Graph.jsx
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/Graph.jsx
@@ -233,8 +233,7 @@ define([
         getTools() {
             return this.props.registry['org.visallo.graph.options'].map(e => ({
                 identifier: e.identifier,
-                optionComponentPath: e.optionComponentPath,
-                getProps: () => ({ cy: this.refs.cytoscape.state.cy })
+                componentPath: e.optionComponentPath
             }));
         },
 

--- a/web/plugins/map-product/src/main/resources/org/visallo/web/product/map/Map.jsx
+++ b/web/plugins/map-product/src/main/resources/org/visallo/web/product/map/Map.jsx
@@ -1,9 +1,10 @@
 define([
     'react',
     './OpenLayers',
+    'components/RegistryInjectorHOC',
     'util/vertex/formatters',
     'util/mapConfig'
-], function(React, OpenLayers, F, mapConfig) {
+], function(React, OpenLayers, RegistryInjectorHOC, F, mapConfig) {
     'use strict';
 
     const PropTypes = React.PropTypes;
@@ -27,6 +28,7 @@ define([
                 <OpenLayers
                     features={this.mapElementsToFeatures()}
                     viewport={viewport}
+                    tools={this.getTools()}
                     generatePreview={generatePreview}
                     panelPadding={this.props.panelPadding}
                     onPan={this.onViewport}
@@ -83,6 +85,13 @@ define([
                     { x: pageX, y: pageY }
                 );
             }
+        },
+
+        getTools() {
+            return this.props.registry['org.visallo.map.options'].map(e => ({
+                identifier: e.identifier,
+                componentPath: e.optionComponentPath
+            }));
         },
 
         onViewport(event) {
@@ -213,5 +222,7 @@ define([
 
     });
 
-    return Map;
+    return RegistryInjectorHOC(Map, [
+        'org.visallo.map.options'
+    ])
 });

--- a/web/plugins/map-product/src/main/resources/org/visallo/web/product/map/OpenLayers.jsx
+++ b/web/plugins/map-product/src/main/resources/org/visallo/web/product/map/OpenLayers.jsx
@@ -29,11 +29,11 @@ define([
             source: PropTypes.string.isRequired,
             sourceOptions: PropTypes.object,
             generatePreview: PropTypes.bool,
+            tools: PropTypes.array,
             onSelectElements: PropTypes.func.isRequired,
             onUpdatePreview: PropTypes.func.isRequired,
             onTap: PropTypes.func,
             onContextTap: PropTypes.func,
-
             onZoom: PropTypes.func,
             onPan: PropTypes.func
         },
@@ -48,7 +48,8 @@ define([
                 onTap: noop,
                 onContextTap: noop,
                 onZoom: noop,
-                onPan: noop
+                onPan: noop,
+                tools: []
             }
         },
 
@@ -209,6 +210,7 @@ define([
                 <div style={{height: '100%'}}>
                     <div style={{height: '100%'}} ref="map"></div>
                     <NavigationControls
+                        tools={this.injectExtraPropsToTools()}
                         rightOffset={this.props.panelPadding.right}
                         onFit={this.onControlsFit}
                         onZoom={this.onControlsZoom}
@@ -558,6 +560,19 @@ define([
         domEvent(el, type, handler) {
             this.domEvents.push(() => el.removeEventListener(type, handler));
             el.addEventListener(type, handler, false);
+        },
+
+        injectExtraPropsToTools() {
+            const { map, cluster } = this.state;
+            if (map && cluster) {
+                return this.props.tools.map(tool => {
+                    return {
+                        ...tool,
+                        props: { ol, map, cluster }
+                    }
+                });
+            }
+            return [];
         }
     })
 

--- a/web/war/src/main/webapp/js/components/NavigationControls.jsx
+++ b/web/war/src/main/webapp/js/components/NavigationControls.jsx
@@ -21,7 +21,11 @@ define([
         propTypes: {
             zoom: PropTypes.bool,
             pan: PropTypes.bool,
-            tools: PropTypes.array,
+            tools: PropTypes.arrayOf(PropTypes.shape({
+                identifier: PropTypes.string.isRequired,
+                componentPath: PropTypes.string.isRequired,
+                props: PropTypes.object
+            })),
             rightOffset: PropTypes.number,
             onZoom: PropTypes.func,
             onPan: PropTypes.func,
@@ -73,8 +77,12 @@ define([
                             title={i18n('controls.options.toggle')}>Options</button>
                         <div style={{display: (optionsOpen ? 'block' : 'none')}} className="options-container">
                             <ul>{
-                                tools.map((tool, i) => {
-                                    return <Attacher nodeType="li" key={tool.identifier} componentPath={tool.optionComponentPath} {...tool.getProps()} />
+                                tools.map(tool => {
+                                    return <Attacher
+                                        nodeType="li"
+                                        key={tool.identifier}
+                                        componentPath={tool.componentPath}
+                                        {...(tool.props || {})} />
                                 })
                             }</ul>
                         </div>


### PR DESCRIPTION
- [x] @joeferner
- [x] @kunklejr @mwizeman @sfeng88 @diegogrz
- [ ] @dsingley @EvanOxfeld 
- [x] @joeybrk372 @rygim @jharwig 

Syntax is the same as `org.visallo.graph.options` except instead of getting `cy` as a prop/attribute you get:
```
ol: OpenLayers object
map: OpenLayers map instance
cluster: Map cluster pins source, layers, instances
```
<img width=200 src="https://cloud.githubusercontent.com/assets/7098/20323627/3f2eae58-ab43-11e6-97a0-c62bd8e114ea.png"/>

CHANGELOG
Added: Add map configuration UI with [`org.visallo.map.options`](http://docs.visallo.org/extension-points/front-end/mapOptions/) extension point