### PR TITLE
When appending element acl, query using user authorizations (2.1.3)

### DIFF
--- a/core/core/src/main/java/org/visallo/core/security/ACLProvider.java
+++ b/core/core/src/main/java/org/visallo/core/security/ACLProvider.java
@@ -153,7 +153,7 @@ public abstract class ACLProvider {
     }
 
     private void appendACL(ClientApiElement apiElement, User user) {
-        Element element = findElement(apiElement);
+        Element element = findElement(apiElement, user);
 
         for (ClientApiProperty apiProperty : apiElement.getProperties()) {
             String key = apiProperty.getKey();
@@ -219,9 +219,10 @@ public abstract class ACLProvider {
         return propertyAcl;
     }
 
-    private Element findElement(ClientApiElement apiElement) {
+    private Element findElement(ClientApiElement apiElement, User user) {
         Element element;
-        Authorizations authorizations = authorizationRepository.getGraphAuthorizations(userRepository.getSystemUser());
+
+        Authorizations authorizations = authorizationRepository.getGraphAuthorizations(user, user.getCurrentWorkspaceId());
         if (apiElement instanceof ClientApiVertex) {
             element = graph.getVertex(apiElement.getId(), authorizations);
             checkNotNull(element, "could not find vertex with id: " + apiElement.getId());


### PR DESCRIPTION
- [x] @joeferner
- [x] @kunklejr @mwizeman @sfeng88 @diegogrz
- [x] @dsingley @EvanOxfeld 
- [ ] @joeybrk372 @rygim @jharwig 



CHANGELOG
Fixed: Acl returning hidden properties on a workspace which cause the UI to throw an ACL error

Originally we were querying using the system level authorization when
appending the acl. This will result in returning "hidden" properties on
a workspace.