### PR TITLE
Graph loading showing unauthorized nodes

### DIFF
--- a/core/core/src/main/java/org/visallo/core/model/workspace/product/WorkProductElements.java
+++ b/core/core/src/main/java/org/visallo/core/model/workspace/product/WorkProductElements.java
@@ -12,9 +12,13 @@ import org.visallo.core.model.properties.VisalloProperties;
 import org.visallo.core.model.workspace.WorkspaceProperties;
 import org.visallo.core.user.User;
 import org.visallo.core.util.JSONUtil;
+import org.visallo.core.util.StreamUtil;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -98,16 +102,23 @@ public abstract class WorkProductElements implements WorkProduct, WorkProductHas
 
         if (params.optBoolean("includeVertices")) {
             JSONArray vertices = new JSONArray();
-            Iterable<Edge> productVertexEdges = productVertex.getEdges(
+            List<Edge> productVertexEdges = Lists.newArrayList(productVertex.getEdges(
                     Direction.OUT,
                     WORKSPACE_PRODUCT_TO_ENTITY_RELATIONSHIP_IRI,
                     authorizations
-            );
+            ));
+
+            List<String> ids = productVertexEdges.stream()
+                    .map(edge -> edge.getOtherVertexId(id))
+                    .collect(Collectors.toList());
+            Map<String, Vertex> othersById = StreamUtil.stream(graph.getVertices(ids, FetchHint.NONE, authorizations))
+                    .collect(Collectors.toMap(Vertex::getId, Function.identity()));
+
             for (Edge propertyVertexEdge : productVertexEdges) {
-                Vertex otherVertex = propertyVertexEdge.getOtherVertex(id, authorizations);
+                String otherId = propertyVertexEdge.getOtherVertexId(id);
                 JSONObject vertex = new JSONObject();
-                vertex.put("id", propertyVertexEdge.getOtherVertexId(id));
-                if (otherVertex == null) {
+                vertex.put("id", otherId);
+                if (!othersById.containsKey(otherId)) {
                     vertex.put("unauthorized", true);
                 }
                 setEdgeJson(propertyVertexEdge, vertex);

--- a/core/core/src/main/java/org/visallo/core/model/workspace/product/WorkProductElements.java
+++ b/core/core/src/main/java/org/visallo/core/model/workspace/product/WorkProductElements.java
@@ -104,9 +104,12 @@ public abstract class WorkProductElements implements WorkProduct, WorkProductHas
                     authorizations
             );
             for (Edge propertyVertexEdge : productVertexEdges) {
-                String other = propertyVertexEdge.getOtherVertexId(id);
+                Vertex otherVertex = propertyVertexEdge.getOtherVertex(id, authorizations);
                 JSONObject vertex = new JSONObject();
-                vertex.put("id", other);
+                vertex.put("id", propertyVertexEdge.getOtherVertexId(id));
+                if (otherVertex == null) {
+                    vertex.put("unauthorized", true);
+                }
                 setEdgeJson(propertyVertexEdge, vertex);
                 vertices.put(vertex);
             }

--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/Graph.jsx
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/Graph.jsx
@@ -559,7 +559,7 @@ define([
         },
 
         mapPropsToElements(editable) {
-            const { selection, product, ghosts, productElementIds, elements, ontology, registry, focusing } = this.props;
+            const { selection, ghosts, productElementIds, elements, ontology, registry, focusing } = this.props;
             const { hovering } = this.state;
             const { vertices: productVertices, edges: productEdges } = productElementIds;
             const { vertices, edges } = elements;

--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/Graph.jsx
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/Graph.jsx
@@ -559,10 +559,9 @@ define([
         },
 
         mapPropsToElements(editable) {
-            const { selection, product, ghosts, elements, ontology, registry, focusing } = this.props;
+            const { selection, product, ghosts, productElementIds, elements, ontology, registry, focusing } = this.props;
             const { hovering } = this.state;
-            const { extendedData } = product;
-            const { vertices: productVertices, edges: productEdges } = extendedData;
+            const { vertices: productVertices, edges: productEdges } = productElementIds;
             const { vertices, edges } = elements;
             const { vertices: verticesSelectedById, edges: edgesSelectedById } = selection;
             const nodeIds = {};

--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/GraphContainer.jsx
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/GraphContainer.jsx
@@ -230,6 +230,7 @@ define([
                 uiPreferences,
                 ontology,
                 panelPadding,
+                productElementIds: productSelectors.getElementIdsInProduct(state),
                 elements: productSelectors.getElementsInProduct(state),
                 workspace: state.workspace.byId[state.workspace.currentId],
                 mimeTypes,

--- a/web/plugins/map-product/src/main/resources/org/visallo/web/product/map/Map.jsx
+++ b/web/plugins/map-product/src/main/resources/org/visallo/web/product/map/Map.jsx
@@ -121,7 +121,7 @@ define([
         },
 
         mapElementsToFeatures() {
-            const { vertices, edges } = productElementIds;
+            const { vertices, edges } = this.props.productElementIds;
             const elementsSelectedById = { ..._.indexBy(this.props.selection.vertices), ..._.indexBy(this.props.selection.edges) };
             const productVertices = _.pick(this.props.elements.vertices, _.pluck(vertices, 'id'));
             const productEdges = _.pick(this.props.elements.edges, _.pluck(edges, 'id'));

--- a/web/plugins/map-product/src/main/resources/org/visallo/web/product/map/Map.jsx
+++ b/web/plugins/map-product/src/main/resources/org/visallo/web/product/map/Map.jsx
@@ -121,8 +121,7 @@ define([
         },
 
         mapElementsToFeatures() {
-            const extended = this.props.product.extendedData;
-            const { vertices, edges } = extended;
+            const { vertices, edges } = productElementIds;
             const elementsSelectedById = { ..._.indexBy(this.props.selection.vertices), ..._.indexBy(this.props.selection.edges) };
             const productVertices = _.pick(this.props.elements.vertices, _.pluck(vertices, 'id'));
             const productEdges = _.pick(this.props.elements.edges, _.pluck(edges, 'id'));

--- a/web/plugins/map-product/src/main/resources/org/visallo/web/product/map/MapContainer.jsx
+++ b/web/plugins/map-product/src/main/resources/org/visallo/web/product/map/MapContainer.jsx
@@ -28,6 +28,7 @@ define([
                 panelPadding: state.panel.padding,
                 selection: productSelectors.getSelectedElementsInProduct(state),
                 viewport: productSelectors.getViewport(state),
+                productElementIds: productSelectors.getElementIdsInProduct(state),
                 elements: productSelectors.getElementsInProduct(state),
                 pixelRatio,
                 mimeTypes,

--- a/web/war/src/main/webapp/js/data/web-worker/store/product/selectors.js
+++ b/web/war/src/main/webapp/js/data/web-worker/store/product/selectors.js
@@ -44,12 +44,13 @@ define(['reselect', '../element/selectors'], function(reselect, elementSelectors
         return productId ? productsById[productId] : null;
     })
 
-    const getElementIdsInProduct = createSelector([getProduct], (product) => {
+    const getElementIdsInProduct = createSelector([getProduct, elementSelectors.getElements], (product, elements) => {
         if (!product || !product.extendedData) return { vertices: [], edges: [] };
 
         const { vertices, edges } = product.extendedData
+        const viewable = v => v.unauthorized !== true || (elements.vertices && elements.vertices[v.id])
 
-        return { vertices, edges }
+        return { vertices: vertices.filter(viewable), edges }
     });
 
     const getElementsInProduct = createSelector([getElementIdsInProduct, elementSelectors.getElements], (elementIds, elements) => {
@@ -95,6 +96,7 @@ define(['reselect', '../element/selectors'], function(reselect, elementSelectors
         getProducts,
         getProductsById,
         getProductTypes,
+        getElementIdsInProduct,
         getElementsInProduct,
         getSelectedElementsInProduct,
         getFocusedElementsInProduct


### PR DESCRIPTION
- [x] @joeferner
- [ ] @diegogrz
- [x] @mwizeman @sfeng88
- [x] @joeybrk372 @rygim @jharwig @EvanOxfeld

Let the client know which product elements are unauthorized/deleted so they don't show loading nodes

Testing Instructions:
Create a new vertex on a workspace, then delete it. Refreshing shouldn't show a loading placeholder for that node. Use network devtool to throttle connection slower to see it.
Also test visibility changes using a shared workspace to a user that doesn't have a visibility. the node should appear/reappear live depending on visibility.

CHANGELOG
Fixed: Don't show placeholder nodes loading for unauthorized or deleted entities

