### PR TITLE
Don't show unresolve option if resolved entity is public

### DIFF
--- a/web/war/src/main/webapp/js/detail/detectedObjects/detectedObjects.js
+++ b/web/war/src/main/webapp/js/detail/detectedObjects/detectedObjects.js
@@ -94,12 +94,14 @@ define([
                 self.$node.off('.actionbar')
 
                 if ($target.hasClass('resolved')) {
+                    const unresolve = Privileges.canEDIT &&
+                        self.attr.model.sandboxStatus !== 'PUBLIC';
 
                     ActionBar.attachTo($target, {
                         alignTo: 'node',
                         actions: $.extend({
                             Open: 'open.actionbar'
-                        }, Privileges.canEDIT ? {
+                        }, unresolve ? {
                             Unresolve: 'unresolve.actionbar'
                         } : {})
                     });

--- a/web/war/src/main/webapp/js/detail/text/text.js
+++ b/web/war/src/main/webapp/js/detail/text/text.js
@@ -533,7 +533,10 @@ define([
                     $textOffset = $text.closest('.nav-with-background').offset();
 
                 if ($target.hasClass('resolved')) {
-                    var info = $target.data('info');
+                    const info = $target.data('info');
+                    const unresolve = Privileges.canEDIT &&
+                        info.termMentionFor === 'VERTEX' &&
+                        info.sandboxStatus !== 'PUBLIC';
 
                     ActionBar.attachTo($target, {
                         alignTo: 'node',
@@ -542,7 +545,7 @@ define([
                         actions: $.extend({
                             Open: 'open',
                             Fullscreen: 'fullscreen'
-                        }, Privileges.canEDIT && info.termMentionFor === 'VERTEX' ? {
+                        }, unresolve ? {
                             Unresolve: 'unresolve'
                         } : {})
                     });


### PR DESCRIPTION
- [x] @joeferner
- [x] @kunklejr @sfeng88 @diegogrz
- [ ] @mwizeman @EvanOxfeld 
- [ ] @joeybrk372 @rygim @jharwig 

CHANGELOG
Fixed: Unresolve option was being displayed for term mentions/detected objects that were public entities which can't be unresolved.

