### PR TITLE
Changed: changed worker status to be extensible

### DIFF
--- a/core/core/src/main/java/org/visallo/core/status/model/ExternalResourceRunnerStatus.java
+++ b/core/core/src/main/java/org/visallo/core/status/model/ExternalResourceRunnerStatus.java
@@ -1,12 +1,7 @@
 package org.visallo.core.status.model;
 
-import com.fasterxml.jackson.annotation.JsonTypeName;
-
-@JsonTypeName("externalResourceRunner")
 public class ExternalResourceRunnerStatus extends WorkerRunnerStatus {
-    @JsonTypeName("externalResourceWorkerStatus")
     public static class ExternalResourceWorkerStatus extends WorkerStatus {
-
         private String threadName;
 
         public void setThreadName(String threadName) {

--- a/core/core/src/main/java/org/visallo/core/status/model/GraphPropertyRunnerStatus.java
+++ b/core/core/src/main/java/org/visallo/core/status/model/GraphPropertyRunnerStatus.java
@@ -1,10 +1,6 @@
 package org.visallo.core.status.model;
 
-import com.fasterxml.jackson.annotation.JsonTypeName;
-
-@JsonTypeName("graphPropertyRunner")
 public class GraphPropertyRunnerStatus extends WorkerRunnerStatus {
-    @JsonTypeName("graphPropertyWorkerStatus")
     public static class GraphPropertyWorkerStatus extends WorkerStatus {
 
     }

--- a/core/core/src/main/java/org/visallo/core/status/model/LongRunningProcessRunnerStatus.java
+++ b/core/core/src/main/java/org/visallo/core/status/model/LongRunningProcessRunnerStatus.java
@@ -1,10 +1,6 @@
 package org.visallo.core.status.model;
 
-import com.fasterxml.jackson.annotation.JsonTypeName;
-
-@JsonTypeName("longRunningProcessRunner")
 public class LongRunningProcessRunnerStatus extends WorkerRunnerStatus {
-    @JsonTypeName("longRunningProcessWorkerStatus")
     public static class LongRunningProcessWorkerStatus extends WorkerStatus {
 
     }

--- a/core/core/src/main/java/org/visallo/core/status/model/Status.java
+++ b/core/core/src/main/java/org/visallo/core/status/model/Status.java
@@ -10,16 +10,7 @@ import org.visallo.web.clientapi.model.ClientApiObject;
 
 import java.util.Date;
 
-@JsonTypeInfo(
-        use = JsonTypeInfo.Id.NAME,
-        include = JsonTypeInfo.As.PROPERTY,
-        property = "type")
-@JsonSubTypes({
-        @JsonSubTypes.Type(value = ExternalResourceRunnerStatus.class, name = "externalResourceRunner"),
-        @JsonSubTypes.Type(value = GraphPropertyRunnerStatus.class, name = "graphPropertyRunner"),
-        @JsonSubTypes.Type(value = LongRunningProcessRunnerStatus.class, name = "longRunningProcessRunner"),
-        @JsonSubTypes.Type(value = QueueStatus.class, name = "queue")
-})
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "type")
 public abstract class Status implements ClientApiObject {
     private String className;
     private String name;

--- a/core/core/src/main/java/org/visallo/core/status/model/WorkerRunnerStatus.java
+++ b/core/core/src/main/java/org/visallo/core/status/model/WorkerRunnerStatus.java
@@ -1,6 +1,5 @@
 package org.visallo.core.status.model;
 
-import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 import java.util.ArrayList;
@@ -15,15 +14,7 @@ public abstract class WorkerRunnerStatus extends ProcessStatus {
         return runningWorkers;
     }
 
-    @JsonTypeInfo(
-            use = JsonTypeInfo.Id.NAME,
-            include = JsonTypeInfo.As.PROPERTY,
-            property = "type")
-    @JsonSubTypes({
-            @JsonSubTypes.Type(value = ExternalResourceRunnerStatus.ExternalResourceWorkerStatus.class, name = "externalResourceWorkerStatus"),
-            @JsonSubTypes.Type(value = GraphPropertyRunnerStatus.GraphPropertyWorkerStatus.class, name = "graphPropertyWorkerStatus"),
-            @JsonSubTypes.Type(value = LongRunningProcessRunnerStatus.LongRunningProcessWorkerStatus.class, name = "longRunningProcessWorkerStatus")
-    })
+    @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "type")
     public static abstract class WorkerStatus extends Status {
         private Map<String, Metric> metrics = new HashMap<>();
 


### PR DESCRIPTION
- [x] @joeferner
- [ ] @kunklejr @diegogrz
- [x] @mwizeman @sfeng88
- [x] @joeybrk372 @rygim @jharwig @EvanOxfeld

Prior to this commit it was not possible to externally extend the worker
status objects because it used named json deserialization. By switching
to class deserialization it is now possible to extend status without
modifing core classes.

CHANGELOG
Changed: changed worker status to be extensible