### PR TITLE
Changed: Enabled find related for multiple selected entities

### DIFF
--- a/web/war/src/main/webapp/js/data/withObjectSelection.js
+++ b/web/war/src/main/webapp/js/data/withObjectSelection.js
@@ -310,9 +310,7 @@ define([
                     return F.vertex.getVertexIdsFromDataEventOrCurrentSelection(data, { async: true });
                 })
                 .then(function(vertexIds) {
-                    if (vertexIds.length === 1) {
-                        self.trigger('searchByRelatedEntity', { vertexIds: vertexIds });
-                    }
+                    self.trigger('searchByRelatedEntity', { vertexIds: vertexIds });
                 })
         };
 

--- a/web/war/src/main/webapp/js/util/vertex/menu.js
+++ b/web/war/src/main/webapp/js/util/vertex/menu.js
@@ -47,10 +47,7 @@ define([
                                 subtitle: i18n('graph.contextmenu.search.related.subtitle'),
                                 shortcut: 'alt+s',
                                 event: 'searchRelated',
-                                selection: 1,
-                                shouldDisable: function(currentSelection) {
-                                    return Object.keys(currentSelection).length > 1;
-                                }
+                                selection: 1
                             }
                         ]
                     },

--- a/web/web-base/src/main/java/org/visallo/web/routes/vertex/ElementSearchBase.java
+++ b/web/web-base/src/main/java/org/visallo/web/routes/vertex/ElementSearchBase.java
@@ -77,7 +77,12 @@ public abstract class ElementSearchBase {
             ElementSearchRunnerBase.QueryAndData queryAndData,
             QueryResultsIterable<? extends Element> searchResults
     ) {
-        results.setTotalHits(searchResults.getTotalHits());
+        // CompositeGraphQuery returns 0 for getTotalHits, it would be nice to change the Vertexium API
+        // to denote this but that would be a breaking change. For now we'll test and not set total hits
+        // and let the UI handle it
+        if(!(queryAndData.getQuery() instanceof CompositeGraphQuery)) {
+            results.setTotalHits(searchResults.getTotalHits());
+        }
 
         if (searchResults instanceof IterableWithSearchTime) {
             results.setSearchTime(((IterableWithSearchTime) searchResults).getSearchTimeNanoSeconds());


### PR DESCRIPTION
- [x] @joeferner
- [ ] @kunklejr @diegogrz
- [x] @mwizeman @sfeng88
- [x] @joeybrk372 @rygim @jharwig @EvanOxfeld

This is a revert of sorts to commit
16568fd4007047ff0656dbf32230ed859caa4da4. It's unclear why this was
disabled before but it could be related to the the CompositeQuery not
returning a hit count. This commit addresses this as well.

Testing Instructions:
Test find related with multiple vertices

CHANGELOG
Changed: Enabled find related for multiple selected entities