### PR TITLE
If limiting the paths being shown, only add those elements

### DIFF
--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/Graph.jsx
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/Graph.jsx
@@ -209,9 +209,11 @@ define([
             })
         },
 
-        onFocusPathsAdd(event, data) {
-            if (data) {
-                const { vertexIds } = data;
+        onFocusPathsAdd(event) {
+            const { paths } = this.state;
+            if (paths) {
+                const limitedPaths = paths.paths.slice(0, MaxPathsToFocus);
+                const vertexIds = _.chain(limitedPaths).flatten().uniq().value();
                 this.props.onDropElementIds({ vertexIds });
             }
         },

--- a/web/war/src/main/webapp/js/activity/builtin/findPath.js
+++ b/web/war/src/main/webapp/js/activity/builtin/findPath.js
@@ -83,7 +83,7 @@ define([
         };
 
         this.onAddVertices = function(event) {
-            this.trigger('focusPathsAddVertexIds', { vertexIds: this.toAdd })
+            this.trigger('focusPathsAddVertexIds');
             this.loadDefaultContent();
         };
 
@@ -94,12 +94,8 @@ define([
             this.dataRequest('longRunningProcess', 'get', this.attr.process.id)
                 .done(function(process) {
                     var paths = process.results && process.results.paths || [],
-                        allVertices = _.flatten(paths),
-                        vertices = _.chain(allVertices)
-                            .unique()
-                            .value();
+                        vertices = _.chain(paths).flatten().uniq().value();
 
-                    self.toAdd = vertices;
                     self.trigger('focusPaths', {
                         paths: paths,
                         sourceId: self.attr.process.outVertexId,


### PR DESCRIPTION
- [x] @joeferner
- [ ] @kunklejr @mwizeman @sfeng88 @diegogrz
- [ ] @dsingley @EvanOxfeld 
- [x] @joeybrk372 @rygim @jharwig 


Find path now limits the number of paths to display to 100. If that limit is reached, and "Add Missing Elements" button is clicked, only add the elements of those first 100 paths.