### PR TITLE
Send product to map options extensions

### DIFF
--- a/docs/extension-points/front-end/mapOptions/index.md
+++ b/docs/extension-points/front-end/mapOptions/index.md
@@ -11,6 +11,14 @@ All registered components will be passed:
     * `clusterSource` [`[MultiPointCluster]`](https://github.com/v5analytics/visallo/blob/master/web/plugins/map-product/src/main/resources/org/visallo/web/product/map/multiPointCluster.js): Implements the [`ol.source.Cluster`](http://openlayers.org/en/latest/apidoc/ol.source.Cluster.html) interface to cluster the `source` features.
     * `source` [`[ol.source.Vector]`](http://openlayers.org/en/latest/apidoc/ol.source.Vector.html): The source of all map pins before clustering. 
     * `layer` [`[ol.layer.Vector]`](http://openlayers.org/en/latest/apidoc/ol.layer.Vector.html): The pin vector layer
+* `product` `[Object]`: Work Product json details
+    * `data` `[Object]`: Data for product (loaded when all products loaded)
+    * `extendedData` `[Object]`: Extended data for product (vertices/edges, loaded only when product opened)
+    * `id` `[String]`: Product identifier
+    * `kind` `[String]`: Work product class name: `org.visallo.web.product.map.MapWorkProduct`.
+    * `previewMD5` `[String]`: Preview image hash
+    * `title` `[String]`: Work product title
+    * `workspaceId` `[String]`: Workspace of the work product
 
 To register an option:
 

--- a/web/plugins/map-product/src/main/resources/org/visallo/web/product/map/Map.jsx
+++ b/web/plugins/map-product/src/main/resources/org/visallo/web/product/map/Map.jsx
@@ -2,10 +2,19 @@ define([
     'react',
     './OpenLayers',
     'components/RegistryInjectorHOC',
+    'configuration/plugins/registry',
     'util/vertex/formatters',
     'util/mapConfig'
-], function(React, OpenLayers, RegistryInjectorHOC, F, mapConfig) {
+], function(React, OpenLayers, RegistryInjectorHOC, registry, F, mapConfig) {
     'use strict';
+
+    registry.documentExtensionPoint('org.visallo.map.options',
+        'Add components to map options dropdown',
+        function(e) {
+            return ('identifier' in e) && ('optionComponentPath' in e);
+        },
+        'http://docs.visallo.org/extension-points/front-end/mapOptions'
+    );
 
     const PropTypes = React.PropTypes;
     const Map = React.createClass({
@@ -90,7 +99,8 @@ define([
         getTools() {
             return this.props.registry['org.visallo.map.options'].map(e => ({
                 identifier: e.identifier,
-                componentPath: e.optionComponentPath
+                componentPath: e.optionComponentPath,
+                product: this.props.product
             }));
         },
 

--- a/web/plugins/map-product/src/main/resources/org/visallo/web/product/map/OpenLayers.jsx
+++ b/web/plugins/map-product/src/main/resources/org/visallo/web/product/map/OpenLayers.jsx
@@ -566,9 +566,10 @@ define([
             const { map, cluster } = this.state;
             if (map && cluster) {
                 return this.props.tools.map(tool => {
+                    const { product, ...rest } = tool;
                     return {
-                        ...tool,
-                        props: { ol, map, cluster }
+                        ...rest,
+                        props: { product, ol, map, cluster }
                     }
                 });
             }


### PR DESCRIPTION
- [x] @joeferner
- [x] @kunklejr @sfeng88 @diegogrz
- [x] @mwizeman @EvanOxfeld 
- [x] @joeybrk372 @rygim @jharwig 

And add registry documentation extension point.

Changelog covered in https://github.com/v5analytics/visallo/pull/735