### PR TITLE
Find correct gpw property to process

### DIFF
--- a/core/core-test/src/test/java/org/visallo/core/ingest/graphProperty/GraphPropertyRunnerTest.java
+++ b/core/core-test/src/test/java/org/visallo/core/ingest/graphProperty/GraphPropertyRunnerTest.java
@@ -19,6 +19,8 @@ import org.visallo.core.status.MetricsManager;
 import org.visallo.core.status.StatusRepository;
 
 import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
@@ -283,6 +285,7 @@ public class GraphPropertyRunnerTest {
         when(prop.getName()).thenReturn(name);
         when(prop.getKey()).thenReturn(key);
         when(prop.getValue()).thenReturn(value);
+        when(prop.getVisibility()).thenReturn(Visibility.EMPTY);
         return prop;
     }
 
@@ -292,8 +295,12 @@ public class GraphPropertyRunnerTest {
         when(v.getId()).thenReturn(id);
         when(v.getProperties()).thenReturn(propList);
         for (Property property : properties) {
-            when(v.getProperty(property.getKey(), property.getName())).thenReturn(property);
-            when(v.getProperty(property.getName())).thenReturn(property);
+            String key = property.getKey();
+            String name = property.getName();
+            when(v.getProperty(key, name)).thenReturn(property);
+            when(v.getProperty(name)).thenReturn(property);
+            when(v.getProperties(name)).thenReturn(Collections.singletonList(property));
+            when(v.getProperties(key, name)).thenReturn(Collections.singletonList(property));
         }
 
         return v;


### PR DESCRIPTION
Cherry picked from  https://github.com/v5analytics/visallo/pull/756 to the release-2.2 branch

NO CHANGELOG

Whenever the value of a published property has been changed on a
workspace, those changes were not being put through the graph property
workers. This change checks all of the properties that can be returned
and uses the workspace ID to decide which property needs to be put
through the graph property workers.