### PR TITLE
Fixed: race condition while adding work products

### DIFF
--- a/core/plugins/model-vertexium/src/main/java/org/visallo/vertexium/model/workspace/VertexiumWorkspaceRepository.java
+++ b/core/plugins/model-vertexium/src/main/java/org/visallo/vertexium/model/workspace/VertexiumWorkspaceRepository.java
@@ -1108,6 +1108,7 @@ public class VertexiumWorkspaceRepository extends WorkspaceRepository {
         }
 
         getGraph().flush();
+        userWorkspaceVertexCache.invalidateAll();
 
         Workspace ws = findById(workspaceId, user);
         ClientApiWorkspace userWorkspace = toClientApi(ws, user, authorizations);


### PR DESCRIPTION
- [x] @joeferner
- [ ] @kunklejr @diegogrz
- [x] @mwizeman @sfeng88
- [x] @joeybrk372 @rygim @jharwig @EvanOxfeld

If a backend process adds a work product the cached version would
prevent the user from seeing the results some of the time. This commit
fixes this by flushing the cache of user workspace vertices.

CHANGELOG
Fixed: race condition while adding work products