### PR TITLE
Added: methods and routes to link two products

### DIFF
--- a/core/core/src/main/java/org/visallo/core/model/workspace/DefaultWorkspaceListener.java
+++ b/core/core/src/main/java/org/visallo/core/model/workspace/DefaultWorkspaceListener.java
@@ -47,4 +47,14 @@ public class DefaultWorkspaceListener implements WorkspaceListener {
     public void workspaceDeleteUser(Workspace workspace, String userId, User user) {
 
     }
+
+    @Override
+    public void workspaceWorkProductsLinked(Product product1, Product product2, User user) {
+
+    }
+
+    @Override
+    public void workspaceWorkProductsUnlinked(Product product1, Product product2, User user) {
+
+    }
 }

--- a/core/core/src/main/java/org/visallo/core/model/workspace/WorkspaceListener.java
+++ b/core/core/src/main/java/org/visallo/core/model/workspace/WorkspaceListener.java
@@ -23,4 +23,8 @@ public interface WorkspaceListener {
     void workspaceBeforeDeleteProduct(String workspaceId, String productId, User user);
 
     void workspaceDeleteUser(Workspace workspace, String userId, User user);
+
+    void workspaceWorkProductsLinked(Product product1, Product product2, User user);
+
+    void workspaceWorkProductsUnlinked(Product product1, Product product2, User user);
 }

--- a/core/core/src/main/java/org/visallo/core/model/workspace/WorkspaceProperties.java
+++ b/core/core/src/main/java/org/visallo/core/model/workspace/WorkspaceProperties.java
@@ -14,6 +14,7 @@ public class WorkspaceProperties {
     public static final String WORKSPACE_TO_DASHBOARD_RELATIONSHIP_IRI = "http://visallo.org/workspace#toDashboard";
     public static final String WORKSPACE_TO_PRODUCT_RELATIONSHIP_IRI = "http://visallo.org/workspace#toProduct";
     public static final String DASHBOARD_TO_DASHBOARD_ITEM_RELATIONSHIP_IRI = "http://visallo.org/workspace#toDashboardItem";
+    public static final String PRODUCT_TO_PRODUCT_RELATIONSHIP_IRI = "http://visallo.org/workspace#productLink";
 
     public static final StringSingleValueVisalloProperty TITLE = new StringSingleValueVisalloProperty("http://visallo.org/workspace#workspace/title");
     public static final BooleanSingleValueVisalloProperty WORKSPACE_TO_USER_IS_CREATOR = new BooleanSingleValueVisalloProperty("http://visallo.org/workspace#toUser/creator");

--- a/core/core/src/main/java/org/visallo/core/model/workspace/WorkspaceRepository.java
+++ b/core/core/src/main/java/org/visallo/core/model/workspace/WorkspaceRepository.java
@@ -158,6 +158,10 @@ public abstract class WorkspaceRepository {
 
     public abstract void deleteUserFromWorkspace(Workspace workspace, String userId, User user);
 
+    public abstract void linkWorkProducts(Product product1, Product product2, User user);
+
+    public abstract void unlinkWorkProducts(Product product1, Product product2, User user);
+
     public abstract UpdateUserOnWorkspaceResult updateUserOnWorkspace(
             Workspace workspace,
             String userId,
@@ -949,6 +953,18 @@ public abstract class WorkspaceRepository {
 
     protected AuthorizationRepository getAuthorizationRepository() {
         return authorizationRepository;
+    }
+
+    protected void fireWorkspaceWorkProductsLinked(Product product1, Product product2, User user) {
+        for (WorkspaceListener workspaceListener : getWorkspaceListeners()) {
+            workspaceListener.workspaceWorkProductsLinked(product1, product2, user);
+        }
+    }
+
+    protected void fireWorkspaceWorkProductsUnlinked(Product product1, Product product2, User user) {
+        for (WorkspaceListener workspaceListener : getWorkspaceListeners()) {
+            workspaceListener.workspaceWorkProductsUnlinked(product1, product2, user);
+        }
     }
 
     protected void fireWorkspaceBeforeDelete(Workspace workspace, User user) {

--- a/core/core/src/main/java/org/visallo/core/model/workspace/product/WorkProduct.java
+++ b/core/core/src/main/java/org/visallo/core/model/workspace/product/WorkProduct.java
@@ -23,6 +23,20 @@ public interface WorkProduct {
     );
 
     /**
+     * Called when a linked product gets updated
+     */
+    void updateLinked(
+            GraphUpdateContext ctx,
+            Vertex workspaceVertex,
+            Vertex sourceProductVertex,
+            Vertex linkedProductVertex,
+            JSONObject params,
+            User user,
+            Visibility visibility,
+            Authorizations authorizations
+    );
+
+    /**
      * Get custom extended data from the work product. This does not include the extended data stored on the
      * product itself.
      */

--- a/core/core/src/main/java/org/visallo/core/model/workspace/product/WorkProductElements.java
+++ b/core/core/src/main/java/org/visallo/core/model/workspace/product/WorkProductElements.java
@@ -77,6 +77,20 @@ public abstract class WorkProductElements implements WorkProduct, WorkProductHas
     }
 
     @Override
+    public void updateLinked(
+            GraphUpdateContext ctx,
+            Vertex workspaceVertex,
+            Vertex sourceProductVertex,
+            Vertex linkedProductVertex,
+            JSONObject params,
+            User user,
+            Visibility visibility,
+            Authorizations authorizations
+    ) {
+        update(ctx, workspaceVertex, linkedProductVertex, params, user, visibility, authorizations);
+    }
+
+    @Override
     public JSONObject getExtendedData(
             Graph graph,
             Vertex workspaceVertex,

--- a/core/core/src/main/resources/org/visallo/core/model/ontology/workspace.owl
+++ b/core/core/src/main/resources/org/visallo/core/model/ontology/workspace.owl
@@ -1,25 +1,15 @@
 <?xml version="1.0"?>
-
-
-<!DOCTYPE rdf:RDF [
-    <!ENTITY visallo "http://visallo.org#" >
-    <!ENTITY owl "http://www.w3.org/2002/07/owl#" >
-    <!ENTITY xsd "http://www.w3.org/2001/XMLSchema#" >
-    <!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#" >
-    <!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#" >
-]>
-
-
 <rdf:RDF xmlns="http://visallo.org/workspace#"
      xml:base="http://visallo.org/workspace"
      xmlns:visallo="http://visallo.org#"
      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
      xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:xml="http://www.w3.org/XML/1998/namespace"
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
     <owl:Ontology rdf:about="http://visallo.org/workspace">
-        <owl:imports rdf:resource="http://visallo.org"/>
         <owl:imports rdf:resource="http://visallo.org/user"/>
+        <owl:imports rdf:resource="http://visallo.org"/>
     </owl:Ontology>
     
 
@@ -35,39 +25,52 @@
     
 
 
+    <!-- http://visallo.org/workspace#productLink -->
+
+    <owl:ObjectProperty rdf:about="http://visallo.org/workspace#productLink">
+        <rdfs:domain rdf:resource="http://visallo.org/workspace#product"/>
+        <rdfs:range rdf:resource="http://visallo.org/workspace#product"/>
+        <rdfs:label xml:lang="en">Link</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
     <!-- http://visallo.org/workspace#toDashboard -->
 
     <owl:ObjectProperty rdf:about="http://visallo.org/workspace#toDashboard">
-        <rdfs:label xml:lang="en">To Dashboard</rdfs:label>
-        <rdfs:range rdf:resource="http://visallo.org/workspace#dashboard"/>
         <rdfs:domain rdf:resource="http://visallo.org/workspace#workspace"/>
+        <rdfs:range rdf:resource="http://visallo.org/workspace#dashboard"/>
+        <rdfs:label xml:lang="en">To Dashboard</rdfs:label>
     </owl:ObjectProperty>
+    
 
 
     <!-- http://visallo.org/workspace#toDashboardItem -->
 
     <owl:ObjectProperty rdf:about="http://visallo.org/workspace#toDashboardItem">
-        <rdfs:label xml:lang="en">To Dashboard Item</rdfs:label>
         <rdfs:domain rdf:resource="http://visallo.org/workspace#dashboard"/>
         <rdfs:range rdf:resource="http://visallo.org/workspace#dashboardItem"/>
+        <rdfs:label xml:lang="en">To Dashboard Item</rdfs:label>
     </owl:ObjectProperty>
-
-
-    <!-- http://visallo.org/workspace#toProduct -->
-
-    <owl:ObjectProperty rdf:about="http://visallo.org/workspace#toProduct">
-        <rdfs:label xml:lang="en">To Product</rdfs:label>
-        <rdfs:domain rdf:resource="http://visallo.org/workspace#workspace"/>
-        <rdfs:range rdf:resource="http://visallo.org/workspace#product"/>
-    </owl:ObjectProperty>
+    
 
 
     <!-- http://visallo.org/workspace#toEntity -->
 
     <owl:ObjectProperty rdf:about="http://visallo.org/workspace#toEntity">
-        <rdfs:label xml:lang="en">To Entity</rdfs:label>
         <rdfs:domain rdf:resource="http://visallo.org/workspace#workspace"/>
-        <rdfs:range rdf:resource="&owl;Thing"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <rdfs:label xml:lang="en">To Entity</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://visallo.org/workspace#toProduct -->
+
+    <owl:ObjectProperty rdf:about="http://visallo.org/workspace#toProduct">
+        <rdfs:domain rdf:resource="http://visallo.org/workspace#workspace"/>
+        <rdfs:range rdf:resource="http://visallo.org/workspace#product"/>
+        <rdfs:label xml:lang="en">To Product</rdfs:label>
     </owl:ObjectProperty>
     
 
@@ -75,9 +78,9 @@
     <!-- http://visallo.org/workspace#toUser -->
 
     <owl:ObjectProperty rdf:about="http://visallo.org/workspace#toUser">
-        <rdfs:label xml:lang="en">To User</rdfs:label>
-        <rdfs:range rdf:resource="http://visallo.org/user#user"/>
         <rdfs:domain rdf:resource="http://visallo.org/workspace#workspace"/>
+        <rdfs:range rdf:resource="http://visallo.org/user#user"/>
+        <rdfs:label xml:lang="en">To User</rdfs:label>
     </owl:ObjectProperty>
     
 
@@ -96,9 +99,9 @@
     <!-- http://visallo.org/workspace#configuration -->
 
     <owl:DatatypeProperty rdf:about="http://visallo.org/workspace#configuration">
-        <visallo:userVisible>false</visallo:userVisible>
         <rdfs:domain rdf:resource="http://visallo.org/workspace#dashboardItem"/>
-        <rdfs:range rdf:resource="&xsd;string"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <visallo:userVisible>false</visallo:userVisible>
     </owl:DatatypeProperty>
     
 
@@ -106,9 +109,9 @@
     <!-- http://visallo.org/workspace#extensionId -->
 
     <owl:DatatypeProperty rdf:about="http://visallo.org/workspace#extensionId">
-        <visallo:userVisible>false</visallo:userVisible>
         <rdfs:domain rdf:resource="http://visallo.org/workspace#dashboardItem"/>
-        <rdfs:range rdf:resource="&xsd;string"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <visallo:userVisible>false</visallo:userVisible>
     </owl:DatatypeProperty>
     
 
@@ -116,9 +119,9 @@
     <!-- http://visallo.org/workspace#toEntity/graphLayoutJson -->
 
     <owl:DatatypeProperty rdf:about="http://visallo.org/workspace#toEntity/graphLayoutJson">
+        <rdfs:domain rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <visallo:userVisible>false</visallo:userVisible>
-        <rdfs:range rdf:resource="&xsd;string"/>
-        <rdfs:domain rdf:resource="&owl;Thing"/>
     </owl:DatatypeProperty>
     
 
@@ -126,9 +129,9 @@
     <!-- http://visallo.org/workspace#toEntity/graphPositionX -->
 
     <owl:DatatypeProperty rdf:about="http://visallo.org/workspace#toEntity/graphPositionX">
+        <rdfs:domain rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
         <visallo:userVisible>false</visallo:userVisible>
-        <rdfs:range rdf:resource="&xsd;integer"/>
-        <rdfs:domain rdf:resource="&owl;Thing"/>
     </owl:DatatypeProperty>
     
 
@@ -136,9 +139,9 @@
     <!-- http://visallo.org/workspace#toEntity/graphPositionY -->
 
     <owl:DatatypeProperty rdf:about="http://visallo.org/workspace#toEntity/graphPositionY">
+        <rdfs:domain rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
         <visallo:userVisible>false</visallo:userVisible>
-        <rdfs:range rdf:resource="&xsd;integer"/>
-        <rdfs:domain rdf:resource="&owl;Thing"/>
     </owl:DatatypeProperty>
     
 
@@ -146,9 +149,9 @@
     <!-- http://visallo.org/workspace#toEntity/visible -->
 
     <owl:DatatypeProperty rdf:about="http://visallo.org/workspace#toEntity/visible">
+        <rdfs:domain rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
         <visallo:userVisible>false</visallo:userVisible>
-        <rdfs:range rdf:resource="&xsd;boolean"/>
-        <rdfs:domain rdf:resource="&owl;Thing"/>
     </owl:DatatypeProperty>
     
 
@@ -156,10 +159,10 @@
     <!-- http://visallo.org/workspace#toUser/access -->
 
     <owl:DatatypeProperty rdf:about="http://visallo.org/workspace#toUser/access">
+        <rdfs:domain rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <visallo:textIndexHints>NONE</visallo:textIndexHints>
         <visallo:userVisible>false</visallo:userVisible>
-        <rdfs:range rdf:resource="&xsd;string"/>
-        <rdfs:domain rdf:resource="&owl;Thing"/>
     </owl:DatatypeProperty>
     
 
@@ -167,9 +170,9 @@
     <!-- http://visallo.org/workspace#toUser/creator -->
 
     <owl:DatatypeProperty rdf:about="http://visallo.org/workspace#toUser/creator">
+        <rdfs:domain rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
         <visallo:userVisible>false</visallo:userVisible>
-        <rdfs:range rdf:resource="&xsd;boolean"/>
-        <rdfs:domain rdf:resource="&owl;Thing"/>
     </owl:DatatypeProperty>
     
 
@@ -177,10 +180,10 @@
     <!-- http://visallo.org/workspace#workspace/title -->
 
     <owl:DatatypeProperty rdf:about="http://visallo.org/workspace#workspace/title">
+        <rdfs:domain rdf:resource="http://visallo.org/workspace#workspace"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <visallo:textIndexHints>EXACT_MATCH,FULL_TEXT</visallo:textIndexHints>
         <visallo:userVisible>false</visallo:userVisible>
-        <rdfs:domain rdf:resource="http://visallo.org/workspace#workspace"/>
-        <rdfs:range rdf:resource="&xsd;string"/>
     </owl:DatatypeProperty>
     
 
@@ -199,9 +202,9 @@
     <!-- http://visallo.org/workspace#dashboard -->
 
     <owl:Class rdf:about="http://visallo.org/workspace#dashboard">
-        <rdfs:label xml:lang="en">Dashboard</rdfs:label>
-        <visallo:userVisible>false</visallo:userVisible>
         <visallo:titleFormula>&apos;Dashboard: &apos; + prop(&apos;http://visallo.org/workspace#workspace/title&apos;)</visallo:titleFormula>
+        <visallo:userVisible>false</visallo:userVisible>
+        <rdfs:label xml:lang="en">Dashboard</rdfs:label>
     </owl:Class>
     
 
@@ -209,30 +212,32 @@
     <!-- http://visallo.org/workspace#dashboardItem -->
 
     <owl:Class rdf:about="http://visallo.org/workspace#dashboardItem">
-        <rdfs:label xml:lang="en">Dashboard Item</rdfs:label>
         <visallo:titleFormula>&apos;Dashboard Item: &apos; + prop(&apos;http://visallo.org/workspace#extensionId&apos;)</visallo:titleFormula>
         <visallo:userVisible>false</visallo:userVisible>
+        <rdfs:label xml:lang="en">Dashboard Item</rdfs:label>
     </owl:Class>
+    
 
 
     <!-- http://visallo.org/workspace#product -->
 
     <owl:Class rdf:about="http://visallo.org/workspace#product">
-        <rdfs:label xml:lang="en">Product</rdfs:label>
         <visallo:userVisible>false</visallo:userVisible>
+        <rdfs:label xml:lang="en">Product</rdfs:label>
     </owl:Class>
+    
 
 
     <!-- http://visallo.org/workspace#workspace -->
 
     <owl:Class rdf:about="http://visallo.org/workspace#workspace">
-        <rdfs:label xml:lang="en">Workspace</rdfs:label>
         <visallo:titleFormula>&apos;Workspace: &apos; + prop(&apos;http://visallo.org/workspace#workspace/title&apos;)</visallo:titleFormula>
         <visallo:userVisible>false</visallo:userVisible>
+        <rdfs:label xml:lang="en">Workspace</rdfs:label>
     </owl:Class>
 </rdf:RDF>
 
 
 
-<!-- Generated by the OWL API (version 3.5.1) http://owlapi.sourceforge.net -->
+<!-- Generated by the OWL API (version 4.2.6.20160910-2108) https://github.com/owlcs/owlapi -->
 

--- a/web/plugins/map-product/src/main/java/org/visallo/web/product/map/MapWorkProduct.java
+++ b/web/plugins/map-product/src/main/java/org/visallo/web/product/map/MapWorkProduct.java
@@ -11,8 +11,6 @@ import org.visallo.core.util.VisalloLogger;
 import org.visallo.core.util.VisalloLoggerFactory;
 
 public class MapWorkProduct extends WorkProductElements {
-    private static final VisalloLogger LOGGER = VisalloLoggerFactory.getLogger(MapWorkProduct.class);
-
     @Inject
     public MapWorkProduct(OntologyRepository ontologyRepository) {
         super(ontologyRepository);

--- a/web/web-base/src/main/java/org/visallo/web/Router.java
+++ b/web/web-base/src/main/java/org/visallo/web/Router.java
@@ -207,6 +207,8 @@ public class Router extends HttpServlet {
             app.get("/product/all", authenticator, csrfProtector, ReadPrivilegeFilter.class, ProductAll.class);
             app.get("/product", authenticator, csrfProtector, ReadPrivilegeFilter.class, ProductGet.class);
             app.get("/product/preview", authenticator, csrfProtector, ReadPrivilegeFilter.class, ProductPreview.class);
+            app.post("/product/link", authenticator, csrfProtector, EditPrivilegeFilter.class, ProductLink.class);
+            app.delete("/product/link", authenticator, csrfProtector, EditPrivilegeFilter.class, ProductUnlink.class);
             app.post("/product", authenticator, csrfProtector, EditPrivilegeFilter.class, ProductUpdate.class);
             app.delete("/product", authenticator, csrfProtector, EditPrivilegeFilter.class, ProductDelete.class);
 

--- a/web/web-base/src/main/java/org/visallo/web/routes/product/ProductLink.java
+++ b/web/web-base/src/main/java/org/visallo/web/routes/product/ProductLink.java
@@ -1,0 +1,44 @@
+package org.visallo.web.routes.product;
+
+import com.google.inject.Inject;
+import com.v5analytics.webster.ParameterizedHandler;
+import com.v5analytics.webster.annotations.Handle;
+import com.v5analytics.webster.annotations.Required;
+import org.visallo.core.exception.VisalloResourceNotFoundException;
+import org.visallo.core.model.workspace.WorkspaceRepository;
+import org.visallo.core.model.workspace.product.Product;
+import org.visallo.core.user.User;
+import org.visallo.web.VisalloResponse;
+import org.visallo.web.clientapi.model.ClientApiSuccess;
+import org.visallo.web.parameterProviders.ActiveWorkspaceId;
+
+public class ProductLink implements ParameterizedHandler {
+    private final WorkspaceRepository workspaceRepository;
+
+    @Inject
+    public ProductLink(WorkspaceRepository workspaceRepository) {
+        this.workspaceRepository = workspaceRepository;
+    }
+
+    @Handle
+    public ClientApiSuccess handle(
+            @Required(name = "product1Id") String product1Id,
+            @Required(name = "product2Id") String product2Id,
+            @ActiveWorkspaceId String workspaceId,
+            User user
+    ) throws Exception {
+        Product product1 = workspaceRepository.findProductById(workspaceId, product1Id, null, false, user);
+        if (product1 == null) {
+            throw new VisalloResourceNotFoundException("Could not find product " + product1Id, product1Id);
+        }
+
+        Product product2 = workspaceRepository.findProductById(workspaceId, product2Id, null, false, user);
+        if (product2 == null) {
+            throw new VisalloResourceNotFoundException("Could not find product " + product2Id, product2Id);
+        }
+
+        workspaceRepository.linkWorkProducts(product1, product2, user);
+        return VisalloResponse.SUCCESS;
+    }
+
+}

--- a/web/web-base/src/main/java/org/visallo/web/routes/product/ProductUnlink.java
+++ b/web/web-base/src/main/java/org/visallo/web/routes/product/ProductUnlink.java
@@ -1,0 +1,44 @@
+package org.visallo.web.routes.product;
+
+import com.google.inject.Inject;
+import com.v5analytics.webster.ParameterizedHandler;
+import com.v5analytics.webster.annotations.Handle;
+import com.v5analytics.webster.annotations.Required;
+import org.visallo.core.exception.VisalloResourceNotFoundException;
+import org.visallo.core.model.workspace.WorkspaceRepository;
+import org.visallo.core.model.workspace.product.Product;
+import org.visallo.core.user.User;
+import org.visallo.web.VisalloResponse;
+import org.visallo.web.clientapi.model.ClientApiSuccess;
+import org.visallo.web.parameterProviders.ActiveWorkspaceId;
+
+public class ProductUnlink implements ParameterizedHandler {
+    private final WorkspaceRepository workspaceRepository;
+
+    @Inject
+    public ProductUnlink(WorkspaceRepository workspaceRepository) {
+        this.workspaceRepository = workspaceRepository;
+    }
+
+    @Handle
+    public ClientApiSuccess handle(
+            @Required(name = "product1Id") String product1Id,
+            @Required(name = "product2Id") String product2Id,
+            @ActiveWorkspaceId String workspaceId,
+            User user
+    ) throws Exception {
+        Product product1 = workspaceRepository.findProductById(workspaceId, product1Id, null, false, user);
+        if (product1 == null) {
+            throw new VisalloResourceNotFoundException("Could not find product " + product1Id, product1Id);
+        }
+
+        Product product2 = workspaceRepository.findProductById(workspaceId, product2Id, null, false, user);
+        if (product2 == null) {
+            throw new VisalloResourceNotFoundException("Could not find product " + product2Id, product2Id);
+        }
+
+        workspaceRepository.unlinkWorkProducts(product1, product2, user);
+        return VisalloResponse.SUCCESS;
+    }
+
+}


### PR DESCRIPTION
- [ ] @joeferner
- [ ] @kunklejr @mwizeman @sfeng88 @diegogrz
- [ ] @dsingley @EvanOxfeld 
- [ ] @joeybrk372 @rygim @jharwig 

Linking two products will update the linked product when the source
product is updated

This PR is for discussion purposes right now...
* Currently these routes and methods are not exposed to the user for linking.
* If existing work products which have existing data get linked that data does not get updated to the linked product. Should it?
* If you link a map to a graph and drag an item onto the map it gets placed at 0,0 since it doesn't have coordinates. What should happen?

CHANGELOG
Added: methods and routes to link two products
