### PR TITLE
Changed: Collapse equal histogram detail values instead of range

### DIFF
--- a/web/war/src/main/webapp/js/detail/properties/histograms.js
+++ b/web/war/src/main/webapp/js/detail/properties/histograms.js
@@ -598,10 +598,9 @@ define([
             display = i18n('detail.multiple.histogram.other');
         } else if (ontology.properties.byTitle[propertyName]) {
             if ('dx' in bin) {
-                display =
-                    F.vertex.propDisplay(propertyName, bin.x) +
-                    ' – ' +
-                    F.vertex.propDisplay(propertyName, bin.x + bin.dx);
+                const min = F.vertex.propDisplay(propertyName, bin.x);
+                const max = F.vertex.propDisplay(propertyName, bin.x + bin.dx);
+                display = min === max ? min : min + ' – ' + max;
             } else {
                 display = F.vertex.propDisplay(propertyName, propertyValue);
             }


### PR DESCRIPTION
- [x] @joeferner
- [x] @kunklejr @mwizeman @sfeng88 @diegogrz
- [ ] @dsingley @EvanOxfeld 
- [ ] @joeybrk372 @rygim @jharwig 

This change is made in response to user feedback. Thoughts?

This commit changes values shown in the histogram details from "123 - 123" to "123". This only effects values that are exactly equal. If the values are different the previous behavior of displaying the range is maintained.

Before
![visallo-hist-before](https://cloud.githubusercontent.com/assets/808857/20333739/a733c120-ab82-11e6-8ea8-063c332569a0.png)

After
![visallo-hist-after](https://cloud.githubusercontent.com/assets/808857/20333741/abfbd292-ab82-11e6-84e3-bb315a02209b.png)
