### PR TITLE
Modified: select related to select vertices connected to edges

### DIFF
--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/Graph.jsx
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/Graph.jsx
@@ -80,10 +80,10 @@ define([
                 selectConnected: (event, data) => {
                     event.stopPropagation();
                     const cy = this.refs.cytoscape.state.cy;
-                    const selected = cy.nodes().filter(':selected');
-                    const other = selected.neighborhood('node');
+                    const selected = cy.elements().filter(':selected');
+                    selected.neighborhood('node').select();
+                    selected.connectedNodes().select();
 
-                    other.select();
                     selected.unselect();
                 },
                 startVertexConnection: (event, { vertexId, connectionType }) => {


### PR DESCRIPTION
- [x] @joeferner
- [x] @diegogrz
- [x] @mwizeman @sfeng88
- [x] @joeybrk372 @rygim @jharwig @EvanOxfeld

I had a scenario where I wanted to get all the vertices connected to a given edge type. So I started by selecting all items on the graph and narrowing the selection down to relationships, then the type of relationship I cared about. I then wanted to select the connected vertices. With this change using the select connected key should allow me to do what I want.

CHANGELOG
Changed: select related to select vertices connected to edges