### PR TITLE
Gpw refactor

### DIFF
--- a/core/core-test/src/main/java/org/visallo/core/ingest/graphProperty/GraphPropertyWorkerTestBase.java
+++ b/core/core-test/src/main/java/org/visallo/core/ingest/graphProperty/GraphPropertyWorkerTestBase.java
@@ -3,7 +3,6 @@ package org.visallo.core.ingest.graphProperty;
 import com.google.inject.Injector;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
-import org.json.JSONObject;
 import org.junit.After;
 import org.junit.Before;
 import org.mockito.Mock;
@@ -297,7 +296,7 @@ public abstract class GraphPropertyWorkerTestBase {
         return graphRepository;
     }
 
-    protected List<JSONObject> getGraphPropertyQueue() {
+    protected List<byte[]> getGraphPropertyQueue() {
         return InMemoryWorkQueueRepository.getQueue(workQueueNames.getGraphPropertyQueueName());
     }
 

--- a/core/core-test/src/main/java/org/visallo/core/model/workQueue/WorkQueueRepositoryTest.java
+++ b/core/core-test/src/main/java/org/visallo/core/model/workQueue/WorkQueueRepositoryTest.java
@@ -149,8 +149,8 @@ public class WorkQueueRepositoryTest {
         workQueueRepository.pushGraphVisalloPropertyQueue(element, properties, Priority.HIGH);
 
         assertEquals(1, workQueueRepository.getWorkQueue().size());
-        GraphPropertyMessage message = new GraphPropertyMessage(workQueueRepository.getWorkQueue().get(0));
-        assertEquals(3, message.getProperties().length());
+        GraphPropertyMessage message = GraphPropertyMessage.create(workQueueRepository.getWorkQueue().get(0));
+        assertEquals(3, message.getProperties().length);
     }
 
     public class TestWorkQueueRepository extends WorkQueueRepository {

--- a/core/core-test/src/main/java/org/visallo/core/model/workQueue/WorkQueueRepositoryTest.java
+++ b/core/core-test/src/main/java/org/visallo/core/model/workQueue/WorkQueueRepositoryTest.java
@@ -6,13 +6,15 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-import org.vertexium.Authorizations;
-import org.vertexium.Graph;
+import org.vertexium.*;
 import org.vertexium.inmemory.InMemoryGraph;
 import org.visallo.core.config.Configuration;
 import org.visallo.core.ingest.WorkerSpout;
+import org.visallo.core.ingest.graphProperty.GraphPropertyMessage;
 import org.visallo.core.model.FlushFlag;
 import org.visallo.core.model.WorkQueueNames;
+import org.visallo.core.model.properties.VisalloProperties;
+import org.visallo.core.model.properties.types.VisalloPropertyUpdate;
 import org.visallo.core.model.user.AuthorizationRepository;
 import org.visallo.core.model.user.UserRepository;
 import org.visallo.core.model.workspace.Workspace;
@@ -22,6 +24,7 @@ import org.visallo.core.user.User;
 import org.visallo.web.clientapi.model.ClientApiWorkspace;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -34,6 +37,7 @@ import static org.mockito.Mockito.when;
 public class WorkQueueRepositoryTest {
     private TestWorkQueueRepository workQueueRepository;
     private Graph graph;
+    private Authorizations authorizations;
 
     @Mock
     private WorkQueueNames workQueueNames;
@@ -62,6 +66,7 @@ public class WorkQueueRepositoryTest {
     @Before
     public void before() {
         graph = InMemoryGraph.create();
+        authorizations = graph.createAuthorizations();
         workQueueRepository = new TestWorkQueueRepository(
                 graph,
                 workQueueNames,
@@ -129,8 +134,29 @@ public class WorkQueueRepositoryTest {
         assertEquals("123-123-1234", json.getString("sourceGuid"));
     }
 
+    @Test
+    public void testPushGraphVisalloPropertyQueue() {
+        Visibility visibility = new Visibility("");
+        VertexBuilder m = graph.prepareVertex("v1", visibility);
+        VisalloProperties.COMMENT.addPropertyValue(m, "k1", "comment1", visibility);
+        VisalloProperties.COMMENT.addPropertyValue(m, "k2", "comment2", visibility);
+        VisalloProperties.COMMENT.addPropertyValue(m, "k3", "comment3", visibility);
+        Vertex element = m.save(authorizations);
+
+        List<VisalloPropertyUpdate> properties = new ArrayList<>();
+        properties.add(new VisalloPropertyUpdate(VisalloProperties.COMMENT, "k1"));
+        properties.add(new VisalloPropertyUpdate(VisalloProperties.COMMENT, "k2"));
+        properties.add(new VisalloPropertyUpdate(VisalloProperties.COMMENT, "k3"));
+        workQueueRepository.pushGraphVisalloPropertyQueue(element, properties, Priority.HIGH);
+
+        assertEquals(1, workQueueRepository.getWorkQueue().size());
+        GraphPropertyMessage message = new GraphPropertyMessage(workQueueRepository.getWorkQueue().get(0));
+        assertEquals(3, message.getProperties().length());
+    }
+
     public class TestWorkQueueRepository extends WorkQueueRepository {
         public List<JSONObject> broadcastJsonValues = new ArrayList<>();
+        public Map<String, List<JSONObject>> queues = new HashMap<>();
 
         public TestWorkQueueRepository(
                 Graph graph,
@@ -153,7 +179,16 @@ public class WorkQueueRepositoryTest {
 
         @Override
         public void pushOnQueue(String queueName, @Deprecated FlushFlag flushFlag, JSONObject json, Priority priority) {
+            List<JSONObject> queue = queues.get(queueName);
+            if (queue == null) {
+                queue = new ArrayList<>();
+                queues.put(queueName, queue);
+            }
+            queue.add(json);
+        }
 
+        public List<JSONObject> getWorkQueue() {
+            return queues.get(workQueueNames.getGraphPropertyQueueName());
         }
 
         @Override

--- a/core/core-test/src/main/java/org/visallo/core/model/workQueue/WorkQueueRepositoryTest.java
+++ b/core/core-test/src/main/java/org/visallo/core/model/workQueue/WorkQueueRepositoryTest.java
@@ -11,7 +11,6 @@ import org.vertexium.inmemory.InMemoryGraph;
 import org.visallo.core.config.Configuration;
 import org.visallo.core.ingest.WorkerSpout;
 import org.visallo.core.ingest.graphProperty.GraphPropertyMessage;
-import org.visallo.core.model.FlushFlag;
 import org.visallo.core.model.WorkQueueNames;
 import org.visallo.core.model.properties.VisalloProperties;
 import org.visallo.core.model.properties.types.VisalloPropertyUpdate;
@@ -156,7 +155,7 @@ public class WorkQueueRepositoryTest {
 
     public class TestWorkQueueRepository extends WorkQueueRepository {
         public List<JSONObject> broadcastJsonValues = new ArrayList<>();
-        public Map<String, List<JSONObject>> queues = new HashMap<>();
+        public Map<String, List<byte[]>> queues = new HashMap<>();
 
         public TestWorkQueueRepository(
                 Graph graph,
@@ -178,16 +177,16 @@ public class WorkQueueRepositoryTest {
         }
 
         @Override
-        public void pushOnQueue(String queueName, @Deprecated FlushFlag flushFlag, JSONObject json, Priority priority) {
-            List<JSONObject> queue = queues.get(queueName);
+        public void pushOnQueue(String queueName, byte[] data, Priority priority) {
+            List<byte[]> queue = queues.get(queueName);
             if (queue == null) {
                 queue = new ArrayList<>();
                 queues.put(queueName, queue);
             }
-            queue.add(json);
+            queue.add(data);
         }
 
-        public List<JSONObject> getWorkQueue() {
+        public List<byte[]> getWorkQueue() {
             return queues.get(workQueueNames.getGraphPropertyQueueName());
         }
 

--- a/core/core-test/src/test/java/org/visallo/core/ingest/graphProperty/GraphPropertyMessageTest.java
+++ b/core/core-test/src/test/java/org/visallo/core/ingest/graphProperty/GraphPropertyMessageTest.java
@@ -1,0 +1,178 @@
+package org.visallo.core.ingest.graphProperty;
+
+import org.json.JSONObject;
+import org.junit.Test;
+import org.visallo.core.model.workQueue.Priority;
+import org.visallo.core.util.JSONUtil;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class GraphPropertyMessageTest {
+    @Test
+    public void testVerticesMessage() {
+        String jsonString = "{" +
+                "  \"propertyKey\": \"key1\"," +
+                "  \"graphVertexId\": [" +
+                "    \"v1\"," +
+                "    \"v2\"" +
+                "  ]," +
+                "  \"propertyName\": \"name1\"," +
+                "  \"beforeActionTimestamp\": 123456789," +
+                "  \"visibilitySource\": \"visibilitySourceValue\"," +
+                "  \"priority\": \"HIGH\"," +
+                "  \"workspaceId\": \"wsTest\"," +
+                "  \"status\": \"UPDATE\"" +
+                "}";
+        GraphPropertyMessage message = GraphPropertyMessage.create(jsonString.getBytes());
+        assertEquals("wsTest", message.getWorkspaceId());
+        assertEquals("visibilitySourceValue", message.getVisibilitySource());
+        assertEquals("key1", message.getPropertyKey());
+        assertEquals("name1", message.getPropertyName());
+        assertEquals(ElementOrPropertyStatus.UPDATE, message.getStatus());
+        assertEquals(123456789, message.getBeforeActionTimestamp().longValue());
+        assertEquals(Priority.HIGH, message.getPriority());
+        assertEquals(2, message.getGraphVertexId().length);
+        assertEquals("v1", message.getGraphVertexId()[0]);
+        assertEquals("v2", message.getGraphVertexId()[1]);
+        assertTrue(
+                new JSONObject(message.toJsonString()).toString(2),
+                JSONUtil.areEqual(new JSONObject(jsonString), new JSONObject(message.toJsonString()))
+        );
+    }
+
+    @Test
+    public void testSingleVertexMessage() {
+        String jsonString = "{" +
+                "  \"propertyKey\": \"key1\"," +
+                "  \"graphVertexId\": \"v1\"," +
+                "  \"propertyName\": \"name1\"," +
+                "  \"beforeActionTimestamp\": 123456789," +
+                "  \"visibilitySource\": \"visibilitySourceValue\"," +
+                "  \"priority\": \"HIGH\"," +
+                "  \"workspaceId\": \"wsTest\"," +
+                "  \"status\": \"UPDATE\"" +
+                "}";
+        GraphPropertyMessage message = GraphPropertyMessage.create(jsonString.getBytes());
+        assertEquals("wsTest", message.getWorkspaceId());
+        assertEquals("visibilitySourceValue", message.getVisibilitySource());
+        assertEquals("key1", message.getPropertyKey());
+        assertEquals("name1", message.getPropertyName());
+        assertEquals(ElementOrPropertyStatus.UPDATE, message.getStatus());
+        assertEquals(123456789, message.getBeforeActionTimestamp().longValue());
+        assertEquals(Priority.HIGH, message.getPriority());
+        assertEquals(1, message.getGraphVertexId().length);
+        assertEquals("v1", message.getGraphVertexId()[0]);
+        assertTrue(
+                new JSONObject(message.toJsonString()).toString(2),
+                JSONUtil.areEqual(new JSONObject(jsonString), new JSONObject(message.toJsonString()))
+        );
+    }
+
+    @Test
+    public void testMultiplePropertiesMessage() {
+        String jsonString = "{" +
+                "  \"graphVertexId\": \"v1\"," +
+                "  \"visibilitySource\": \"visibilitySourceValue\"," +
+                "  \"priority\": \"HIGH\"," +
+                "  \"properties\": [" +
+                "    {" +
+                "      \"propertyKey\": \"key1\"," +
+                "      \"propertyName\": \"name1\"," +
+                "      \"beforeActionTimestamp\": 123456," +
+                "      \"status\": \"UPDATE\"" +
+                "    }," +
+                "    {" +
+                "      \"propertyKey\": \"key2\"," +
+                "      \"propertyName\": \"name2\"," +
+                "      \"beforeActionTimestamp\": 234567," +
+                "      \"status\": \"UPDATE\"" +
+                "    }" +
+                "  ]," +
+                "  \"workspaceId\": \"wsTest\"" +
+                "}";
+        GraphPropertyMessage message = GraphPropertyMessage.create(jsonString.getBytes());
+        assertEquals("wsTest", message.getWorkspaceId());
+        assertEquals("visibilitySourceValue", message.getVisibilitySource());
+        assertEquals(Priority.HIGH, message.getPriority());
+        assertEquals(1, message.getGraphVertexId().length);
+        assertEquals("v1", message.getGraphVertexId()[0]);
+
+        assertEquals(2, message.getProperties().length);
+        GraphPropertyMessage.Property[] properties = message.getProperties();
+        GraphPropertyMessage.Property property = properties[0];
+        assertEquals("key1", property.getPropertyKey());
+        assertEquals("name1", property.getPropertyName());
+        assertEquals(ElementOrPropertyStatus.UPDATE, property.getStatus());
+        assertEquals(123456, property.getBeforeActionTimestamp().longValue());
+        property = properties[1];
+        assertEquals("key2", property.getPropertyKey());
+        assertEquals("name2", property.getPropertyName());
+        assertEquals(ElementOrPropertyStatus.UPDATE, property.getStatus());
+        assertEquals(234567, property.getBeforeActionTimestamp().longValue());
+        assertTrue(
+                new JSONObject(message.toJsonString()).toString(2),
+                JSONUtil.areEqual(new JSONObject(jsonString), new JSONObject(message.toJsonString()))
+        );
+    }
+
+    @Test
+    public void testEdgesMessage() {
+        String jsonString = "{" +
+                "  \"propertyKey\": \"key1\"," +
+                "  \"graphEdgeId\": [" +
+                "    \"e1\"," +
+                "    \"e2\"" +
+                "  ]," +
+                "  \"propertyName\": \"name1\"," +
+                "  \"beforeActionTimestamp\": 123456789," +
+                "  \"visibilitySource\": \"visibilitySourceValue\"," +
+                "  \"priority\": \"HIGH\"," +
+                "  \"workspaceId\": \"wsTest\"," +
+                "  \"status\": \"UPDATE\"" +
+                "}";
+        GraphPropertyMessage message = GraphPropertyMessage.create(jsonString.getBytes());
+        assertEquals("wsTest", message.getWorkspaceId());
+        assertEquals("visibilitySourceValue", message.getVisibilitySource());
+        assertEquals("key1", message.getPropertyKey());
+        assertEquals("name1", message.getPropertyName());
+        assertEquals(ElementOrPropertyStatus.UPDATE, message.getStatus());
+        assertEquals(123456789, message.getBeforeActionTimestamp().longValue());
+        assertEquals(Priority.HIGH, message.getPriority());
+        assertEquals(2, message.getGraphEdgeId().length);
+        assertEquals("e1", message.getGraphEdgeId()[0]);
+        assertEquals("e2", message.getGraphEdgeId()[1]);
+        assertTrue(
+                new JSONObject(message.toJsonString()).toString(2),
+                JSONUtil.areEqual(new JSONObject(jsonString), new JSONObject(message.toJsonString()))
+        );
+    }
+
+    @Test
+    public void testSingleEdgeMessage() {
+        String jsonString = "{" +
+                "  \"propertyKey\": \"key1\"," +
+                "  \"graphEdgeId\": \"e1\"," +
+                "  \"propertyName\": \"name1\"," +
+                "  \"beforeActionTimestamp\": 123456789," +
+                "  \"visibilitySource\": \"visibilitySourceValue\"," +
+                "  \"priority\": \"HIGH\"," +
+                "  \"workspaceId\": \"wsTest\"," +
+                "  \"status\": \"UPDATE\"" +
+                "}";
+        GraphPropertyMessage message = GraphPropertyMessage.create(jsonString.getBytes());
+        assertEquals("wsTest", message.getWorkspaceId());
+        assertEquals("visibilitySourceValue", message.getVisibilitySource());
+        assertEquals("key1", message.getPropertyKey());
+        assertEquals("name1", message.getPropertyName());
+        assertEquals(ElementOrPropertyStatus.UPDATE, message.getStatus());
+        assertEquals(123456789, message.getBeforeActionTimestamp().longValue());
+        assertEquals(Priority.HIGH, message.getPriority());
+        assertEquals(1, message.getGraphEdgeId().length);
+        assertEquals("e1", message.getGraphEdgeId()[0]);
+        assertTrue(
+                new JSONObject(message.toJsonString()).toString(2),
+                JSONUtil.areEqual(new JSONObject(jsonString), new JSONObject(message.toJsonString()))
+        );
+    }
+}

--- a/core/core-test/src/test/java/org/visallo/core/model/WorkerBaseTest.java
+++ b/core/core-test/src/test/java/org/visallo/core/model/WorkerBaseTest.java
@@ -1,6 +1,5 @@
 package org.visallo.core.model;
 
-import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -9,7 +8,9 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.visallo.core.config.Configuration;
 import org.visallo.core.exception.VisalloException;
 import org.visallo.core.ingest.WorkerSpout;
+import org.visallo.core.ingest.graphProperty.WorkerItem;
 import org.visallo.core.model.workQueue.WorkQueueRepository;
+import org.visallo.core.status.JmxMetricsManager;
 import org.visallo.core.status.StatusServer;
 import org.visallo.core.util.VisalloLogger;
 
@@ -66,9 +67,14 @@ public class WorkerBaseTest {
         assertEquals(1, nextTupleExceptionCount);
     }
 
-    private class TestWorker extends WorkerBase {
+    private class TestWorker extends WorkerBase<TestWorkerItem> {
         protected TestWorker(WorkQueueRepository workQueueRepository, Configuration configuration) {
-            super(workQueueRepository, configuration);
+            super(workQueueRepository, configuration, new JmxMetricsManager());
+        }
+
+        @Override
+        public TestWorkerItem tupleDataToWorkerItem(byte[] data) {
+            return new TestWorkerItem(data);
         }
 
         @Override
@@ -77,7 +83,7 @@ public class WorkerBaseTest {
         }
 
         @Override
-        protected void process(Object messageId, JSONObject json) throws Exception {
+        protected void process(TestWorkerItem workerItem) throws Exception {
             stop();
         }
 
@@ -94,6 +100,14 @@ public class WorkerBaseTest {
                 return;
             }
             super.handleNextTupleException(logger, ex);
+        }
+    }
+
+    private class TestWorkerItem extends WorkerItem {
+        private final byte[] data;
+
+        public TestWorkerItem(byte[] data) {
+            this.data = data;
         }
     }
 }

--- a/core/core-test/src/test/java/org/visallo/core/model/graph/GraphRepositoryTest.java
+++ b/core/core-test/src/test/java/org/visallo/core/model/graph/GraphRepositoryTest.java
@@ -320,7 +320,7 @@ public class GraphRepositoryTest {
             assertNotNull(v2);
         }
 
-        List<JSONObject> queue = InMemoryWorkQueueRepository.getQueue("graphProperty");
+        List<byte[]> queue = InMemoryWorkQueueRepository.getQueue("graphProperty");
         assertEquals(2, queue.size());
         assertWorkQueueContains(queue, "v1", "", VisalloProperties.MODIFIED_DATE.getPropertyName());
         assertWorkQueueContains(queue, "v1", "", VisalloProperties.VISIBILITY_JSON.getPropertyName());
@@ -339,12 +339,13 @@ public class GraphRepositoryTest {
         assertEquals(visibilityJson, VisalloProperties.VISIBILITY_JSON.getPropertyValue(v1));
     }
 
-    private void assertWorkQueueContains(List<JSONObject> queue, String vertexId, String propertyKey, String propertyName) {
-        for (JSONObject item : queue) {
-            JSONArray properties = item.getJSONArray("properties");
+    private void assertWorkQueueContains(List<byte[]> queue, String vertexId, String propertyKey, String propertyName) {
+        for (byte[] item : queue) {
+            JSONObject json = new JSONObject(new String(item));
+            JSONArray properties = json.getJSONArray("properties");
             for (int i = 0; i < properties.length(); i++) {
                 JSONObject property = properties.getJSONObject(i);
-                if (item.getString("graphVertexId").equals(vertexId)
+                if (json.getString("graphVertexId").equals(vertexId)
                         && property.getString("propertyKey").equals(propertyKey)
                         && property.getString("propertyName").equals(propertyName)) {
                     return;

--- a/core/core-test/src/test/java/org/visallo/core/model/graph/GraphRepositoryTest.java
+++ b/core/core-test/src/test/java/org/visallo/core/model/graph/GraphRepositoryTest.java
@@ -1,6 +1,7 @@
 package org.visallo.core.model.graph;
 
 import com.google.common.collect.ImmutableSet;
+import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
@@ -320,7 +321,7 @@ public class GraphRepositoryTest {
         }
 
         List<JSONObject> queue = InMemoryWorkQueueRepository.getQueue("graphProperty");
-        assertEquals(8, queue.size());
+        assertEquals(2, queue.size());
         assertWorkQueueContains(queue, "v1", "", VisalloProperties.MODIFIED_DATE.getPropertyName());
         assertWorkQueueContains(queue, "v1", "", VisalloProperties.VISIBILITY_JSON.getPropertyName());
         assertWorkQueueContains(queue, "v1", "", VisalloProperties.CONCEPT_TYPE.getPropertyName());
@@ -340,10 +341,14 @@ public class GraphRepositoryTest {
 
     private void assertWorkQueueContains(List<JSONObject> queue, String vertexId, String propertyKey, String propertyName) {
         for (JSONObject item : queue) {
-            if (item.getString("graphVertexId").equals(vertexId)
-                    && item.getString("propertyKey").equals(propertyKey)
-                    && item.getString("propertyName").equals(propertyName)) {
-                return;
+            JSONArray properties = item.getJSONArray("properties");
+            for (int i = 0; i < properties.length(); i++) {
+                JSONObject property = properties.getJSONObject(i);
+                if (item.getString("graphVertexId").equals(vertexId)
+                        && property.getString("propertyKey").equals(propertyKey)
+                        && property.getString("propertyName").equals(propertyName)) {
+                    return;
+                }
             }
         }
         fail("Could not find queue item " + vertexId + ", " + propertyKey + ", " + propertyName);

--- a/core/core/src/main/java/org/visallo/core/externalResource/QueueExternalResourceWorker.java
+++ b/core/core/src/main/java/org/visallo/core/externalResource/QueueExternalResourceWorker.java
@@ -65,7 +65,8 @@ public abstract class QueueExternalResourceWorker extends ExternalResourceWorker
             }
             try (Timer.Context t = processingTimeTimer.time()) {
                 long startTime = System.currentTimeMillis();
-                process(tuple.getMessageId(), tuple.getJson(), authorizations);
+                JSONObject json = new JSONObject(new String(tuple.getData()));
+                process(tuple.getMessageId(), json, authorizations);
                 long endTime = System.currentTimeMillis();
                 logger.debug("completed processing in (%dms)", endTime - startTime);
                 workerSpout.ack(tuple.getMessageId());

--- a/core/core/src/main/java/org/visallo/core/ingest/FileImport.java
+++ b/core/core/src/main/java/org/visallo/core/ingest/FileImport.java
@@ -318,7 +318,8 @@ public class FileImport {
             this.workQueueRepository.broadcastElement(vertex, workspaceId);
             this.workQueueRepository.pushGraphVisalloPropertyQueue(
                     vertex,
-                    changedProperties, workspace == null ? null : workspace.getWorkspaceId(),
+                    changedProperties,
+                    workspace == null ? null : workspace.getWorkspaceId(),
                     visibilitySource,
                     priority
             );

--- a/core/core/src/main/java/org/visallo/core/ingest/WorkerTuple.java
+++ b/core/core/src/main/java/org/visallo/core/ingest/WorkerTuple.java
@@ -1,29 +1,26 @@
 package org.visallo.core.ingest;
 
-import org.json.JSONObject;
-
 public class WorkerTuple {
     private final Object messageId;
-    private final JSONObject json;
+    private final byte[] data;
 
-    public WorkerTuple(Object messageId, JSONObject json) {
+    public WorkerTuple(Object messageId, byte[] data) {
         this.messageId = messageId;
-        this.json = json;
+        this.data = data;
     }
 
     public Object getMessageId() {
         return messageId;
     }
 
-    public JSONObject getJson() {
-        return json;
+    public byte[] getData() {
+        return data;
     }
 
     @Override
     public String toString() {
         return "WorkerTuple{" +
                 "messageId=" + messageId +
-                ", json=" + json.toString() +
                 '}';
     }
 }

--- a/core/core/src/main/java/org/visallo/core/ingest/graphProperty/GraphPropertyMessage.java
+++ b/core/core/src/main/java/org/visallo/core/ingest/graphProperty/GraphPropertyMessage.java
@@ -23,13 +23,12 @@ public class GraphPropertyMessage {
 
     private JSONObject _obj;
 
-    public boolean isValid() {
-        return canHandleVertex() || canHandleEdge();
+    public GraphPropertyMessage(byte[] data) {
+        this(new String(data));
     }
 
-    public enum ProcessingType {
-        PROPERTY,
-        ELEMENT
+    public GraphPropertyMessage(String data) {
+        this(new JSONObject(data));
     }
 
     public GraphPropertyMessage(JSONObject obj) {

--- a/core/core/src/main/java/org/visallo/core/ingest/graphProperty/GraphPropertyMessage.java
+++ b/core/core/src/main/java/org/visallo/core/ingest/graphProperty/GraphPropertyMessage.java
@@ -19,6 +19,7 @@ public class GraphPropertyMessage {
     public static final String PRIORITY = "priority";
     public static final String STATUS = "status";
     public static final String BEFORE_ACTION_TIMESTAMP = "beforeActionTimestamp";
+    public static final String PROPERTIES = "properties";
 
     private JSONObject _obj;
 
@@ -39,16 +40,16 @@ public class GraphPropertyMessage {
         return _obj.optString(WORKSPACE_ID, null);
     }
 
-    public String getVisibilitySource(){
+    public String getVisibilitySource() {
         return _obj.optString(VISIBILITY_SOURCE, null);
     }
 
-    public Priority getPriority(){
+    public Priority getPriority() {
         String priorityString = _obj.optString(PRIORITY, null);
         return Priority.safeParse(priorityString);
     }
 
-    public String getPropertyKey(){
+    public String getPropertyKey() {
         return _obj.optString(PROPERTY_KEY, "");
     }
 
@@ -60,7 +61,7 @@ public class GraphPropertyMessage {
         return getListOfItemsFromJSONKey(_obj, GRAPH_VERTEX_ID);
     }
 
-    public List<String> getEdgeIds(){
+    public List<String> getEdgeIds() {
         return getListOfItemsFromJSONKey(_obj, GRAPH_EDGE_ID);
     }
 
@@ -69,49 +70,49 @@ public class GraphPropertyMessage {
         return ElementOrPropertyStatus.safeParse(status);
     }
 
-    public long getBeforeActionTimestamp() { return _obj.optLong(BEFORE_ACTION_TIMESTAMP, -1L); }
+    public long getBeforeActionTimestamp() {
+        return _obj.optLong(BEFORE_ACTION_TIMESTAMP, -1L);
+    }
 
-    public boolean canHandleVertex(){
+    public JSONArray getProperties() {
+        return _obj.optJSONArray(PROPERTIES);
+    }
+
+    public boolean canHandleVertex() {
         return canHandleElementById(getVertexIds());
     }
 
-    public boolean canHandleEdge(){
+    public boolean canHandleEdge() {
         return canHandleElementById(getEdgeIds());
     }
 
-    public boolean canHandleByProperty(){
+    public boolean canHandleByProperty() {
         return _obj.has(PROPERTY_KEY) || this._obj.has(PROPERTY_NAME);
     }
 
-    public ProcessingType findProcessingType(){
-        if(canHandleByProperty()){
-            return ProcessingType.PROPERTY;
-        }
-        else if(canHandleVertex() || canHandleEdge()) {
-            return ProcessingType.ELEMENT;
-        }
-
-        throw new VisalloException(String.format("Unable to determine processing type from invalid message %s", _obj.toString()));
+    public boolean canHandleByProperties() {
+        return _obj.has(PROPERTIES);
     }
 
-    private static boolean canHandleElementById(List<String> id){
+    private static boolean canHandleElementById(List<String> id) {
         return id != null && !id.isEmpty();
     }
 
-    private static List<String> getListOfItemsFromJSONKey(JSONObject obj, String key){
+    private static List<String> getListOfItemsFromJSONKey(JSONObject obj, String key) {
         Object edges = obj.opt(key);
 
-        if(edges == null){
+        if (edges == null) {
             return Lists.newArrayList();
         }
-        if(edges instanceof JSONArray){
+
+        if (edges instanceof JSONArray) {
             return JSONUtil.toStringList((JSONArray) edges);
         }
-        else if(edges instanceof String){
-            return Lists.newArrayList((String)edges);
+
+        if (edges instanceof String) {
+            return Lists.newArrayList((String) edges);
         }
-        else{
-            throw new VisalloException("unknown format to parse messages");
-        }
+
+        throw new VisalloException("unknown format to parse messages");
     }
 }

--- a/core/core/src/main/java/org/visallo/core/ingest/graphProperty/GraphPropertyWorkerItem.java
+++ b/core/core/src/main/java/org/visallo/core/ingest/graphProperty/GraphPropertyWorkerItem.java
@@ -1,0 +1,22 @@
+package org.visallo.core.ingest.graphProperty;
+
+import com.google.common.collect.ImmutableList;
+import org.vertexium.Element;
+
+public class GraphPropertyWorkerItem extends WorkerItem {
+    private final GraphPropertyMessage message;
+    private final ImmutableList<Element> elements;
+
+    public GraphPropertyWorkerItem(GraphPropertyMessage message, ImmutableList<Element> elements) {
+        this.message = message;
+        this.elements = elements;
+    }
+
+    public GraphPropertyMessage getMessage() {
+        return message;
+    }
+
+    public ImmutableList<Element> getElements() {
+        return elements;
+    }
+}

--- a/core/core/src/main/java/org/visallo/core/ingest/graphProperty/WorkerItem.java
+++ b/core/core/src/main/java/org/visallo/core/ingest/graphProperty/WorkerItem.java
@@ -1,0 +1,4 @@
+package org.visallo.core.ingest.graphProperty;
+
+public abstract class WorkerItem {
+}

--- a/core/core/src/main/java/org/visallo/core/model/WorkerBase.java
+++ b/core/core/src/main/java/org/visallo/core/model/WorkerBase.java
@@ -153,7 +153,7 @@ public abstract class WorkerBase<TWorkerItem extends WorkerItem> {
      * This method gets called in a different thread than {@link #process(WorkerItem)} this
      * allows an implementing class to prefetch data needed for processing.
      */
-    protected abstract TWorkerItem tupleDataToWorkerItem(byte[] data);
+    protected abstract TWorkerItem tupleDataToWorkerItem(byte[] data) throws Exception;
 
     public void stop() {
         shouldRun = false;

--- a/core/core/src/main/java/org/visallo/core/model/longRunningProcess/LongRunningProcessWorkerItem.java
+++ b/core/core/src/main/java/org/visallo/core/model/longRunningProcess/LongRunningProcessWorkerItem.java
@@ -1,0 +1,24 @@
+package org.visallo.core.model.longRunningProcess;
+
+import org.json.JSONObject;
+import org.visallo.core.ingest.graphProperty.WorkerItem;
+
+public class LongRunningProcessWorkerItem extends WorkerItem {
+    private final JSONObject json;
+
+    public LongRunningProcessWorkerItem(byte[] data) {
+        this(new String(data));
+    }
+
+    public LongRunningProcessWorkerItem(String data) {
+        this(new JSONObject(data));
+    }
+
+    public LongRunningProcessWorkerItem(JSONObject json) {
+        this.json = json;
+    }
+
+    public JSONObject getJson() {
+        return json;
+    }
+}

--- a/core/core/src/main/java/org/visallo/core/model/workQueue/WorkQueueRepository.java
+++ b/core/core/src/main/java/org/visallo/core/model/workQueue/WorkQueueRepository.java
@@ -998,10 +998,21 @@ public abstract class WorkQueueRepository {
         return json;
     }
 
-    public abstract void pushOnQueue(
+    public final void pushOnQueue(
             String queueName,
             @Deprecated FlushFlag flushFlag,
             JSONObject json,
+            Priority priority
+    ) {
+        if (priority != null) {
+            json.put("priority", priority.name());
+        }
+        pushOnQueue(queueName, json.toString().getBytes(), priority);
+    }
+
+    public abstract void pushOnQueue(
+            String queueName,
+            byte[] data,
             Priority priority
     );
 


### PR DESCRIPTION
- [x] @joeferner
- [x] @kunklejr @mwizeman @sfeng88 @diegogrz
- [ ] @dsingley @EvanOxfeld 
- [x] @joeybrk372 @rygim @jharwig 

CHANGELOG
Changed: GraphPropertyMessage to use Jackson for serialization
Changed: Prefetch messages WorkerBase and queue spouts to return byte[] instead of JSONObject.
Changed: Enqueue a single item on to the queue when setting multiple properties at once
