### PR TITLE
add tika parser to dependency management to exclude conflicting dependencies (3.1)

### DIFF
--- a/root/pom.xml
+++ b/root/pom.xml
@@ -638,6 +638,26 @@
                 <version>${aws-java-sdk.version}</version>
             </dependency>
 
+            <dependency>
+                <groupId>org.apache.tika</groupId>
+                <artifactId>tika-parsers</artifactId>
+                <version>${tika.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.sis.core</groupId>
+                        <artifactId>sis-referencing</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>javax.measure</groupId>
+                        <artifactId>jsr-275</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.opengis</groupId>
+                        <artifactId>geoapi</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
 
             <!-- Provided Dependencies -->
             <dependency>

--- a/web/plugins/structured-ingest/parquet/pom.xml
+++ b/web/plugins/structured-ingest/parquet/pom.xml
@@ -34,14 +34,6 @@
             <version>${tika.version}</version>
         </dependency>
 
-
-
-        <!--<dependency>-->
-            <!--<groupId>org.apache.tika</groupId>-->
-            <!--<artifactId>tika-core</artifactId>-->
-            <!--<version>${tika.version}</version>-->
-        <!--</dependency>-->
-
         <!-- for parquet -->
         <dependency>
             <groupId>org.apache.hadoop</groupId>
@@ -53,21 +45,11 @@
             <artifactId>parquet-hadoop</artifactId>
             <version>${parquet.version}</version>
         </dependency>
-        <!--<dependency>-->
-            <!--<groupId>org.apache.parquet</groupId>-->
-            <!--<artifactId>parquet-common</artifactId>-->
-            <!--<version>${parquet.version}</version>-->
-        <!--</dependency>-->
         <dependency>
             <groupId>org.apache.parquet</groupId>
             <artifactId>parquet-tools</artifactId>
             <version>${parquet.version}</version>
         </dependency>
-        <!--<dependency>-->
-            <!--<groupId>org.apache.parquet</groupId>-->
-            <!--<artifactId>parquet-avro</artifactId>-->
-            <!--<version>${parquet.version}</version>-->
-        <!--</dependency>-->
         <dependency>
             <groupId>org.vertexium</groupId>
             <artifactId>vertexium-inmemory</artifactId>


### PR DESCRIPTION
- [x] @joeferner
- [ ] @diegogrz
- [x] @mwizeman @sfeng88
- [x] @joeybrk372 @rygim @jharwig @EvanOxfeld

Testing Instructions: Make sure that `tika-mime-type`, `tika-text-extractor`, and `visallo-web-structured-ingest-parquet` produces the expected output.

Points of Regression: None

CHANGELOG
Removed: Conflicting inner dependencies of tika-parser

This will be less of an issue once `tika-parser` releases 2.0. In 2.0 they will module parsers rather than all of the parsers lumped together (https://issues.apache.org/jira/browse/TIKA-1367).