### PR TITLE
Upgrade cytoscape from 2.7.10 to 2.7.11 (master)

### DIFF
--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/package.json
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/package.json
@@ -10,7 +10,7 @@
   "license": "Apache-2.0",
   "private": true,
   "dependencies": {
-    "cytoscape": "2.7.10"
+    "cytoscape": "2.7.11"
   },
   "devDependencies": {
     "babel-core": "^6.14.0",

--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/yarn.lock
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/yarn.lock
@@ -752,9 +752,9 @@ crypto-browserify@~3.2.6:
     ripemd160 "0.2.0"
     sha.js "2.2.6"
 
-cytoscape@2.7.10:
-  version "2.7.10"
-  resolved "https://registry.yarnpkg.com/cytoscape/-/cytoscape-2.7.10.tgz#ed3aeb89623d9fa3ac1636c814ef5c58cc736421"
+cytoscape@2.7.11:
+  version "2.7.11"
+  resolved "https://registry.yarnpkg.com/cytoscape/-/cytoscape-2.7.11.tgz#64739074cec00820841266ce4611582ebb9bea31"
 
 dashdash@^1.12.0:
   version "1.14.0"
@@ -1380,11 +1380,7 @@ minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
-minimist@~0.0.1:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
-
-minimist@0.0.8:
+minimist@~0.0.1, minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
@@ -1497,13 +1493,7 @@ object.omit@^2.0.0:
     for-own "^0.1.4"
     is-extendable "^0.1.1"
 
-once@^1.3.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
-  dependencies:
-    wrappy "1"
-
-once@~1.3.3:
+once@^1.3.0, once@~1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/once/-/once-1.3.3.tgz#b2e261557ce4c314ec8304f3fa82663e4297ca20"
   dependencies:


### PR DESCRIPTION
- [x] @joeferner
- [ ] @kunklejr @mwizeman @sfeng88 @diegogrz
- [ ] @dsingley @EvanOxfeld 
- [ ] @joeybrk372 @rygim @jharwig 

this is slightly different because of yarn instead of npm

3.0 pr https://github.com/v5analytics/visallo/pull/770


