### PR TITLE
Select only added vertices on add related, not all connected(3.0)

### DIFF
--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/worker/actions-impl.js
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/worker/actions-impl.js
@@ -175,7 +175,7 @@ define([
 
             dispatch(selectionActions.set({
                 selection: {
-                    vertices: _.pluck(vertices, 'id')
+                    vertices: Object.keys(updateVertices)
                 }
             }));
         }


### PR DESCRIPTION
- [x] @joeferner
- [x] @kunklejr @sfeng88 @diegogrz
- [ ] @mwizeman
- [ ] @joeybrk372 @rygim @jharwig @EvanOxfeld 

CHANGELOG
Fixed: Select only added vertices on add related, not all connected.
