### PR TITLE
Upgrade cytoscape from 2.7.10 to 2.7.11 (3.0)

### DIFF
--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/npm-shrinkwrap.json
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/npm-shrinkwrap.json
@@ -433,6 +433,11 @@
       "from": "crypto-browserify@>=3.2.6 <3.3.0",
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.2.8.tgz"
     },
+    "cytoscape": {
+      "version": "2.7.11",
+      "from": "cytoscape@2.7.11",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-2.7.11.tgz"
+    },
     "date-now": {
       "version": "0.1.4",
       "from": "date-now@>=0.1.4 <0.2.0",
@@ -462,18 +467,6 @@
       "version": "1.0.0",
       "from": "git+https://github.com/nemanjan00/ejs.git",
       "resolved": "git+https://github.com/nemanjan00/ejs.git#ba8ef7f575e190fc60017bc82911151378fe3258"
-    },
-    "ejs-compiled-loader": {
-      "version": "1.1.0",
-      "from": "ejs-compiled-loader@latest",
-      "resolved": "https://registry.npmjs.org/ejs-compiled-loader/-/ejs-compiled-loader-1.1.0.tgz",
-      "dependencies": {
-        "uglify-js": {
-          "version": "1.3.5",
-          "from": "uglify-js@>=1.3.4 <1.4.0",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.3.5.tgz"
-        }
-      }
     },
     "emojis-list": {
       "version": "2.1.0",

--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/package.json
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/package.json
@@ -10,7 +10,7 @@
   "license": "Apache-2.0",
   "private": true,
   "dependencies": {
-    "cytoscape": "2.7.10"
+    "cytoscape": "2.7.11"
   },
   "devDependencies": {
     "babel-core": "^6.14.0",


### PR DESCRIPTION
- [x] @joeferner
- [ ] @kunklejr @mwizeman @sfeng88 @diegogrz
- [ ] @dsingley @EvanOxfeld 
- [x] @joeybrk372 @rygim @jharwig 

Cytoscape had an issue which is fixed in 2.7.11 where dynamically added nodes would not update the layer bounds, so certain changes in pan/zoom would only draw the bounds for the old set of nodes.

no changelog

