### PR TITLE
Fixed: Find related properties missing

### DIFF
--- a/web/war/src/main/webapp/js/search/filters/filters.js
+++ b/web/war/src/main/webapp/js/search/filters/filters.js
@@ -268,6 +268,10 @@ define([
         this.setEdgeTypeFilter = function(edgeId) {
             var self = this;
 
+            if (this.matchType === 'vertex') {
+                return;
+            }
+
             this.edgeLabelFilter = edgeId || '';
             this.trigger(this.select('edgeLabelDropdownSelector'), 'selectRelationshipId', { relationshipId: edgeId });
 
@@ -330,6 +334,10 @@ define([
 
         this.setConceptFilter = function(conceptId) {
             var self = this;
+
+            if (this.matchType === 'edge') {
+                return;
+            }
 
             this.conceptFilter = conceptId || '';
             this.trigger(this.select('conceptDropdownSelector'), 'selectConceptId', { conceptId: conceptId });


### PR DESCRIPTION
- [x] @joeferner
- [x] @kunklejr @mwizeman @sfeng88 @diegogrz
- [ ] @dsingley @EvanOxfeld 
- [ ] @joeybrk372 @rygim @jharwig 

Find related was showing the properties from the edges and not the
vertices. This fix ensures the correct properties are shown.

CHANGELOG
Fixed: Find related properties missing