### PR TITLE
Added: JSONObject#null values to be serialized by objectmapper

### DIFF
--- a/web/client-api/src/main/java/org/visallo/web/clientapi/util/ObjectMapperFactory.java
+++ b/web/client-api/src/main/java/org/visallo/web/clientapi/util/ObjectMapperFactory.java
@@ -1,9 +1,12 @@
 package org.visallo.web.clientapi.util;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import org.json.JSONObject;
+
+import java.io.IOException;
 
 public class ObjectMapperFactory {
     private static ObjectMapper mapper;
@@ -14,7 +17,21 @@ public class ObjectMapperFactory {
             mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
             mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
             mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+            mapper.registerModule(createVisalloObjectMapperModule());
         }
         return mapper;
+    }
+
+    private static Module createVisalloObjectMapperModule() {
+        SimpleModule visalloModule = new SimpleModule();
+        visalloModule.addSerializer(JSONObject.NULL.getClass(), new JSONObjectNullSerializer());
+        return visalloModule;
+    }
+
+    private static class JSONObjectNullSerializer extends JsonSerializer<Object> {
+        @Override
+        public void serialize(Object value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
+            jgen.writeNull();
+        }
     }
 }


### PR DESCRIPTION
- [x] @joeferner
- [x] @kunklejr @sfeng88 @diegogrz
- [ ] @mwizeman
- [x] @joeybrk372 @rygim @jharwig @EvanOxfeld

When work products round trip, if they have null values in the data or
extended data JSONObject will parse null values as JSONObject#NULL. This
commit will allow that value to be serialized back to null when sending
back to the UI.

CHANGELOG
Added: JSONObject#null values to be serialized by objectmapper
