### PR TITLE
Fix postinstall npm scripts on windows

### DIFF
--- a/web/war/src/main/webapp/package.json
+++ b/web/war/src/main/webapp/package.json
@@ -97,8 +97,8 @@
     "redux-devtools": "^3.3.1"
   },
   "scripts": {
-    "test": "karma start --single-run",
-    "postinstall": "node_modules/grunt-cli/bin/grunt deps"
+    "test": "node ./node_modules/karma/bin/karma start --single-run",
+    "postinstall": "node ./node_modules/grunt-cli/bin/grunt deps"
   },
   "author": "V5 Analytics LLC",
   "license": "Apache-2.0"


### PR DESCRIPTION
- [x] @joeferner
- [ ] @diegogrz
- [x] @mwizeman @sfeng88
- [x] @joeybrk372 @rygim @jharwig @EvanOxfeld

Fixes build problems encountered by people in mailing list

Testing Instructions: Run `mvn compile` on supported platforms, Mac, Linux, Windows

CHANGELOG
Fixed: Windows build script run postinstall scripts correctly
