### PR TITLE
Fix graph images in IE (3.0)

### DIFF
--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/Cytoscape.jsx
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/Cytoscape.jsx
@@ -6,6 +6,7 @@ define([
     'colorjs',
     './betterGrid',
     './Menu',
+    './cytoscapeCorsFix',
     'util/formatters'
 ], function(
     React,
@@ -15,6 +16,7 @@ define([
     colorjs,
     betterGrid,
     Menu,
+    fixCytoscapeCorsHandling,
     F) {
     const { PropTypes } = React;
     const ANIMATION = { duration: 400, easing: 'spring(250, 20)' };
@@ -103,6 +105,7 @@ define([
             this.previousConfig = this.prepareConfig();
             const cy = cytoscape(this.previousConfig);
 
+            fixCytoscapeCorsHandling(cy);
             cytoscape('layout', 'bettergrid', betterGrid);
 
             this.clientRect = this.refs.cytoscape.getBoundingClientRect();

--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/cytoscapeCorsFix.js
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/cytoscapeCorsFix.js
@@ -1,0 +1,48 @@
+define([], function() {
+
+    return function fixCytoscapeCorsHandling(cy) {
+        const r = cy.renderer();
+        if (_.isFunction(r.getCachedImage)) {
+            r.getCachedImage = fixedGetCachedImage;
+        } else {
+            throw new Error('Expected to replace getCachedImage function');
+        }
+    }
+
+    function fixedGetCachedImage(url, onLoad) {
+        if (arguments.length !== 2) {
+            throw new Error('Expected 2 arguments, maybe cytoscape was upgraded?');
+        }
+        if (!_.isString(url)) {
+            throw new Error('Expected string url argument');
+        }
+        if (!_.isFunction(onLoad)) {
+            throw new Error('Expected function onLoad argument');
+        }
+
+        var r = this;
+        var imageCache = r.imageCache = r.imageCache || {};
+        var cache = imageCache[ url ];
+
+        if( cache ){
+            if( !cache.image.complete ){
+                cache.image.addEventListener('load', onLoad);
+            }
+
+            return cache.image;
+        } else {
+            cache = imageCache[ url ] = imageCache[ url ] || {};
+            var image = cache.image = new Image(); // eslint-disable-line no-undef
+            image.addEventListener('load', onLoad);
+            if ((/^(\/\/|http)/).test(url)) {
+                image.crossOrigin = 'Anonymous'; // prevent tainted canvas
+            }
+            image.onerror = function(e){
+                console.warn('Error loading graph image', e)
+            }
+            image.src = url;
+
+            return image;
+        }
+    }
+});


### PR DESCRIPTION
- [x] @joeferner
- [x] @kunklejr @mwizeman @sfeng88 @diegogrz
- [ ] @dsingley @EvanOxfeld 
- [x] @joeybrk372 @rygim @jharwig 

* Caused by cytoscape change to include crossOrigin attribute on image
loading. IE doesn't send credentials (even to same origin) when
requesting image with crossOrigin attribute = 'anonymous'.

So, we replace the function with our own (with some checks to try to
mitigate cytoscape updates breaking it)

https://github.com/v5analytics/visallo-lts/issues/1887