### PR TITLE
Changed: Multi-select detail histogram bottom margin

### DIFF
--- a/web/war/src/main/webapp/less/detail/detail.less
+++ b/web/war/src/main/webapp/less/detail/detail.less
@@ -416,7 +416,7 @@
     ul.histograms {
       list-style: none;
       padding: 0;
-      margin: 0 1em 3em 1em;
+      margin: 0 1em 0 1em;
       overflow-x: hidden;
       li {
         padding: 0;


### PR DESCRIPTION
- [x] @joeferner
- [x] @kunklejr @mwizeman @sfeng88 @diegogrz
- [ ] @dsingley @EvanOxfeld 
- [ ] @joeybrk372 @rygim @jharwig 

When adding a multi-select details plugin the margin of the histogram pushes the additional plugin way down. This removes this gap.

Anyone have any idea why this margin was there in the first place? @jharwig 

Before
![image](https://cloud.githubusercontent.com/assets/808857/20417184/a731275e-ad11-11e6-8247-b11c0f4afc03.png)

After
![image](https://cloud.githubusercontent.com/assets/808857/20417195/b052e598-ad11-11e6-942a-a9d396ae5102.png)
