### PR TITLE
Bump graph version + add cli tool(3.1)

### DIFF
--- a/core/core/src/main/java/org/visallo/core/bootstrap/VisalloBootstrap.java
+++ b/core/core/src/main/java/org/visallo/core/bootstrap/VisalloBootstrap.java
@@ -55,7 +55,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public class VisalloBootstrap extends AbstractModule {
     private static final VisalloLogger LOGGER = VisalloLoggerFactory.getLogger(VisalloBootstrap.class);
     private static final String GRAPH_METADATA_VISALLO_GRAPH_VERSION_KEY = "visallo.graph.version";
-    private static final Integer GRAPH_METADATA_VISALLO_GRAPH_VERSION = 2;
+    private static final Integer GRAPH_METADATA_VISALLO_GRAPH_VERSION = 3;
 
     private static VisalloBootstrap visalloBootstrap;
 

--- a/tools/migrations/graph-version-bump/pom.xml
+++ b/tools/migrations/graph-version-bump/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>visallo-tools-migrations</artifactId>
+        <groupId>org.visallo</groupId>
+        <version>3.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>visallo-tools-migration-graph-version-bump</artifactId>
+    <name>Visallo: Tools - Bump Graph Version</name>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.visallo</groupId>
+            <artifactId>visallo-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/tools/migrations/graph-version-bump/src/main/java/org/visallo/tools/migrations/GraphVersionBump.java
+++ b/tools/migrations/graph-version-bump/src/main/java/org/visallo/tools/migrations/GraphVersionBump.java
@@ -1,0 +1,59 @@
+package org.visallo.tools.migrations;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import org.vertexium.*;
+import org.visallo.core.bootstrap.VisalloBootstrap;
+import org.visallo.core.cmdline.CommandLineTool;
+import org.visallo.core.config.Configuration;
+import org.visallo.core.exception.VisalloException;
+import org.visallo.core.util.VisalloLogger;
+import org.visallo.core.util.VisalloLoggerFactory;
+
+@Parameters(commandDescription = "Update Visallo metadata graph version")
+public class GraphVersionBump extends CommandLineTool {
+    private static final VisalloLogger LOGGER = VisalloLoggerFactory.getLogger(GraphVersionBump.class);
+    private static final String VISALLO_GRAPH_VERSION = "visallo.graph.version";
+    private Graph graph = null;
+
+    @Parameter(required = true, names = {"--graph-version"}, description = "Specify the metadata graph version to set.")
+    private Integer toVersion;
+
+    public static void main(String[] args) throws Exception {
+        CommandLineTool.main(new GraphVersionBump(), args, false);
+    }
+
+    @Override
+    protected int run() throws Exception {
+        VisalloBootstrap bootstrap = VisalloBootstrap.bootstrap(getConfiguration());
+        graph = getGraph();
+
+        try {
+            Object visalloGraphVersionObj = graph.getMetadata(VISALLO_GRAPH_VERSION);
+
+            if (visalloGraphVersionObj == null) {
+                throw new VisalloException("No graph metadata version set");
+            } else if (visalloGraphVersionObj instanceof Integer) {
+                Integer visalloGraphVersion = (Integer) visalloGraphVersionObj;
+                if (toVersion.equals(visalloGraphVersion)) {
+                    return 0;
+                }
+            }
+
+            graph.setMetadata(VISALLO_GRAPH_VERSION, toVersion);
+            return 0;
+        } finally {
+            graph.shutdown();
+        }
+    }
+
+    @Override
+    public Graph getGraph() {
+        if (graph == null) {
+            GraphFactory factory = new GraphFactory();
+            graph = factory.createGraph(getConfiguration().getSubset(Configuration.GRAPH_PROVIDER));
+        }
+        return graph;
+    }
+}
+

--- a/tools/migrations/graph-version-bump/src/main/resources/META-INF/services/org.visallo.core.cmdline.CommandLineTool
+++ b/tools/migrations/graph-version-bump/src/main/resources/META-INF/services/org.visallo.core.cmdline.CommandLineTool
@@ -1,0 +1,1 @@
+org.visallo.tools.migrations.GraphVersionBump

--- a/tools/migrations/pom.xml
+++ b/tools/migrations/pom.xml
@@ -15,5 +15,6 @@
 
     <modules>
         <module>workspace-to-workproduct</module>
+        <module>graph-version-bump</module>
     </modules>
 </project>


### PR DESCRIPTION
- [x] @joeferner
- [x] @kunklejr @diegogrz
- [x] @mwizeman @sfeng88
- [x] @joeybrk372 @rygim @jharwig @EvanOxfeld

This needs to be run with `--graph-version 3` before starting the web server if Visallo was previously at v3.0.x

CHANGELOG
Added: Cli tool to update the graph metadata version.
