### PR TITLE
Add route to get saved search on a workspace

### DIFF
--- a/core/core/src/main/java/org/visallo/core/model/search/SearchRepository.java
+++ b/core/core/src/main/java/org/visallo/core/model/search/SearchRepository.java
@@ -36,6 +36,8 @@ public abstract class SearchRepository {
 
     public abstract ClientApiSearch getSavedSearch(String id, User user);
 
+    public abstract ClientApiSearch getSavedSearchOnWorkspace(String id, User user, String workspaceId);
+
     public abstract void deleteSearch(String id, User user);
 
     public SearchRunner findSearchRunnerByUri(String searchUri) {

--- a/web/war/src/main/webapp/js/data/web-worker/services/search.js
+++ b/web/war/src/main/webapp/js/data/web-worker/services/search.js
@@ -50,6 +50,12 @@ define(['../util/ajax'], function(ajax) {
             });
         },
 
+        get: function(queryId) {
+            return ajax('GET', '/search', {
+                id: queryId
+            });
+        },
+
         run: function(queryId, otherParams) {
             return ajax('GET', '/search/run', _.extend({}, otherParams || {}, {
                 id: queryId

--- a/web/web-base/src/main/java/org/visallo/web/Router.java
+++ b/web/web-base/src/main/java/org/visallo/web/Router.java
@@ -44,10 +44,7 @@ import org.visallo.web.routes.product.*;
 import org.visallo.web.routes.resource.MapMarkerImage;
 import org.visallo.web.routes.resource.ResourceExternalGet;
 import org.visallo.web.routes.resource.ResourceGet;
-import org.visallo.web.routes.search.SearchDelete;
-import org.visallo.web.routes.search.SearchList;
-import org.visallo.web.routes.search.SearchRun;
-import org.visallo.web.routes.search.SearchSave;
+import org.visallo.web.routes.search.*;
 import org.visallo.web.routes.user.*;
 import org.visallo.web.routes.vertex.*;
 import org.visallo.web.routes.workspace.*;
@@ -124,6 +121,7 @@ public class Router extends HttpServlet {
 
             app.post("/search/save", authenticator, csrfProtector, SearchSave.class);
             app.get("/search/all", authenticator, csrfProtector, SearchList.class);
+            app.get("/search", authenticator, csrfProtector, SearchGet.class);
             app.get("/search/run", authenticator, csrfProtector, SearchRun.class);
             app.post("/search/run", authenticator, csrfProtector, SearchRun.class);
             app.delete("/search", authenticator, csrfProtector, SearchDelete.class);

--- a/web/web-base/src/main/java/org/visallo/web/routes/search/SearchGet.java
+++ b/web/web-base/src/main/java/org/visallo/web/routes/search/SearchGet.java
@@ -1,0 +1,35 @@
+package org.visallo.web.routes.search;
+
+import com.google.inject.Inject;
+import com.v5analytics.webster.ParameterizedHandler;
+import com.v5analytics.webster.annotations.Handle;
+import com.v5analytics.webster.annotations.Required;
+import org.visallo.core.exception.VisalloResourceNotFoundException;
+import org.visallo.core.model.search.SearchRepository;
+import org.visallo.core.user.User;
+import org.visallo.web.clientapi.model.ClientApiSearch;
+import org.visallo.web.parameterProviders.ActiveWorkspaceId;
+
+public class SearchGet implements ParameterizedHandler {
+    private final SearchRepository searchRepository;
+
+    @Inject
+    public SearchGet(SearchRepository searchRepository) {
+        this.searchRepository = searchRepository;
+    }
+
+    @Handle
+    public ClientApiSearch handle(
+            @Required(name = "id") String id,
+            @ActiveWorkspaceId String workspaceId,
+            User user
+    ) throws Exception {
+        ClientApiSearch search = this.searchRepository.getSavedSearchOnWorkspace(id, user, workspaceId);
+
+        if (search == null) {
+            throw new VisalloResourceNotFoundException("Could not find search with id: " + id);
+        }
+
+        return search;
+    }
+}


### PR DESCRIPTION
- [x] @joeferner
- [x] @kunklejr @mwizeman @sfeng88 @diegogrz
- [ ] @dsingley @EvanOxfeld 
- [x] @joeybrk372 @rygim @jharwig 

Also updated saved search cards to get the search first before running it.

CHANGELOG
Fixed: Saved search cards will now show configuration message instead of an error if the search they were configured to run has been deleted.

