### PR TITLE
Fix multiple selection undo last selection 

### DIFF
--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/Graph.jsx
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/Graph.jsx
@@ -665,6 +665,8 @@ define([
                     const edges = Object.keys(this._queuedSelection.add.edges);
                     if (vertices.length || edges.length) {
                         this.props.onSetSelection({ vertices, edges })
+                    } else {
+                        this.props.onClearSelection();
                     }
                 }, 100);
             }


### PR DESCRIPTION
- [ ] @joeferner
- [x] @kunklejr @diegogrz
- [x] @mwizeman @sfeng88
- [x] @joeybrk372 @rygim @jharwig @EvanOxfeld

Testing Instructions: Select multiple items using shift, then keep holding shift and click all selected items. Element inspector should have closed and all blue selected items not selected.


CHANGELOG
Fixed: Multiple selection undo last selection wouldn't close element inspector


https://github.com/v5analytics/visallo/issues/861