### PR TITLE
Added: message when pasting elements

### DIFF
--- a/core/core/src/main/resources/MessageBundle.properties
+++ b/core/core/src/main/resources/MessageBundle.properties
@@ -441,6 +441,8 @@ vertex.contextmenu.remove.subtitle=Remove from View
 
 element.clipboard.copy.one=Copied element
 element.clipboard.copy.some=Copied {0} elements
+element.clipboard.paste.one=Pasted element
+element.clipboard.paste.some=Pasted {0} elements
 
 element.clipboard.action.cut=Cut
 element.clipboard.action.copy=Copying

--- a/web/war/src/main/webapp/js/util/clipboardManager.js
+++ b/web/war/src/main/webapp/js/util/clipboardManager.js
@@ -71,14 +71,28 @@ define([
         this.onPaste = function(event) {
             var self = this;
             _.defer(function() {
-                var textarea = self.textarea,
-                    val = textarea.val();
+                require(['util/vertex/urlFormatters'], function(F) {
+                    var textarea = self.textarea,
+                        val = textarea.val(),
+                        parameters = F.vertexUrl.parametersInUrl(val),
+                        vertices = parameters && parameters.vertexIds && parameters.vertexIds.length || 0,
+                        edges = parameters && parameters.edgeIds && parameters.edgeIds.length || 0,
+                        total = vertices + edges;
 
-                console.debug('Clipboard: Paste', val);
+                    console.debug('Clipboard: Paste', val);
 
-                self.trigger('clipboardPaste', { data: val });
-                self.lastSetData = null;
-                textarea.val('').focus();
+                    self.trigger('clipboardPaste', {data: val});
+                    self.lastSetData = null;
+                    textarea.val('').focus();
+
+                    if (total === 1) {
+                        self.trigger('displayInformation', {message: i18n('element.clipboard.paste.one')});
+                    } else if (total > 1) {
+                        self.trigger('displayInformation', {
+                            message: i18n('element.clipboard.paste.some', total)
+                        });
+                    }
+                });
             });
         };
 


### PR DESCRIPTION
- [x] @joeferner
- [ ] @kunklejr @diegogrz
- [x] @mwizeman @sfeng88
- [x] @joeybrk372 @rygim @jharwig @EvanOxfeld

This commit adds a message similar to the copy message when pasting
elements. This is added to let the user know the paste was successful when
viewing the map where it is not not always obvious especially when some
or all entities may not include geolocations

CHANGELOG
Added: message when pasting elements