### PR TITLE
Fix trying to append acls when user is null(3.0)

### DIFF
--- a/core/core/src/main/java/org/visallo/core/security/ACLProvider.java
+++ b/core/core/src/main/java/org/visallo/core/security/ACLProvider.java
@@ -257,6 +257,9 @@ public abstract class ACLProvider {
     }
 
     public final ClientApiObject appendACL(ClientApiObject clientApiObject, User user) {
+        if (user == null) {
+            return clientApiObject;
+        }
         Set<String> privileges = privilegeRepository.getPrivileges(user);
         return appendACL(clientApiObject, privileges, user);
     }


### PR DESCRIPTION
- [x] @joeferner
- [ ] @kunklejr @mwizeman @sfeng88 @diegogrz
- [ ] @dsingley @EvanOxfeld 
- [x] @joeybrk372 @rygim @jharwig 

CHANGELOG
Fixed: After a successful logout, a 'Server is not available' message would appear.
