### PR TITLE
modify to use displayname instead of username in user account management modal (3.0)

### DIFF
--- a/web/war/src/main/webapp/js/workspaces/overlay.js
+++ b/web/war/src/main/webapp/js/workspaces/overlay.js
@@ -412,7 +412,7 @@ define([
                             'workspaces/userAccount/userAccount'
                         ], function(modalTemplate, UserAccount) {
                             var modal = $(modalTemplate({
-                                userName: visalloData.currentUser.userName
+                                displayName: visalloData.currentUser.displayName
                             })).appendTo(document.body);
                             UserAccount.attachTo(modal);
                             modal.modal('show');

--- a/web/war/src/main/webapp/js/workspaces/userAccount/modal.hbs
+++ b/web/war/src/main/webapp/js/workspaces/userAccount/modal.hbs
@@ -1,7 +1,7 @@
 <div class="user-account modal hide fade" tabindex="-1">
   <div class="modal-header">
     <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
-    <h3>{{ i18n 'useraccount.modal.title' userName}}</h3>
+    <h3>{{ i18n 'useraccount.modal.title' displayName}}</h3>
   </div>
   <div class="modal-body">
     <ul class="nav nav-list"></ul>


### PR DESCRIPTION
2.2.2 PR: https://github.com/v5analytics/visallo/pull/820