### PR TITLE
Fix edge creation highlighting & control drag(3.0)

### DIFF
--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/Cytoscape.jsx
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/Cytoscape.jsx
@@ -58,6 +58,8 @@ define([
         tapend: 'onTapEnd',
         taphold: 'onTapHold',
         cxttap: 'onContextTap',
+        cxttapstart: 'onCxtTapStart',
+        cxttapend: 'onCxtTapEnd',
         pan: 'onPan',
         zoom: 'onZoom',
         fit: 'onFit',

--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/Cytoscape.jsx
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/Cytoscape.jsx
@@ -96,15 +96,18 @@ define([
         },
 
         getInitialState() {
-            return { showGraphMenu: false };
+            return {
+                showGraphMenu: false,
+                controlDragSelection: null
+            };
         },
 
         componentDidMount() {
             this.moving = {};
-            this.updatePreview = _.debounce(this._updatePreview, PREVIEW_DEBOUNCE_SECONDS * 1000)
+            this.updatePreview = _.debounce(this._updatePreview, PREVIEW_DEBOUNCE_SECONDS * 1000);
             this.previousConfig = this.prepareConfig();
             const cy = cytoscape(this.previousConfig);
-
+            const updateControlDragSelection = (nodeId = null) => this.setState({ controlDragSelection: nodeId });
             fixCytoscapeCorsHandling(cy);
             cytoscape('layout', 'bettergrid', betterGrid);
 
@@ -120,20 +123,35 @@ define([
                 }
             })
             cy.on('mousemove', (event) => {
+                const { controlDragSelection } = this.state;
                 const { drawEdgeToMouseFrom } = this.props;
-                if (drawEdgeToMouseFrom && !drawEdgeToMouseFrom.toVertexId) {
-                    const { pageX, pageY } = event.originalEvent;
-                    const { left, top } = this.clientRect;
-                    const { cyTarget, cy } = event;
-                    const node = cy.getElementById(DrawEdgeNodeId);
+                const { cyTarget, cy } = event;
+                const targetIsNode = cyTarget !== cy && cyTarget.is('node.v');
 
-                    if (cyTarget !== cy && cyTarget.is('node.v')) {
-                        node.position(cyTarget.position());
-                    } else {
-                        node.renderedPosition({ x: pageX - left, y: pageY - top });
+                if (drawEdgeToMouseFrom) {
+                    if (targetIsNode && !drawEdgeToMouseFrom.toVertexId) {
+                        if (cyTarget.data().id !== controlDragSelection) {
+                            updateControlDragSelection(cyTarget.id());
+                        }
+                    } else if (controlDragSelection) {
+                        updateControlDragSelection();
                     }
+
+                    if (!drawEdgeToMouseFrom.toVertexId) {
+                        const { pageX, pageY } = event.originalEvent;
+                        const { left, top } = this.clientRect;
+                        const node = cy.getElementById(DrawEdgeNodeId);
+
+                        if (targetIsNode) {
+                            node.position(cyTarget.position());
+                        } else {
+                            node.renderedPosition({ x: pageX - left, y: pageY - top });
+                        }
+                    }
+                } else if (!drawEdgeToMouseFrom && controlDragSelection) {
+                    updateControlDragSelection();
                 }
-            })
+            });
         },
 
         componentWillUnmount() {
@@ -144,7 +162,7 @@ define([
         },
 
         componentDidUpdate() {
-            const { cy } = this.state;
+            const { cy, controlDragSelection } = this.state;
             const { elements, drawEdgeToMouseFrom, initialProductDisplay, hasPreview } = this.props;
             const newData = { elements };
             const oldData = cy.json()
@@ -152,6 +170,7 @@ define([
 
             this.drawEdgeToMouseFrom(newData);
             this.drawPaths(newData);
+            this.drawControlDragSelection(newData);
 
             // Create copies of objects because cytoscape mutates :(
             const getAllData = nodes => nodes.map(({data, selected, grabbable, selectable, locked, position, renderedPosition, classes}) => ({
@@ -735,19 +754,41 @@ define([
                             y: window.lastMousePositionY - top
                         }
                     };
-                newData.elements.nodes.push({
-                    data: { id: DrawEdgeNodeId },
-                    classes: 'drawEdgeToMouse',
-                    ...position
-                })
-                newData.elements.edges.push({
-                    data: {
-                        source: vertexId,
-                        target: DrawEdgeNodeId,
-                    },
-                    classes: 'drawEdgeToMouse'
-                })
+                const nodeIndex = newData.elements.nodes.findIndex((node) => node.data.id === DrawEdgeNodeId);
+
+                if (nodeIndex > -1) {
+                    newData.elements.nodes[nodeIndex] = {
+                        ...newData.elements.nodes[nodeIndex],
+                        ...position
+                    };
+                } else {
+                    newData.elements.nodes.push({
+                        data: { id: DrawEdgeNodeId },
+                        classes: 'drawEdgeToMouse',
+                        ...position
+                    })
+                    newData.elements.edges.push({
+                        data: {
+                            source: vertexId,
+                            target: DrawEdgeNodeId,
+                        },
+                        classes: 'drawEdgeToMouse'
+                    })
+                }
             }
+        },
+
+        drawControlDragSelection(newData) {
+            const { controlDragSelection } = this.state;
+            const select = (node) => {
+                if (node.data.id === controlDragSelection) {
+                    node.classes += ' controlDragSelection';
+                } else {
+                    node.classes = node.classes.replace(/controlDragSelection/g, '');
+                }
+            };
+
+            newData.elements.nodes.forEach((node) => select(node));
         }
     })
 

--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/Graph.jsx
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/Graph.jsx
@@ -165,6 +165,8 @@ define([
                     onTap: this.onTap,
                     onTapHold: this.onTapHold,
                     onTapStart: this.onTapStart,
+                    onCxtTapStart: this.onTapStart,
+                    onCxtTapEnd: this.onCxtTapEnd,
                     onContextTap: this.onContextTap,
                     onPan: this.onViewport,
                     onZoom: this.onViewport
@@ -471,6 +473,13 @@ define([
                     this.coalesceSelection('clear');
                     this.props.onClearSelection();
                 }
+            }
+        },
+
+        onCxtTapEnd(event) {
+            const { cy, cyTarget } = event;
+            if (cy !== cyTarget && event.originalEvent.ctrlKey) {
+                this.onTap(event);
             }
         },
 


### PR DESCRIPTION
- [x] @joeferner
- [x] @kunklejr @sfeng88 @diegogrz
- [ ] @mwizeman
- [ ] @joeybrk372 @rygim @jharwig @EvanOxfeld 

Points of Regression: graph selection/positioning/panning, graph context menus

CHANGELOG
Fixed: When dragging a new connection for an edge or to find a path, vertices under the pointer were not being highlighted.
Fixed: Control + left-clicking to drag an edge connection would sometimes not work in Firefox on Mac.
