### PR TITLE
Fixes for graph selection when changing selection outside of graph

### DIFF
--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/Graph.jsx
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/Graph.jsx
@@ -124,6 +124,9 @@ define([
         },
 
         componentWillReceiveProps(nextProps) {
+            if (nextProps.selection !== this.props.selection) {
+                this.resetQueuedSelection(nextProps.selection);
+            }
             if (nextProps.product.id === this.props.product.id) {
                 this.setState({ viewport: {}, initialProductDisplay: false })
             } else {
@@ -681,9 +684,13 @@ define([
             return { nodes: cyNodes, edges: cyEdges };
         },
 
-        coalesceSelection(action, type, cyElementOrId) {
-            if (!this._queuedSelection) {
-                this._queuedSelection = { add: {vertices: {}, edges: {}}, remove: {vertices: {}, edges: {}} };
+        resetQueuedSelection(sel) {
+            this._queuedSelection = sel ? {
+                add: { vertices: sel.vertices, edges: sel.edges },
+                remove: {vertices: {}, edges: {}}
+            } : { add: {vertices: {}, edges: {}}, remove: {vertices: {}, edges: {}} };
+
+            if (!this._queuedSelectionTrigger) {
                 this._queuedSelectionTrigger = _.debounce(() => {
                     const vertices = Object.keys(this._queuedSelection.add.vertices);
                     const edges = Object.keys(this._queuedSelection.add.edges);
@@ -693,6 +700,12 @@ define([
                         this.props.onClearSelection();
                     }
                 }, 100);
+            }
+        },
+
+        coalesceSelection(action, type, cyElementOrId) {
+            if (!this._queuedSelection) {
+                this.resetQueuedSelection();
             }
             var id = cyElementOrId;
 
@@ -709,7 +722,7 @@ define([
 
 
             if (action !== 'clear') {
-                this._queuedSelection[action][type][id] = true;
+                this._queuedSelection[action][type][id] = id;
             }
 
             if (action === 'add') {

--- a/web/war/src/main/webapp/test/unit/spec/data/web-worker/store/selection/actionsImplTest.js
+++ b/web/war/src/main/webapp/test/unit/spec/data/web-worker/store/selection/actionsImplTest.js
@@ -1,0 +1,35 @@
+define(['/base/jsc/data/web-worker/store/actions'], function(actions) {
+    actions.protectFromWorker = actions.protectFromMain = () => {}
+    require(['/base/jsc/data/web-worker/store/selection/actions-impl'], function(actions) {
+        describe('selectionActions', () => {
+
+            it('should be able to add selections', () => {
+                const selection = {};
+                actions.add({ selection }).should.deep.equal({
+                    type: 'SELECTION_ADD',
+                    payload: { selection }
+                })
+            })
+
+            it('should be able to remove selections', () => {
+                const selection = {};
+                actions.remove({ selection }).should.deep.equal({
+                    type: 'SELECTION_REMOVE',
+                    payload: { selection }
+                })
+            })
+
+            it('should be able to clear selections', () => {
+                actions.clear().should.deep.equal({ type: 'SELECTION_CLEAR' })
+            })
+
+            it('should be able to set selections', () => {
+                const selection = {}
+                actions.set({ selection }).should.deep.equal({
+                    type: 'SELECTION_SET',
+                    payload: { selection }
+                })
+            })
+        })
+    })
+})

--- a/web/war/src/main/webapp/test/unit/spec/data/web-worker/store/selection/reducerTest.js
+++ b/web/war/src/main/webapp/test/unit/spec/data/web-worker/store/selection/reducerTest.js
@@ -1,0 +1,98 @@
+define(['/base/jsc/data/web-worker/store/selection/reducer'], function(reducer) {
+    const emptyState = {
+        idsByType: { vertices: [], edges: [] }
+    };
+    const genState = ({ vertices = [], edges = [] }) => ({
+        idsByType: { vertices, edges }
+    })
+
+    describe.only('selectionReducer', () => {
+
+        it('should initialize state', () => {
+            reducer(null, {}).should.deep.equal(emptyState)
+        })
+
+        it('should should add selection to empty', () => {
+            var result = reducer(emptyState, {
+                type: 'SELECTION_ADD',
+                payload: { selection: { vertices: ['a'], edges: [] }} 
+            });
+            result.should.deep.equal({
+                idsByType: { vertices: ['a'], edges: [] }
+            })
+
+            result = reducer(emptyState, {
+                type: 'SELECTION_ADD',
+                payload: { selection: { vertices: [], edges: ['b'] }} 
+            });
+            result.should.deep.equal({
+                idsByType: { vertices: [], edges: ['b'] }
+            })
+        })
+        
+        it('should should add selection to existing', () => {
+            const vertices = ['a'], edges = ['b']
+            var result = reducer(genState({ vertices, edges }), {
+                type: 'SELECTION_ADD',
+                payload: { selection: { vertices: ['a2'], edges: ['b2', 'b3'] }} 
+            });
+            result.should.deep.equal({
+                idsByType: { vertices: ['a', 'a2'], edges: ['b', 'b2', 'b3'] }
+            })
+        })
+
+        it('should should remove selection from existing', () => {
+            const vertices = ['a'], edges = ['b', 'b3']
+            var result = reducer(genState({ vertices, edges }), {
+                type: 'SELECTION_REMOVE',
+                payload: { selection: { vertices: ['a'], edges: ['b'] }} 
+            });
+            result.should.deep.equal({
+                idsByType: { vertices: [], edges: ['b3'] }
+            })
+        })
+
+        it('should should clear selection', () => {
+            const vertices = ['a'], edges = ['b', 'b3']
+            var result = reducer(genState({ vertices, edges }), {
+                type: 'SELECTION_CLEAR'
+            });
+            result.should.deep.equal({
+                idsByType: { vertices: [], edges: [] }
+            })
+        })
+
+        it('should should set selection', () => {
+            const vertices = ['a'], edges = ['b', 'b3']
+            var result = reducer(genState({ vertices, edges }), {
+                type: 'SELECTION_SET',
+                payload: { selection: { vertices: ['a1'], edges: ['b1']} }
+            });
+            result.should.deep.equal({
+                idsByType: { vertices: ['a1'], edges: ['b1'] }
+            })
+        })
+
+        it('should should not create new objects if not updating', () => {
+            const edges = [];
+            var result = reducer(genState({ edges }), {
+                type: 'SELECTION_ADD',
+                payload: { selection: { vertices: ['a'], edges: [] }} 
+            });
+            expect(result.idsByType.edges === edges).to.be.true
+
+            result = reducer(genState({ vertices: edges }), {
+                type: 'SELECTION_ADD',
+                payload: { selection: { vertices: [], edges: ['a'] }} 
+            });
+            expect(result.idsByType.vertices === edges).to.be.true
+
+            result = reducer(genState({ vertices: edges, edges }), {
+                type: 'SELECTION_ADD',
+                payload: { selection: { vertices: [], edges: [] }} 
+            });
+            expect(result.idsByType.vertices === edges).to.be.true
+            expect(result.idsByType.edges === edges).to.be.true
+        })
+    })
+});


### PR DESCRIPTION
- [x] @joeferner
- [ ] @diegogrz
- [x] @mwizeman @sfeng88
- [x] @joeybrk372 @rygim @jharwig @EvanOxfeld

Graph selection state could get in unknown state when selection changes are made outside of graph. (It uses a coalescing internal selection state to manage the many selection changes from cytoscape, and wasn't updating itself from outside changes)

Testing Instructions: Select multiple items, from multiple detail pane select a bar that will change the selection. Then try select-all in the graph, and clicking items in the graph. Selection state should work as expected

CHANGELOG
Fixed: Graph selection state could be unstable after changing the selection in the graph, then in external component, then in graph again.

