### PR TITLE
Update maven-front-end plugin

### DIFF
--- a/root/pom.xml
+++ b/root/pom.xml
@@ -149,7 +149,7 @@
         <plugin.sonar.version>4.0</plugin.sonar.version>
         <plugin.taglist.version>2.4</plugin.taglist.version>
         <plugin.template.resgen.version>0.11</plugin.template.resgen.version>
-        <plugin.frontend>1.2</plugin.frontend>
+        <plugin.frontend>1.3</plugin.frontend>
         <maven.plugin.gpg.version>1.6</maven.plugin.gpg.version>
 
         <!-- Node Properties -->


### PR DESCRIPTION
- [x] @joeferner
- [x] @kunklejr @sfeng88 @diegogrz
- [x] @mwizeman @EvanOxfeld 
- [x] @joeybrk372 @rygim @jharwig 

1.3 fixes an issue that would always reinstall yarn, even if it already was.

https://github.com/eirslett/frontend-maven-plugin/pull/511

No change log as yarn hasn't officially been in a release