### PR TITLE
Fix issue where saved search card entities couldn't be selected.

### DIFF
--- a/web/war/src/main/webapp/js/util/element/list.js
+++ b/web/war/src/main/webapp/js/util/element/list.js
@@ -126,6 +126,7 @@ define([
 
         this.onClick = function(event) {
             event.preventDefault();
+            event.stopPropagation();
 
             const {vertexIds, edgeIds} = visalloData.selectedObjects;
             const $target = $(event.target).parents('li');


### PR DESCRIPTION
- [x] @joeferner
- [ ] @diegogrz
- [x] @mwizeman @sfeng88
- [x] @joeybrk372 @rygim @jharwig @EvanOxfeld

Dashboard was cancelling the selection

Testing Instructions: Select items in saved search dashboard card

CHANGELOG
Fixed: Entity selection in dashboard saved-search card