### PR TITLE
Fix IE Drag and Drop (master)

### DIFF
--- a/core/core/src/main/java/org/visallo/core/model/workQueue/WorkQueueRepository.java
+++ b/core/core/src/main/java/org/visallo/core/model/workQueue/WorkQueueRepository.java
@@ -529,12 +529,13 @@ public abstract class WorkQueueRepository {
         broadcastJson(json);
     }
 
-    public void broadcastWorkProductChange(String workProductId, ClientApiWorkspace workspace, User user) {
+    public void broadcastWorkProductChange(String workProductId, ClientApiWorkspace workspace, User user, String skipSourceGuid) {
         JSONObject json = new JSONObject();
         json.put("type", "workProductChange");
         json.put("permissions", getPermissionsWithUsers(workspace, null));
         JSONObject dataJson = new JSONObject();
         dataJson.put("id", workProductId);
+        dataJson.putOpt("skipSourceGuid", skipSourceGuid);
         json.put("data", dataJson);
         broadcastJson(json);
     }

--- a/core/plugins/model-vertexium/src/main/java/org/visallo/vertexium/model/workspace/VertexiumWorkspaceRepository.java
+++ b/core/plugins/model-vertexium/src/main/java/org/visallo/vertexium/model/workspace/VertexiumWorkspaceRepository.java
@@ -1055,7 +1055,15 @@ public class VertexiumWorkspaceRepository extends WorkspaceRepository {
         Workspace ws = findById(workspaceId, user);
         ClientApiWorkspace userWorkspace = toClientApi(ws, user, authorizations);
 
-        getWorkQueueRepository().broadcastWorkProductChange(productVertex.getId(), userWorkspace, user);
+        String skipSourceId = null;
+        if (params != null && params.has("broadcastOptions")) {
+            JSONObject broadcastOptions = params.getJSONObject("broadcastOptions");
+            if (broadcastOptions.optBoolean("preventBroadcastToSourceGuid", false)) {
+                skipSourceId = broadcastOptions.getString("sourceGuid");
+            }
+        }
+        getWorkQueueRepository().broadcastWorkProductChange(productVertex.getId(), userWorkspace, user, skipSourceId);
+
 
         return productVertexToProduct(workspaceId, productVertex, authorizations, null, user);
     }

--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/Cytoscape.jsx
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/Cytoscape.jsx
@@ -108,11 +108,6 @@ define([
             this.clientRect = this.refs.cytoscape.getBoundingClientRect();
             this.setState({ cy })
 
-            cy.on('add remove position', ({ cy, cyTarget }) => {
-                if (cyTarget !== cy && cyTarget.is('node.v')) {
-                    this.updatePreview()
-                }
-            });
             cy.on('tap mouseover mouseout', 'node.decoration', event => {
                 this.props.onDecorationEvent(event);
             });
@@ -596,19 +591,26 @@ define([
 
                         case 'position':
                             if (!cyNode.grabbed() && !(cyNode.id() in this.moving)) {
-                                modifiedPosition = true;
                                 if (!item.data.alignment) {
-                                    if (this.props.animate) {
-                                        this.positionDisabled = true;
-                                        this.updateDecorationPositions(cyNode, { toPosition: item.position, animate: true });
-                                        cyNode.stop().animate({ position: item.position }, { ...ANIMATION, complete: () => {
-                                            this.positionDisabled = false;
-                                        }})
-                                    } else {
-                                        this.disableEvent('position', () => {
-                                            cyNode.position(item.position)
-                                            this.updateDecorationPositions(cyNode);
-                                        })
+                                    const positionChangedWithinTolerance = _.some(cyNode.position(), (oldV, key) => {
+                                        const newV = item.position[key];
+                                        return (Math.max(newV, oldV) - Math.min(newV, oldV)) >= 1
+                                    });
+
+                                    if (positionChangedWithinTolerance) {
+                                        modifiedPosition = true;
+                                        if (this.props.animate) {
+                                            this.positionDisabled = true;
+                                            this.updateDecorationPositions(cyNode, { toPosition: item.position, animate: true });
+                                            cyNode.stop().animate({ position: item.position }, { ...ANIMATION, complete: () => {
+                                                this.positionDisabled = false;
+                                            }})
+                                        } else {
+                                            this.disableEvent('position', () => {
+                                                cyNode.position(item.position)
+                                                this.updateDecorationPositions(cyNode);
+                                            })
+                                        }
                                     }
                                 }
                             } else if (this.layoutDone) {

--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/GraphContainer.jsx
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/GraphContainer.jsx
@@ -8,6 +8,7 @@ define([
     'components/DroppableHOC',
     'configuration/plugins/registry',
     'util/retina',
+    'util/dnd',
     './worker/actions',
     './Graph'
 ], function(
@@ -20,6 +21,7 @@ define([
     DroppableHOC,
     registry,
     retina,
+    dnd,
     graphActions,
     Graph) {
     'use strict';
@@ -252,13 +254,12 @@ define([
                     }
                 },
                 onDrop: (event, position) => {
-                    const dataStr = event.dataTransfer.getData(VISALLO_MIMETYPES.ELEMENTS);
-                    if (dataStr) {
+                    const { dataTransfer } = event;
+                    const elements = dnd.getElementsFromDataTransfer(dataTransfer);
+                    if (elements) {
                         event.preventDefault();
                         event.stopPropagation();
-
-                        const data = JSON.parse(dataStr);
-                        dispatch(graphActions.dropElements(props.product.id, data.elements, position))
+                        dispatch(graphActions.dropElements(props.product.id, elements, position))
                     }
                 },
                 onDropElementIds: (elementIds, position) => {

--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/plugin.js
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/plugin.js
@@ -2,22 +2,17 @@ require(['configuration/plugins/registry'], function(registry) {
     registry.registerExtension('org.visallo.workproduct', {
         identifier: 'org.visallo.web.product.graph.GraphWorkProduct',
         componentPath: 'org/visallo/web/product/graph/dist/Graph',
-        handleDrop: function(event, product) {
-            const dataStr = event.dataTransfer.getData(window.VISALLO_MIMETYPES.ELEMENTS);
-            if (dataStr) {
-                const data = JSON.parse(dataStr);
-                visalloData.storePromise.then(function(store) {
-                    store.dispatch({
-                        type: 'ROUTE_TO_WORKER_ACTION',
-                        payload: { productId: product.id, elements: data.elements},
-                        meta: {
-                            workerImpl: 'org/visallo/web/product/graph/dist/actions-impl',
-                            name: 'dropElements'
-                        }
-                    })
+        handleDrop: function(elements, product) {
+            visalloData.storePromise.then(function(store) {
+                store.dispatch({
+                    type: 'ROUTE_TO_WORKER_ACTION',
+                    payload: { productId: product.id, elements },
+                    meta: {
+                        workerImpl: 'org/visallo/web/product/graph/dist/actions-impl',
+                        name: 'dropElements'
+                    }
                 })
-                return true;
-            }
+            })
         }
     })
 

--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/webpack.config.js
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/webpack.config.js
@@ -20,6 +20,7 @@ var VisalloAmdExternals = [
     'util/formatters',
     'util/vertex/formatters',
     'util/retina',
+    'util/dnd',
     'util/withContextMenu',
     'util/withDataRequest',
     'util/withTeardown',

--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/worker/actions-impl.js
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/worker/actions-impl.js
@@ -48,24 +48,19 @@ define([
             }
 
             const workspaceId = getState().workspace.currentId;
+            updateVertices = _.mapObject(updateVertices, pos => {
+                return _.mapObject(pos, v => Math.round(v));
+            });
             dispatch({
                 type: 'PRODUCT_GRAPH_SET_POSITIONS',
                 payload: {
                     productId,
                     updateVertices,
+                    snapToGrid,
                     workspaceId
                 }
             })
             if (snapToGrid) {
-                dispatch({
-                    type: 'PRODUCT_GRAPH_SET_POSITIONS',
-                    payload: {
-                        productId,
-                        updateVertices,
-                        snapToGrid,
-                        workspaceId
-                    }
-                })
                 const product = getState().product.workspaces[workspaceId].products[productId];
                 const byId = _.indexBy(product.extendedData.vertices, 'id');
                 updateVertices = _.mapObject(updateVertices, (pos, id) => {
@@ -73,7 +68,15 @@ define([
                 });
             }
 
-            ajax('POST', '/product', { productId, params: { updateVertices } });
+            ajax('POST', '/product', {
+                productId,
+                params: {
+                    updateVertices,
+                    broadcastOptions: {
+                        preventBroadcastToSourceGuid: true
+                    } 
+                },
+            });
         },
 
         updatePositions: ({ productId, updateVertices }) => (dispatch, getState) => {

--- a/web/plugins/map-product/src/main/resources/org/visallo/web/product/map/MapContainer.jsx
+++ b/web/plugins/map-product/src/main/resources/org/visallo/web/product/map/MapContainer.jsx
@@ -5,10 +5,11 @@ define([
     'data/web-worker/store/selection/actions',
     'data/web-worker/store/product/actions',
     'data/web-worker/store/product/selectors',
+    'util/dnd',
     './worker/actions',
     'components/DroppableHOC',
     './Map'
-], function(React, redux, ReactDom, selectionActions, productActions, productSelectors, mapActions, DroppableHOC, Map) {
+], function(React, redux, ReactDom, selectionActions, productActions, productSelectors, dnd, mapActions, DroppableHOC, Map) {
     'use strict';
 
     const mimeTypes = [VISALLO_MIMETYPES.ELEMENTS];
@@ -46,14 +47,12 @@ define([
 
                 // For DroppableHOC
                 onDrop: (event) => {
-                    const dataStr = event.dataTransfer.getData(VISALLO_MIMETYPES.ELEMENTS);
-                    if (dataStr) {
+                    const elements = dnd.getElementsFromDataTransfer(event.dataTransfer);
+                    if (elements) {
                         event.preventDefault();
                         event.stopPropagation();
 
-                        const data = JSON.parse(dataStr);
-                        // TODO: mapActions
-                        dispatch(mapActions.dropElements(props.product.id, data.elements))
+                        dispatch(mapActions.dropElements(props.product.id, elements))
                     }
                 },
 

--- a/web/plugins/map-product/src/main/resources/org/visallo/web/product/map/plugin.js
+++ b/web/plugins/map-product/src/main/resources/org/visallo/web/product/map/plugin.js
@@ -2,22 +2,17 @@ require(['configuration/plugins/registry'], function(registry) {
     registry.registerExtension('org.visallo.workproduct', {
         identifier: 'org.visallo.web.product.map.MapWorkProduct',
         componentPath: 'org/visallo/web/product/map/dist/Map',
-        handleDrop: function(event, product) {
-            const dataStr = event.dataTransfer.getData(window.VISALLO_MIMETYPES.ELEMENTS);
-            if (dataStr) {
-                const data = JSON.parse(dataStr);
-                visalloData.storePromise.then(function(store) {
-                    store.dispatch({
-                        type: 'ROUTE_TO_WORKER_ACTION',
-                        payload: { productId: product.id, elements: data.elements},
-                        meta: {
-                            workerImpl: 'org/visallo/web/product/map/dist/actions-impl',
-                            name: 'dropElements'
-                        }
-                    })
+        handleDrop: function(elements, product) {
+            visalloData.storePromise.then(function(store) {
+                store.dispatch({
+                    type: 'ROUTE_TO_WORKER_ACTION',
+                    payload: { productId: product.id, elements },
+                    meta: {
+                        workerImpl: 'org/visallo/web/product/map/dist/actions-impl',
+                        name: 'dropElements'
+                    }
                 })
-                return true;
-            }
+            })
         }
     })
     $(document).on('applicationReady currentUserVisalloDataUpdated', function() {

--- a/web/plugins/map-product/src/main/resources/org/visallo/web/product/map/webpack.config.js
+++ b/web/plugins/map-product/src/main/resources/org/visallo/web/product/map/webpack.config.js
@@ -12,6 +12,7 @@ var VisalloAmdExternals = [
     'data/web-worker/store/user/actions-impl',
     'data/web-worker/util/ajax',
     'public/v1/api',
+    'util/dnd',
     'util/formatters',
     'util/popovers/fileImport/fileImport',
     'util/vertex/formatters',

--- a/web/war/src/main/webapp/js/components/DroppableHOC.jsx
+++ b/web/war/src/main/webapp/js/components/DroppableHOC.jsx
@@ -1,4 +1,4 @@
-define(['react'], function(React) {
+define(['react', 'util/dnd'], function(React, dnd) {
     'use strict';
 
     const Events = 'dragover dragenter dragleave drop'.split(' ');
@@ -28,7 +28,7 @@ define(['react'], function(React) {
             })
         },
         dataTransferHasValidMimeType(dataTransfer) {
-            return _.any(dataTransfer.types, type => this.props.mimeTypes.includes(type));
+            return dnd.dataTransferHasValidMimeType(dataTransfer, this.props.mimeTypes)
         },
         dragover(event) {
             const { dataTransfer } = event;

--- a/web/war/src/main/webapp/js/data/web-worker/handlers/websocketMessage.js
+++ b/web/war/src/main/webapp/js/data/web-worker/handlers/websocketMessage.js
@@ -24,6 +24,13 @@ define([
                 })
             },
             workProductChange: function(data) {
+                const guid = publicData.socketSourceGuid;
+                if ('skipSourceGuid' in data) {
+                    if (guid === data.skipSourceGuid) {
+                        return;
+                    }
+                }
+
                 require(['../store/product/actions-impl'], function(actions) {
                     store.getStore().dispatch(actions.changedOnServer(data.id));
                 })

--- a/web/war/src/main/webapp/js/data/web-worker/store/product/actions-impl.js
+++ b/web/war/src/main/webapp/js/data/web-worker/store/product/actions-impl.js
@@ -45,9 +45,6 @@ define([
         }),
 
         changedOnServer: (productId) => (dispatch, getState) => {
-            // TODO: Should check current workspace
-            // not current ? just mark it invalid
-            // is current  ? is it selected ? get : load list
             dispatch(api.get({ productId, invalidate: true }));
         },
 

--- a/web/war/src/main/webapp/js/detail/detectedObjects/detectedObjects.js
+++ b/web/war/src/main/webapp/js/detail/detectedObjects/detectedObjects.js
@@ -3,6 +3,7 @@ define([
     'util/withDataRequest',
     'util/vertex/formatters',
     'util/privileges',
+    'util/dnd',
     'd3',
     'require'
 ], function(
@@ -10,6 +11,7 @@ define([
     withDataRequest,
     F,
     Privileges,
+    dnd,
     d3,
     require) {
     'use strict';
@@ -299,7 +301,7 @@ define([
                         const dt = event.originalEvent.dataTransfer;
 
                         dt.effectAllowed = 'all';
-                        dt.setData(VISALLO_MIMETYPES.ELEMENTS, JSON.stringify({ elements }));
+                        dnd.setDataTransferWithElements(dt, elements);
                     });
             })
         };

--- a/web/war/src/main/webapp/js/detail/item/withItem.js
+++ b/web/war/src/main/webapp/js/detail/item/withItem.js
@@ -4,6 +4,7 @@ define([
     'util/vertex/formatters',
     'util/withDataRequest',
     'util/privileges',
+    'util/dnd',
     'require'
 ], function(
     withElementScrolling,
@@ -11,6 +12,7 @@ define([
     F,
     withDataRequest,
     Privileges,
+    dnd,
     require) {
     'use strict';
 
@@ -119,10 +121,10 @@ define([
                     dt.effectAllowed = 'all';
                     if (model.id === id) {
                         const url = F.vertexUrl.url([model], visalloData.currentWorkspaceId);
-                        dt.setData('text/uri-list', url);
-                        dt.setData('text/plain', [F.vertex.title(model), url].join('\n'));
+                        dnd.setDataTransferWithElements(dt, { elements: [model] })
+                    } else {
+                        dnd.setDataTransferWithElements(dt, elements);
                     }
-                    dt.setData(VISALLO_MIMETYPES.ELEMENTS, JSON.stringify({ elements }));
                 })
         };
 

--- a/web/war/src/main/webapp/js/detail/text/text.js
+++ b/web/war/src/main/webapp/js/detail/text/text.js
@@ -8,6 +8,7 @@ define([
     'util/jquery.withinScrollable',
     'util/withCollapsibleSections',
     'util/popovers/propertyInfo/withPropertyInfo',
+    'util/dnd',
     'colorjs',
     'hbs!./transcriptEntries',
     'tpl!util/alert',
@@ -23,6 +24,7 @@ define([
     jqueryWithinScrollable,
     withCollapsibleSections,
     withPropertyInfo,
+    dnd,
     colorjs,
     transcriptEntriesTemplate,
     alertTemplate,
@@ -914,8 +916,7 @@ define([
                                     const dt = event.originalEvent.dataTransfer;
                                     const elements = { vertexIds: [info.resolvedToVertexId], edgeIds: [] };
                                     dt.effectAllowed = 'all';
-                                    dt.setData(VISALLO_MIMETYPES.ELEMENTS, JSON.stringify({ elements }));
-                                    dt.setData(VISALLO_MIMETYPES.RESOLVED_INFO, JSON.stringify({ info }));
+                                    dnd.setDataTransferWithElements(dt, elements);
                                     $(this).closest('.text').addClass('drag-focus');
                                     currentlyDragging = event.target;
                                 })

--- a/web/war/src/main/webapp/js/product/ProductListItem.jsx
+++ b/web/war/src/main/webapp/js/product/ProductListItem.jsx
@@ -1,7 +1,8 @@
 define([
     'react',
-    'components/DroppableHOC'
-], function(React, DroppableHOC) {
+    'components/DroppableHOC',
+    'util/dnd'
+], function(React, DroppableHOC, dnd) {
     'use strict';
 
     const MaxTitleLength = 128;
@@ -137,7 +138,9 @@ define([
                 });
 
                 if (_.isFunction(extension.handleDrop)) {
-                    if (extension.handleDrop(e, props.product)) {
+                    const elements = dnd.getElementsFromDataTransfer(e.dataTransfer);
+                    if (elements) {
+                        extension.handleDrop(elements, props.product);
                         e.preventDefault();
                         e.stopPropagation();
                     }

--- a/web/war/src/main/webapp/js/util/dnd.js
+++ b/web/war/src/main/webapp/js/util/dnd.js
@@ -1,0 +1,80 @@
+define(['util/vertex/formatters'], function(F) {
+
+    const FALLBACK_PREFIX = 'Visallo_ElementIds: ';
+
+    // IE doesn't support setData([mimetype], ...)
+    // if only supports setData('text', ...)
+    const checkIfSupportsMultipleTypes = _.once((fn, dataTransfer) => {
+        try {
+            if (fn === 'set') {
+                dataTransfer.setData('CHECK_ALLOWS_MANY_TYPES', 'true')
+            } else {
+                dataTransfer.getData('CHECK_ALLOWS_MANY_TYPES')
+            }
+            return true;
+        } catch(e) {
+            return false;
+        }
+    })
+
+    return {
+        dataTransferHasValidMimeType(dataTransfer, mimeTypes = []) {
+            if (checkIfSupportsMultipleTypes('get', dataTransfer)) {
+                return _.any(dataTransfer.types, type => mimeTypes.includes(type));
+            }
+            return true;
+        },
+        setDataTransferWithElements(dataTransfer, { vertexIds, edgeIds, elements = [] }) {
+            const typeToData = segmentToTypes(vertexIds, edgeIds, elements);
+            if (checkIfSupportsMultipleTypes('set', dataTransfer)) {
+                _.each(typeToData, (data, type) => {
+                    if (data) {
+                        dataTransfer.setData(type, data);
+                    }
+                })
+            } else {
+                dataTransfer.setData('Text', FALLBACK_PREFIX + typeToData[VISALLO_MIMETYPES.ELEMENTS])
+            }
+        },
+        getElementsFromDataTransfer(dataTransfer) {
+            var dataStr;
+            if (checkIfSupportsMultipleTypes('get', dataTransfer)) {
+                dataStr = dataTransfer.getData(VISALLO_MIMETYPES.ELEMENTS);
+            } else {
+                const text = dataTransfer.getData('Text');
+                if (text.indexOf(FALLBACK_PREFIX) === 0) {
+                    dataStr = text.substring(FALLBACK_PREFIX.length);
+                }
+            }
+
+            if (dataStr) {
+                return JSON.parse(dataStr);
+            }
+        }
+    }
+
+    function segmentToTypes(vertexIds = [], edgeIds = [], elements) {
+        const hasFullElements = elements.length > 0;
+        if (hasFullElements) {
+            vertexIds = [];
+            edgeIds = [];
+            elements.forEach(({ id, type }) => {
+                if (type === 'vertex') {
+                    vertexIds.push(id);
+                } else {
+                    edgeIds.push(id);
+                }
+            })
+        }
+        const url = F.vertexUrl.url(hasFullElements ? elements : vertexIds.concat(edgeIds), visalloData.currentWorkspaceId);
+        const plain = hasFullElements && elements.map(item => [
+                F.vertex.title(item), F.vertexUrl.url([item], visalloData.currentWorkspaceId)
+            ].join('\n')).join('\n\n') || null;
+
+        return {
+            'text/uri-list': url,
+            'text/plain': plain,
+            [VISALLO_MIMETYPES.ELEMENTS]: JSON.stringify({ vertexIds, edgeIds })
+        }
+    }
+})

--- a/web/war/src/main/webapp/js/util/withFileDrop.js
+++ b/web/war/src/main/webapp/js/util/withFileDrop.js
@@ -54,7 +54,10 @@ define([
 
                     if (self.$node.hasClass('uploading')) return;
                     if (e.dataTransfer.files.length === 0 &&
-                        e.dataTransfer.items.length === 0) return;
+                        (!e.dataTransfer.items ||
+                          e.dataTransfer.items.length === 0)) {
+                        return;
+                    }
 
                     if (Privileges.canEDIT) {
                         var dt = e.dataTransfer,

--- a/web/war/src/main/webapp/js/workspaces/diff/diff.js
+++ b/web/war/src/main/webapp/js/workspaces/diff/diff.js
@@ -4,13 +4,15 @@ define([
     'react-dom',
     './DiffPanel',
     'util/vertex/formatters',
-    'util/withDataRequest'
+    'util/withDataRequest',
+    'util/dnd'
 ], function(
     defineComponent,
     ReactDOM,
     DiffPanel,
     F,
-    withDataRequest) {
+    withDataRequest,
+    dnd) {
     'use strict';
 
     var SHOW_CHANGES_TEXT_SECONDS = 3;
@@ -546,7 +548,7 @@ define([
                     const dt = event.originalEvent.dataTransfer;
 
                     dt.effectAllowed = 'all';
-                    dt.setData(VISALLO_MIMETYPES.ELEMENTS, JSON.stringify({ elements }));
+                    dnd.setDataTransferWithElements(dt, elements);
                 });
         };
 

--- a/web/web-base/src/main/java/org/visallo/web/routes/product/ProductUpdate.java
+++ b/web/web-base/src/main/java/org/visallo/web/routes/product/ProductUpdate.java
@@ -12,6 +12,7 @@ import org.visallo.core.user.User;
 import org.visallo.core.util.ClientApiConverter;
 import org.visallo.web.clientapi.model.ClientApiProduct;
 import org.visallo.web.parameterProviders.ActiveWorkspaceId;
+import org.visallo.web.parameterProviders.SourceGuid;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.ResourceBundle;
@@ -32,6 +33,7 @@ public class ProductUpdate implements ParameterizedHandler {
             @Optional(name = "params") String paramsStr,
             @Optional(name = "preview") String previewDataUrl,
             @ActiveWorkspaceId String workspaceId,
+            @SourceGuid String sourceGuid,
             Authorizations authorizations,
             ResourceBundle resourceBundle,
             HttpServletRequest request,
@@ -43,6 +45,9 @@ public class ProductUpdate implements ParameterizedHandler {
         }
         Product product = null;
         if (previewDataUrl == null) {
+            if (params != null && params.has("broadcastOptions")) {
+                params.getJSONObject("broadcastOptions").put("sourceGuid", sourceGuid);
+            }
             product = workspaceRepository.addOrUpdateProduct(workspaceId, productId, title, kind, params, user);
         } else {
             product = workspaceRepository.updateProductPreview(workspaceId, productId, previewDataUrl, user);


### PR DESCRIPTION
- [x] @joeferner
- [x] @kunklejr @mwizeman @sfeng88 @diegogrz
- [ ] @dsingley @EvanOxfeld 
- [x] @joeybrk372 @rygim @jharwig 

* We used custom types in dataTransfer which isn't supported in IE, so
switched to helper util that put it in "Text" for browsers that don't
support it.
* Also some fixes for fast moving of vertices causing them to jump back
to previous positions using sourceGuid to ignore vertex changes that the
browser initiated
* Finally fixed search results to set the `li` to be draggable instead
of the `a` because IE wasn't working with that element.