### PR TITLE
Fix propertyInfo for comments and edge visibility(3.0)

### DIFF
--- a/web/war/src/main/webapp/js/util/acl.js
+++ b/web/war/src/main/webapp/js/util/acl.js
@@ -45,16 +45,14 @@ define([
             function mergeElementPropertyAcls(propertyAcls) {
                 elements.forEach(function (e) {
                     e.acl.propertyAcls.forEach(function (elementPropertyAcl) {
-                        var matches = _.where(propertyAcls, {
-                            name: elementPropertyAcl.name,
-                            key: elementPropertyAcl.keys || null
+                        var matchIndex = propertyAcls.findIndex((p) => {
+                            let key = elementPropertyAcl.key || null;
+                            return p.name === elementPropertyAcl.name && p.key === key;
                         });
-                        if (matches.length === 0) {
+                        if (matchIndex < 0) {
                             propertyAcls.push(elementPropertyAcl);
                         } else {
-                            _.each(matches, function(r) {
-                                _.extend(r, elementPropertyAcl);
-                            });
+                            propertyAcls[matchIndex] = _.extend(propertyAcls[matchIndex], elementPropertyAcl);
                         }
                     });
                 });
@@ -66,14 +64,14 @@ define([
         findPropertyAcl: function(propertiesAcl, propName, propKey) {
             var props = _.where(propertiesAcl, {name: propName, key: propKey});
             if (props.length === 0) {
-                var propsByName = _.where(propertiesAcl, {name: propName});
+                var propsByName = _.where(propertiesAcl, { name: propName, key: null });
                 if (propsByName.length === 0) {
                     throw new Error('no ACL property defined "' + propName + ':' + propKey + '"');
                 }
                 props = propsByName;
             }
             if (props.length !== 1) {
-                throw new Error('more than one ACL property with the same name defined "' + propName + ':' + propKey + '" lenght: ' + props.length);
+                throw new Error('more than one ACL property with the same name defined "' + propName + ':' + propKey + '" length: ' + props.length);
             }
             return props[0];
         }

--- a/web/war/src/main/webapp/js/util/popovers/propertyInfo/propertyInfo.js
+++ b/web/war/src/main/webapp/js/util/popovers/propertyInfo/propertyInfo.js
@@ -87,9 +87,11 @@ define([
                 .then((propertyAcls) => {
                     if (config.property) {
                         config.isComment = config.property.name === 'http://visallo.org/comment#entry';
+                        config.isVisibility = config.property.name === 'http://visallo.org#visibilityJson';
                         config.canAdd = config.canEdit = config.canDelete = false;
 
-                        var propertyAcl = acl.findPropertyAcl(propertyAcls, config.property.name, config.property.key);
+                        var propertyAcl = config.isVisibility ? config.ontologyProperty :
+                            acl.findPropertyAcl(propertyAcls, config.property.name, config.property.key);
 
                         if (config.isComment && visalloData.currentWorkspaceCommentable) {
                             config.canAdd = config.property.addable !== undefined ? config.property.addable !== false : propertyAcl.addable !== false;
@@ -99,7 +101,7 @@ define([
                             config.canAdd = config.property.addable !== undefined ? config.property.addable !== false : propertyAcl.addable !== false;
                             config.canEdit = config.property.updateable !== undefined ? config.property.updateable !== false : propertyAcl.updateable !== false;
                             config.canDelete = (config.property.deleteable !== undefined ? config.property.deleteable !== false : propertyAcl.deleteable !== false) &&
-                                config.property.name !== 'http://visallo.org#visibilityJson';
+                                !config.isVisibility;
                         }
 
                         var isCompoundField = config.ontologyProperty && config.ontologyProperty.dependentPropertyIris &&


### PR DESCRIPTION
- [x] @joeferner
- [ ] @kunklejr @sfeng88 @diegogrz
- [x] @mwizeman @EvanOxfeld 
- [x] @joeybrk372 @rygim @jharwig 

Fixes not being able to open the property info popover for comments that were not your own, and visibility on edges (which prevented you from replying and editing respectively)

no changelog