### PR TITLE
Fix acl util returning all property acls(3.0)

### DIFF
--- a/web/war/src/main/webapp/js/detail/dropdowns/propertyForm/propForm.js
+++ b/web/war/src/main/webapp/js/detail/dropdowns/propertyForm/propForm.js
@@ -108,8 +108,7 @@ define([
         });
 
         this.setupPropertySelectionField = function() {
-            var self = this,
-                ontologyRequest;
+            let ontologyRequest;
 
             if (F.vertex.isEdge(this.attr.data)) {
                 ontologyRequest = this.dataRequest('ontology', 'propertiesByRelationship', this.attr.data.label);
@@ -118,15 +117,18 @@ define([
                     F.vertex.prop(this.attr.data, 'conceptType'));
             }
 
-            ontologyRequest.then(function(ontologyProperties) {
-                var propertyAcls = acl.getPropertyAcls(self.attr.data);
-                FieldSelection.attachTo(self.select('propertyListSelector'), {
+            Promise.all([
+                ontologyRequest,
+                acl.getPropertyAcls(this.attr.data)
+            ]).spread((ontologyProperties, propertyAcls) => {
+                FieldSelection.attachTo(this.select('propertyListSelector'), {
                     properties: ontologyProperties.list,
                     focus: true,
                     placeholder: i18n('property.form.field.selection.placeholder'),
                     unsupportedProperties: _.pluck(_.where(propertyAcls, {addable: false}), 'name')
                 });
-                self.manualOpen();
+
+                this.manualOpen();
             });
         };
 

--- a/web/war/src/main/webapp/js/detail/toolbar/toolbar.js
+++ b/web/war/src/main/webapp/js/detail/toolbar/toolbar.js
@@ -83,7 +83,10 @@ define([
 
         this.after('initialize', function() {
             var model = this.attr.model;
-            this.initializeToolbar(model, acl.getPropertyAcls(model));
+
+            acl.getPropertyAcls(model).then((propertyAcls) => {
+                this.initializeToolbar(model, propertyAcls);
+            });
         });
 
         this.initializeToolbar = function(model, propertyAcls) {

--- a/web/war/src/main/webapp/js/util/popovers/propertyInfo/propertyInfo.js
+++ b/web/war/src/main/webapp/js/util/popovers/propertyInfo/propertyInfo.js
@@ -33,43 +33,13 @@ define([
         });
 
         this.before('initialize', function(node, config) {
-            config.template = 'propertyInfo/template';
-            config.isFullscreen = visalloData.isFullscreen;
-            if (config.property) {
-
-                config.isComment = config.property.name === 'http://visallo.org/comment#entry';
-                config.canAdd = config.canEdit = config.canDelete = false;
-
-                var allPropertyAcls = acl.getPropertyAcls(config.data);
-                var propertyAcl = acl.findPropertyAcl(allPropertyAcls, config.property.name, config.property.key);
-
-                if (config.isComment && visalloData.currentWorkspaceCommentable) {
-                    config.canAdd = config.property.addable !== undefined ? config.property.addable !== false : propertyAcl.addable !== false;
-                    config.canEdit = config.property.updateable !== undefined ? config.property.updateable !== false : propertyAcl.updateable !== false;
-                    config.canDelete = config.property.deleteable !== undefined ? config.property.deleteable !== false : propertyAcl.deleteable !== false;
-                } else if (!config.isComment && visalloData.currentWorkspaceEditable) {
-                    config.canAdd = config.property.addable !== undefined ? config.property.addable !== false : propertyAcl.addable !== false;
-                    config.canEdit = config.property.updateable !== undefined ? config.property.updateable !== false : propertyAcl.updateable !== false;
-                    config.canDelete = config.property.deleteable !== undefined ? config.property.deleteable !== false : propertyAcl.deleteable !== false &&
-                        config.property.name !== 'http://visallo.org#visibilityJson';
-                }
-
-                var isCompoundField = config.ontologyProperty && config.ontologyProperty.dependentPropertyIris &&
-                    config.ontologyProperty.dependentPropertyIris.length;
-
-                config.canSearch = config.ontologyProperty &&
-                    (config.ontologyProperty.searchable || isCompoundField) &&
-                    !config.isFullscreen;
-
-                if (config.property.streamingPropertyValue) {
-                    config.canAdd = config.canDelete = config.canSearch = false;
-                }
-            }
-            config.hideDialog = true;
+            config.manualSetup = true;
         });
 
         this.after('initialize', function() {
             var self = this;
+
+            this.setupConfig(this.attr);
 
             this.after('setupWithTemplate', function() {
                 this.dataRequest('config', 'properties')
@@ -108,6 +78,48 @@ define([
                     });
             });
         });
+
+        this.setupConfig = function(config) {
+            config.template = 'propertyInfo/template';
+            config.isFullscreen = visalloData.isFullscreen;
+
+            acl.getPropertyAcls(config.data)
+                .then((propertyAcls) => {
+                    if (config.property) {
+                        config.isComment = config.property.name === 'http://visallo.org/comment#entry';
+                        config.canAdd = config.canEdit = config.canDelete = false;
+
+                        var propertyAcl = acl.findPropertyAcl(propertyAcls, config.property.name, config.property.key);
+
+                        if (config.isComment && visalloData.currentWorkspaceCommentable) {
+                            config.canAdd = config.property.addable !== undefined ? config.property.addable !== false : propertyAcl.addable !== false;
+                            config.canEdit = config.property.updateable !== undefined ? config.property.updateable !== false : propertyAcl.updateable !== false;
+                            config.canDelete = config.property.deleteable !== undefined ? config.property.deleteable !== false : propertyAcl.deleteable !== false;
+                        } else if (!config.isComment && visalloData.currentWorkspaceEditable) {
+                            config.canAdd = config.property.addable !== undefined ? config.property.addable !== false : propertyAcl.addable !== false;
+                            config.canEdit = config.property.updateable !== undefined ? config.property.updateable !== false : propertyAcl.updateable !== false;
+                            config.canDelete = (config.property.deleteable !== undefined ? config.property.deleteable !== false : propertyAcl.deleteable !== false) &&
+                                config.property.name !== 'http://visallo.org#visibilityJson';
+                        }
+
+                        var isCompoundField = config.ontologyProperty && config.ontologyProperty.dependentPropertyIris &&
+                            config.ontologyProperty.dependentPropertyIris.length;
+
+                        config.canSearch = config.ontologyProperty &&
+                            (config.ontologyProperty.searchable || isCompoundField) &&
+                            !config.isFullscreen;
+
+                        if (config.property.streamingPropertyValue) {
+                            config.canAdd = config.canDelete = config.canSearch = false;
+                        }
+
+                    }
+
+                    config.hideDialog = true;
+
+                    this.attr.finishSetup();
+            });
+        };
 
         this.onEscapeKey = function() {
             this.teardown();


### PR DESCRIPTION
- [x] @joeferner
- [x] @kunklejr @mwizeman @sfeng88 @diegogrz
- [ ] @dsingley @EvanOxfeld 
- [x] @joeybrk372 @rygim @jharwig 

`getPropertyAcls` was returning all property acls instead of just the properties of the given elements.

requires https://github.com/v5analytics/visallo/pull/762

no changelog