### PR TITLE
Fix dashboard freeze by leftover draggable-wrapper (release-2.2)

### DIFF
--- a/web/war/src/main/webapp/js/data/withWorkspaceVertexDrop.js
+++ b/web/war/src/main/webapp/js/data/withWorkspaceVertexDrop.js
@@ -38,6 +38,26 @@ define([], function() {
                 });
 
                 require(['jquery-ui'], function() {
+                  var stopDroppable = function(event, ui) {
+                      $('.draggable-wrapper').remove();
+
+                      // Early exit if should leave to a different droppable
+                      if (!enabled) return;
+
+                        verticesFromDraggable(ui.draggable, self.dataRequestPromise)
+                            .done(function(vertices) {
+                                var graphVisible = $('.graph-pane-2d').is('.visible');
+
+                                if (visalloData.currentWorkspaceEditable && vertices.length) {
+                                    self.trigger('clearWorkspaceFilter');
+                                    self.trigger('verticesDropped', {
+                                        vertices: vertices,
+                                        dropPosition: { x: event.clientX, y: event.clientY }
+                                    });
+                                }
+                            })
+                    };
+
                     droppable.droppable({
                         tolerance: 'pointer',
                         accept: function(item) {
@@ -109,25 +129,8 @@ define([], function() {
                                 }
                             });
                         },
-                        drop: function(event, ui) {
-                            $('.draggable-wrapper').remove();
-
-                            // Early exit if should leave to a different droppable
-                            if (!enabled) return;
-
-                            verticesFromDraggable(ui.draggable, self.dataRequestPromise)
-                                .done(function(vertices) {
-                                    var graphVisible = $('.graph-pane-2d').is('.visible');
-
-                                    if (visalloData.currentWorkspaceEditable && vertices.length) {
-                                        self.trigger('clearWorkspaceFilter');
-                                        self.trigger('verticesDropped', {
-                                            vertices: vertices,
-                                            dropPosition: { x: event.clientX, y: event.clientY }
-                                        });
-                                    }
-                                })
-                        }
+                        deactivate: stopDroppable,
+                        drop: stopDroppable,
                     });
                 });
             }));


### PR DESCRIPTION
- [x] @joeferner
- [x] @kunklejr @mwizeman @sfeng88 @diegogrz
- [ ] @dsingley @EvanOxfeld 
- [x] @joeybrk372 @rygim @jharwig 

CHANGELOG
Fixed: Dashboard does not freeze anymore when cards are moved vertically

When moving the dashboard cards in the way that was shown in issue
1807, the draggable-wrapper that was added is never cleared away. By
registering the method to clear on the deactivate event as well as the
drop event, the wrapper is cleared and the dashboard can be arranged as
normal with no freezing.

This is only being submitted for release-2.2 since the work products
branch on master and in release-3.0 has changes that would remove this
code

Fixes https://github.com/v5analytics/visallo-lts/issues/1807 for branch release-2.2