### PR TITLE
Fix workspace privileges

### DIFF
--- a/web/war/src/main/webapp/js/data/withWorkspaces.js
+++ b/web/war/src/main/webapp/js/data/withWorkspaces.js
@@ -41,6 +41,9 @@ define(['util/undoManager'], function(UndoManager) {
                         _.each(state.workspace.byId, (workspace, id) => {
                             const workspaceChanged = previous.workspace.byId[id] !== workspace;
                             if (workspaceChanged) {
+                                this.setPublicApi('currentWorkspaceName', workspace.title);
+                                this.setPublicApi('currentWorkspaceEditable', workspace.editable);
+                                this.setPublicApi('currentWorkspaceCommentable', workspace.commentable);
                                 this.trigger('workspaceUpdated', { workspace })
                             }
                         });


### PR DESCRIPTION
- [x] @joeferner
- [ ] @kunklejr @mwizeman @sfeng88 @diegogrz
- [ ] @dsingley @EvanOxfeld 
- [x] @joeybrk372 @rygim @jharwig 

When the workspace was updated the `visalloData.currentWorkspace[...]` variables weren't updating. Legacy flight components rely on these. They only changed on switching workspaces.
    
Fixes detail pane showing comment reply buttons and add property/comment toolbar items

https://github.com/v5analytics/visallo-lts/issues/1891