### PR TITLE
Modified: WorkProductElements ontology update to only occur once

### DIFF
--- a/core/core/src/main/java/org/visallo/core/model/workspace/product/WorkProductElements.java
+++ b/core/core/src/main/java/org/visallo/core/model/workspace/product/WorkProductElements.java
@@ -20,29 +20,33 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 public abstract class WorkProductElements implements WorkProduct, WorkProductHasElements {
     public static final String WORKSPACE_PRODUCT_TO_ENTITY_RELATIONSHIP_IRI = "http://visallo.org/workspace/product#toEntity";
+    private static boolean addProductToEntityRelationshipToOntologyComplete = false;
 
     protected WorkProductElements(OntologyRepository ontologyRepository) {
         addProductToEntityRelationshipToOntology(ontologyRepository);
     }
 
     private void addProductToEntityRelationshipToOntology(OntologyRepository ontologyRepository) {
-        Concept productConcept = ontologyRepository.getConceptByIRI(WorkspaceProperties.PRODUCT_CONCEPT_IRI);
-        checkNotNull(productConcept, "Could not find " + WorkspaceProperties.PRODUCT_CONCEPT_IRI);
+        if (!addProductToEntityRelationshipToOntologyComplete) {
+            Concept productConcept = ontologyRepository.getConceptByIRI(WorkspaceProperties.PRODUCT_CONCEPT_IRI);
+            checkNotNull(productConcept, "Could not find " + WorkspaceProperties.PRODUCT_CONCEPT_IRI);
 
-        Concept thingConcept = ontologyRepository.getConceptByIRI(VisalloProperties.CONCEPT_TYPE_THING);
-        checkNotNull(thingConcept, "Could not find " + VisalloProperties.CONCEPT_TYPE_THING);
+            Concept thingConcept = ontologyRepository.getConceptByIRI(VisalloProperties.CONCEPT_TYPE_THING);
+            checkNotNull(thingConcept, "Could not find " + VisalloProperties.CONCEPT_TYPE_THING);
 
-        List<Concept> domainConcepts = new ArrayList<>();
-        domainConcepts.add(productConcept);
-        List<Concept> rangeConcepts = new ArrayList<>();
-        rangeConcepts.add(thingConcept);
-        ontologyRepository.getOrCreateRelationshipType(
-                null,
-                domainConcepts,
-                rangeConcepts,
-                WORKSPACE_PRODUCT_TO_ENTITY_RELATIONSHIP_IRI
-        );
-        ontologyRepository.clearCache();
+            List<Concept> domainConcepts = new ArrayList<>();
+            domainConcepts.add(productConcept);
+            List<Concept> rangeConcepts = new ArrayList<>();
+            rangeConcepts.add(thingConcept);
+            ontologyRepository.getOrCreateRelationshipType(
+                    null,
+                    domainConcepts,
+                    rangeConcepts,
+                    WORKSPACE_PRODUCT_TO_ENTITY_RELATIONSHIP_IRI
+            );
+            ontologyRepository.clearCache();
+            addProductToEntityRelationshipToOntologyComplete = true;
+        }
     }
 
     @Override

--- a/web/plugins/graph-product/src/main/java/org/visallo/web/product/graph/GraphWorkProduct.java
+++ b/web/plugins/graph-product/src/main/java/org/visallo/web/product/graph/GraphWorkProduct.java
@@ -19,6 +19,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 public class GraphWorkProduct extends WorkProductElements {
     public static final JsonSingleValueVisalloProperty ENTITY_POSITION = new JsonSingleValueVisalloProperty("http://visallo.org/workspace/product/graph#entityPosition");
+    private static boolean addEdgePositionToOntologyComplete;
 
     @Inject
     public GraphWorkProduct(OntologyRepository ontologyRepository) {
@@ -27,17 +28,20 @@ public class GraphWorkProduct extends WorkProductElements {
     }
 
     private void addEdgePositionToOntology(OntologyRepository ontologyRepository) {
-        Relationship productToEntityRelationship = ontologyRepository.getRelationshipByIRI(WORKSPACE_PRODUCT_TO_ENTITY_RELATIONSHIP_IRI);
-        checkNotNull(productToEntityRelationship, "Cannot find relationship: " + WORKSPACE_PRODUCT_TO_ENTITY_RELATIONSHIP_IRI);
-        OntologyPropertyDefinition propertyDefinition = new OntologyPropertyDefinition(
-                new ArrayList<>(),
-                ENTITY_POSITION.getPropertyName(),
-                "Entity Position",
-                PropertyType.STRING
-        );
-        propertyDefinition.setTextIndexHints(TextIndexHint.NONE);
-        propertyDefinition.getRelationships().add(productToEntityRelationship);
-        ontologyRepository.getOrCreateProperty(propertyDefinition);
+        if (!addEdgePositionToOntologyComplete) {
+            Relationship productToEntityRelationship = ontologyRepository.getRelationshipByIRI(WORKSPACE_PRODUCT_TO_ENTITY_RELATIONSHIP_IRI);
+            checkNotNull(productToEntityRelationship, "Cannot find relationship: " + WORKSPACE_PRODUCT_TO_ENTITY_RELATIONSHIP_IRI);
+            OntologyPropertyDefinition propertyDefinition = new OntologyPropertyDefinition(
+                    new ArrayList<>(),
+                    ENTITY_POSITION.getPropertyName(),
+                    "Entity Position",
+                    PropertyType.STRING
+            );
+            propertyDefinition.setTextIndexHints(TextIndexHint.NONE);
+            propertyDefinition.getRelationships().add(productToEntityRelationship);
+            ontologyRepository.getOrCreateProperty(propertyDefinition);
+            addEdgePositionToOntologyComplete = true;
+        }
     }
 
     @Override


### PR DESCRIPTION
- [x] @joeferner
- [x] @diegogrz
- [x] @mwizeman @sfeng88
- [x] @joeybrk372 @rygim @jharwig @EvanOxfeld

For performance reasons updating the ontology should only occur at most
once per running of the application. It is also not necissary to clear
the ontology cache and is the resposibility of the ontology repository
to mange the state.
