### PR TITLE
Fixed: Dashboard horizontal bar text clip colors in FF

### DIFF
--- a/web/war/src/main/webapp/js/dashboard/reportRenderers/bar.js
+++ b/web/war/src/main/webapp/js/dashboard/reportRenderers/bar.js
@@ -309,7 +309,7 @@ define([
                                     if (self.isHorizontal) {
                                         var genClipPath = function(rowPart) {
                                                 return function(d, col, row) {
-                                                    return 'clip-path-' + row + '-' + rowPart;
+                                                    return 'clip-path-' + self.attr.item.id + '-' + row + '-' + rowPart;
                                                 }
                                             },
                                             genClipPathRef = function(rowPart) {


### PR DESCRIPTION
- [x] @joeferner
- [x] @kunklejr @sfeng88 @diegogrz
- [ ] @mwizeman
- [x] @joeybrk372 @rygim @jharwig @EvanOxfeld

FF doesn't scope the clip-path defs like Chrome does. This commit adds
the component id into the id to create a globally uniq id

CHANGELOG
Fixed: Dashboard horizontal bar text clip colors in FF

Before
![before](https://cloud.githubusercontent.com/assets/808857/21446219/4729c898-c891-11e6-83a8-2fbcceb6675e.jpg)

After
![after](https://cloud.githubusercontent.com/assets/808857/21446220/488203c2-c891-11e6-9fb3-da2f779a5b72.jpg)
