### PR TITLE
Allow manual withPopover setup(3.0)

### DIFF
--- a/web/war/src/main/webapp/js/util/popovers/withPopover.js
+++ b/web/war/src/main/webapp/js/util/popovers/withPopover.js
@@ -12,8 +12,9 @@ define([], function() {
         this.defaultAttrs({
             withPopoverInputSelector: 'input,select',
             hideDialog: false,
-            keepInView: true
-        })
+            keepInView: true,
+            manualSetup: false
+        });
 
         this.before('teardown', function() {
             clearTimeout(this.positionChangeErrorCheck);
@@ -27,16 +28,28 @@ define([], function() {
         });
 
         this.after('initialize', function() {
-            var t = this.attr.template || 'noTemplate',
-                path;
+            const self = this;
 
-            if (/^\//.test(t)) {
-                path = 'hbs!' + t.substring(1);
-            } else {
-                path = 'hbs!util/popovers/' + t;
+            this.attr.finishSetup = () => {
+                return require([getTemplatePath()], this.setupWithTemplate.bind(this));
+            };
+
+            if (!this.attr.manualSetup) {
+                this.attr.finishSetup();
             }
 
-            require([path], this.setupWithTemplate.bind(this));
+            function getTemplatePath() {
+                const t = self.attr.template || 'noTemplate';
+                let path;
+
+                if (/^\//.test(t)) {
+                    path = 'hbs!' + t.substring(1);
+                } else {
+                    path = 'hbs!util/popovers/' + t;
+                }
+
+                return path;
+            }
         });
 
         this.setupWithTemplate = function(tpl) {


### PR DESCRIPTION
- [x] @joeferner
- [ ] @kunklejr @mwizeman @sfeng88 @diegogrz
- [ ] @dsingley @EvanOxfeld 
- [x] @joeybrk372 @rygim @jharwig 

`withPopover` mixin will do setup with a template automatically by default, but this change allows components to call the setup themselves which gives them the opportunity for asynchronous configuration.