### PR TITLE
Remove search related icon in fullscreen vertex details

### DIFF
--- a/web/war/src/main/webapp/js/detail/relationships/relationships.js
+++ b/web/war/src/main/webapp/js/detail/relationships/relationships.js
@@ -205,9 +205,11 @@ define([
                                 this.append('h1')
                                     .call(function() {
                                         this.append('strong');
-                                        this.append('s')
-                                            .attr('class', 'search-related')
-                                            .attr('title', i18n('detail.entity.relationships.open_in_search'));
+                                        if (!visalloData.isFullscreen) {
+                                            this.append('s')
+                                                .attr('class', 'search-related')
+                                                .attr('title', i18n('detail.entity.relationships.open_in_search'));
+                                        }
                                         this.append('span').attr('class', 'badge');
                                     });
                                 this.append('div');


### PR DESCRIPTION
- [x] @joeferner
- [ ] @kunklejr @mwizeman @sfeng88 @diegogrz
- [ ] @dsingley @EvanOxfeld 
- [ ] @joeybrk372 @rygim @jharwig 

CHANGELOG
Fixed: Search related icon on relationship sections in vertex detail panes no longer shows in fullscreen details where search is not available.
