### PR TITLE
Changed: WorkerBase no longer sleeps in between spout polling

### DIFF
--- a/core/core/src/main/java/org/visallo/core/ingest/WorkerSpout.java
+++ b/core/core/src/main/java/org/visallo/core/ingest/WorkerSpout.java
@@ -16,5 +16,13 @@ public abstract class WorkerSpout {
 
     }
 
+    /**
+     * Get the next tuple from the queue. This method should poll and wait for a time period to
+     * prevent spinning and causing high cpu load as the method calling this method will not sleep
+     * if a null is returned. This method should also not wait indefinitely because the calling
+     * method needs to perform periodic work.
+     *
+     * @return null, if no tuple is available in the polling period.
+     */
     public abstract WorkerTuple nextTuple() throws Exception;
 }

--- a/core/core/src/main/java/org/visallo/core/model/WorkerBase.java
+++ b/core/core/src/main/java/org/visallo/core/model/WorkerBase.java
@@ -122,7 +122,6 @@ public abstract class WorkerBase<TWorkerItem extends WorkerItem> {
                 continue;
             }
             if (workerItemWrapper == null) {
-                Thread.sleep(100);
                 continue;
             }
             synchronized (tupleQueue) {

--- a/core/plugins/model-queue-inmemory/src/main/java/org/visallo/model/queue/inmemory/InMemoryWorkQueueRepository.java
+++ b/core/plugins/model-queue-inmemory/src/main/java/org/visallo/model/queue/inmemory/InMemoryWorkQueueRepository.java
@@ -77,10 +77,12 @@ public class InMemoryWorkQueueRepository extends WorkQueueRepository {
             public WorkerTuple nextTuple() throws Exception {
                 synchronized (queue) {
                     if (queue.size() == 0) {
+                        Thread.sleep(100);
                         return null;
                     }
                     byte[] entry = queue.remove(0);
                     if (entry == null) {
+                        Thread.sleep(100);
                         return null;
                     }
                     return new WorkerTuple("", entry);


### PR DESCRIPTION
- [x] @joeferner
- [x] @kunklejr @sfeng88 @diegogrz
- [x] @mwizeman @EvanOxfeld 
- [x] @joeybrk372 @rygim @jharwig 

By removing the sleep and putting the sleep requirement on
WorkerSpout#nextTuple the overall GPW throughput is increased.

CHANGELOG
Changed: WorkerBase no longer sleeps in between spout polling