### PR TITLE
Changed: Treat zero as a special case for details histogram

### DIFF
--- a/web/war/src/main/webapp/js/detail/properties/histograms.js
+++ b/web/war/src/main/webapp/js/detail/properties/histograms.js
@@ -241,17 +241,31 @@ define([
 
                                                 d.values = values;
 
+                                                var createBin = function(props) {
+                                                    return _.reject(
+                                                        d3.layout.histogram().value(_.property('value'))(props), function(bin) {
+                                                            return bin.length === 0;
+                                                        });
+                                                };
+
                                                 if (ontologyProperty &&
                                                     ~BINABLE_TYPES.indexOf(ontologyProperty.dataType) &&
                                                    !ontologyProperty.possibleValues) {
 
-                                                    var bins = _.reject(
-                                                        d3.layout.histogram().value(_.property('value'))(d[1]), function(bin) {
-                                                        return bin.length === 0;
-                                                    });
+                                                    var lessThanZeroBins = createBin(_.filter(d[1], function(prop) {
+                                                        return prop.value < 0;
+                                                    }));
+                                                    var greaterThanZeroBins = createBin(_.filter(d[1], function(prop) {
+                                                        return prop.value > 0;
+                                                    }));
+                                                    var zeroBins = createBin(_.filter(d[1], function(prop) {
+                                                        return prop.value === 0;
+                                                    }));
 
-                                                    d.bins = bins;
-                                                    return bins.length * BAR_HEIGHT;
+                                                    d.bins = lessThanZeroBins
+                                                        .concat(zeroBins)
+                                                        .concat(greaterThanZeroBins);
+                                                    return d.bins.length * BAR_HEIGHT;
                                                 }
 
                                                 if ('bins' in d) {


### PR DESCRIPTION
- [x] @joeferner
- [ ] @kunklejr @mwizeman @sfeng88 @diegogrz
- [ ] @dsingley @EvanOxfeld 
- [ ] @joeybrk372 @rygim @jharwig 

This change is based on user feedback. Thoughts?

Many times when dealing with numbers zero is a special case, this
commit addresses this by moving zero values into their own histogram
bin.

Before
![visallo-hist-before](https://cloud.githubusercontent.com/assets/808857/20334036/0c854538-ab85-11e6-819b-aad36bb68895.png)

After
![visallo-hist-after](https://cloud.githubusercontent.com/assets/808857/20334037/118d480a-ab85-11e6-8662-139148c8b1df.png)

Combined with PR https://github.com/v5analytics/visallo/pull/737 this can create a nicer histogram. 