### PR TITLE
Fix editing compound property visibility when multiple are present(2.1)

### DIFF
--- a/web/war/src/main/webapp/js/detail/dropdowns/propertyForm/propForm.js
+++ b/web/war/src/main/webapp/js/detail/dropdowns/propertyForm/propForm.js
@@ -332,7 +332,10 @@ define([
                         fieldComponent;
 
                     if (isCompoundField) {
-                        self.currentValue = _.pluck(F.vertex.props(self.attr.data, propertyName), 'value');
+                        const dependentProperties = property.key ?
+                            F.vertex.props(self.attr.data, propertyName, property.key) :
+                            F.vertex.props(self.attr.data, propertyName);
+                        self.currentValue = _.pluck(dependentProperties, 'value');
                         fieldComponent = 'fields/compound/compound';
                     } else if (propertyDetails.displayType === 'duration') {
                         fieldComponent = 'fields/duration';


### PR DESCRIPTION
- [x] @joeferner
- [x] @kunklejr @mwizeman @sfeng88 @diegogrz
- [ ] @dsingley @EvanOxfeld 
- [x] @joeybrk372 @rygim @jharwig 

We were getting the property form's current values without supplying a property key, which meant if there were multiple compound properties we would eventually send all of the dependent properties on the element.

will cherry-pick to all versions >2.1

CHANGELOG
Fixed: Not being able to edit the visibility of compound properties when there are multiple properties present.
