### PR TITLE
Changed: GraphUpdateContext to use Vertexium's bulk save

### DIFF
--- a/core/core-test/src/test/java/org/visallo/core/model/graph/GraphRepositoryTest.java
+++ b/core/core-test/src/test/java/org/visallo/core/model/graph/GraphRepositoryTest.java
@@ -306,18 +306,16 @@ public class GraphRepositoryTest {
 
         try (GraphUpdateContext ctx = graphRepository.beginGraphUpdate(Priority.NORMAL, user1, defaultAuthorizations)) {
             ElementMutation<Vertex> m = graph.prepareVertex("v1", new Visibility(""));
-            Vertex v1 = ctx.update(m, modifiedDate, visibilityJson, "http://visallo.org/text#concept1", updateContext -> {
+            ctx.update(m, modifiedDate, visibilityJson, "http://visallo.org/text#concept1", updateContext -> {
                 VisalloProperties.FILE_NAME.updateProperty(updateContext, "k1", "test1.txt", metadata);
             });
-            assertNotNull(v1);
 
             m = graph.prepareVertex("v2", new Visibility(""));
-            Vertex v2 = ctx.update(m, updateContext -> {
+            ctx.update(m, updateContext -> {
                 updateContext.updateBuiltInProperties(modifiedDate, visibilityJson);
                 updateContext.setConceptType("http://visallo.org/text#concept1");
                 VisalloProperties.FILE_NAME.updateProperty(updateContext, "k1", "test2.txt", metadata);
             });
-            assertNotNull(v2);
         }
 
         List<byte[]> queue = InMemoryWorkQueueRepository.getQueue("graphProperty");

--- a/core/core/src/main/java/org/visallo/core/model/graph/ElementUpdateContext.java
+++ b/core/core/src/main/java/org/visallo/core/model/graph/ElementUpdateContext.java
@@ -1,6 +1,5 @@
 package org.visallo.core.model.graph;
 
-import org.vertexium.Authorizations;
 import org.vertexium.Edge;
 import org.vertexium.Element;
 import org.vertexium.Visibility;
@@ -23,7 +22,7 @@ public class ElementUpdateContext<T extends Element> {
     private final ElementMutation<T> mutation;
     private final User user;
     private final List<VisalloPropertyUpdate> properties = new ArrayList<>();
-    private T element;
+    private final T element;
 
     public ElementUpdateContext(VisibilityTranslator visibilityTranslator, ElementMutation<T> mutation, User user) {
         this.visibilityTranslator = visibilityTranslator;
@@ -31,12 +30,9 @@ public class ElementUpdateContext<T extends Element> {
         this.user = user;
         if (mutation instanceof ExistingElementMutation) {
             element = ((ExistingElementMutation<T>) mutation).getElement();
+        } else {
+            element = null;
         }
-    }
-
-    public T save(Authorizations authorizations) {
-        this.element = this.mutation.save(authorizations);
-        return this.element;
     }
 
     public boolean isNewElement() {

--- a/core/plugins/model-vertexium/src/main/java/org/visallo/vertexium/model/ontology/VertexiumOntologyRepository.java
+++ b/core/plugins/model-vertexium/src/main/java/org/visallo/vertexium/model/ontology/VertexiumOntologyRepository.java
@@ -525,7 +525,7 @@ public class VertexiumOntologyRepository extends OntologyRepositoryBase {
                     OntologyProperties.SUBTITLE_FORMULA.updateProperty(elemCtx, "prop('http://visallo.org#source') || ''", VISIBILITY.getVisibility());
                     OntologyProperties.TIME_FORMULA.updateProperty(elemCtx, "''", VISIBILITY.getVisibility());
                 }
-            });
+            }).get();
 
             concept = createConcept(vertex);
             if (parent != null) {
@@ -631,7 +631,7 @@ public class VertexiumOntologyRepository extends OntologyRepositoryBase {
                         OntologyProperties.INTENT.updateProperty(elemCtx, intent, intent, metadata, visibility);
                     }
                 }
-            });
+            }).get();
 
             return createOntologyProperty(vertex, dependentPropertyIris);
         } catch (Exception e) {
@@ -677,7 +677,7 @@ public class VertexiumOntologyRepository extends OntologyRepositoryBase {
             Vertex relationshipVertex = ctx.update(builder, elemCtx -> {
                 VisalloProperties.CONCEPT_TYPE.updateProperty(elemCtx, TYPE_RELATIONSHIP, VISIBILITY.getVisibility());
                 OntologyProperties.ONTOLOGY_TITLE.updateProperty(elemCtx, relationshipIRI, VISIBILITY.getVisibility());
-            });
+            }).get();
 
             for (Concept domainConcept : domainConcepts) {
                 findOrAddEdge(ctx, ((VertexiumConcept) domainConcept).getVertex(), relationshipVertex, LabelName.HAS_EDGE.toString());
@@ -749,7 +749,7 @@ public class VertexiumOntologyRepository extends OntologyRepositoryBase {
                             OntologyProperties.TEXT_INDEX_HINTS.updateProperty(elemCtx, textIndexHint, textIndexHint, metadata, VISIBILITY.getVisibility());
                         });
                     }
-                });
+                }).get();
 
                 for (Concept concept : concepts) {
                     findOrAddEdge(ctx, ((VertexiumConcept) concept).getVertex(), propertyVertex, LabelName.HAS_PROPERTY.toString());
@@ -897,5 +897,6 @@ public class VertexiumOntologyRepository extends OntologyRepositoryBase {
                 vertex.softDeleteProperty(property.getKey(), property.getName(), authorizations);
             }
         }
+        graph.flush();
     }
 }

--- a/core/plugins/model-vertexium/src/main/java/org/visallo/vertexium/model/ontology/VertexiumRelationship.java
+++ b/core/plugins/model-vertexium/src/main/java/org/visallo/vertexium/model/ontology/VertexiumRelationship.java
@@ -37,25 +37,25 @@ public class VertexiumRelationship extends Relationship {
     @Override
     public void addIntent(String intent, Authorizations authorizations) {
         OntologyProperties.INTENT.addPropertyValue(vertex, intent, intent, OntologyRepository.VISIBILITY.getVisibility(), authorizations);
-        vertex.getGraph().flush();
+        getVertex().getGraph().flush();
     }
 
     @Override
     public void removeIntent(String intent, Authorizations authorizations) {
         OntologyProperties.INTENT.removeProperty(vertex, intent, authorizations);
-        vertex.getGraph().flush();
+        getVertex().getGraph().flush();
     }
 
     @Override
     public void setProperty(String name, Object value, Authorizations authorizations) {
         getVertex().setProperty(name, value, OntologyRepository.VISIBILITY.getVisibility(), authorizations);
-        vertex.getGraph().flush();
+        getVertex().getGraph().flush();
     }
 
     @Override
     public void removeProperty(String name, Authorizations authorizations) {
         getVertex().softDeleteProperty(ElementMutation.DEFAULT_KEY, name, authorizations);
-        vertex.getGraph().flush();
+        getVertex().getGraph().flush();
     }
 
     @Override

--- a/core/plugins/model-vertexium/src/main/java/org/visallo/vertexium/model/workspace/VertexiumWorkspaceRepository.java
+++ b/core/plugins/model-vertexium/src/main/java/org/visallo/vertexium/model/workspace/VertexiumWorkspaceRepository.java
@@ -997,7 +997,7 @@ public class VertexiumWorkspaceRepository extends WorkspaceRepository {
                             visibility
                     );
                 }
-            });
+            }).get();
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -1047,7 +1047,7 @@ public class VertexiumWorkspaceRepository extends WorkspaceRepository {
                 if (productId == null) {
                     WorkspaceProperties.PRODUCT_KIND.setProperty(elemCtx.getMutation(), kind, visibility);
                 }
-            });
+            }).get();
 
             WorkProduct workProduct = getWorkProductByKind(
                     kind == null


### PR DESCRIPTION
- [x] @joeferner
- [x] @kunklejr @mwizeman @sfeng88 @diegogrz
- [ ] @dsingley @EvanOxfeld 
- [ ] @joeybrk372 @rygim @jharwig 

By saving multiple mutations at once, this increases performance
while using Elasticsearch by performing a bulk update instead of
many smaller updates.

CHANGELOG
Changed: GraphUpdateContext to use Vertexium's bulk save