### PR TITLE
Fix Structured Ingest error handling (3.1)

### DIFF
--- a/web/plugins/structured-ingest/core/src/main/resources/org/visallo/web/structuredingest/core/js/auxillary/geoLocation.js
+++ b/web/plugins/structured-ingest/core/src/main/resources/org/visallo/web/structuredingest/core/js/auxillary/geoLocation.js
@@ -19,20 +19,20 @@ define([
 
         this.after('initialize', function() {
             var self = this,
-                column = this.attr.mapping.column,
+                key = this.attr.mapping.key,
                 hints = this.attr.mapping.hints;
 
             this.$node.html(template({
-                otherColumn: self.attr.allHeaders.map(function(header, i) {
+                otherColumn: self.attr.allHeaders.map(function(header, i, headers) {
                     return {
                         value: i,
                         display: header,
                         selected:
-                            column === hints.columnLatitude ?
-                                hints.columnLongitude === i :
-                            column === hints.columnLongitude ?
-                                hints.columnLatitude === i : false,
-                        disabled: i === column
+                            key === hints.columnLatitude ?
+                                hints.columnLongitude === header :
+                            key === hints.columnLongitude ?
+                                hints.columnLatitude === header : false,
+                        disabled: header === key
                     };
                 }),
                 contains: [
@@ -42,11 +42,11 @@ define([
                 ].map(function(c) {
                     if ('columnLatitude' in hints &&
                         c.value === 'latitude' &&
-                        column === hints.columnLatitude) {
+                        key === hints.columnLatitude) {
                         c.selected = true;
                     } else if ('columnLongitude' in hints &&
                         c.value === 'longitude' &&
-                        column === hints.columnLongitude) {
+                        key === hints.columnLongitude) {
                         c.selected = true;
                     } else if (c.value === 'both') {
                         c.selected = true;
@@ -57,8 +57,8 @@ define([
                     { value: 'DEGREES_MINUTES_SECONDS', display: '0° 0\' 00.0" (degrees, minutes, seconds)' },
                     { value: 'DEGREES_DECIMAL_MINUTES', display: '0° 00.000\'  (degrees, decimal minutes)' },
                     { value: 'DECIMAL', display: '00.000°     (decimal degrees)' }
-                ].map(function(f) {
-                    if (f.value === hints.format) {
+                ].map(function(f, i) {
+                    if (f.value === hints.format || (!hints.format && i === 2)) {
                         f.selected = true;
                     }
                     return f;
@@ -100,13 +100,13 @@ define([
                 format: this.select('formatSelector').val()
             }, function(data) {
                 if (contains === 'latitude') {
-                    data.columnLatitude = self.attr.mapping.column
-                    data.columnLongitude = otherColumnNumber;
+                    data.columnLatitude = self.attr.mapping.key
+                    data.columnLongitude = self.attr.allHeaders[otherColumnNumber];
                     self.$node.find('.otherType').text('Longitude')
                 }
                 if (contains === 'longitude') {
-                    data.columnLatitude = otherColumnNumber;
-                    data.columnLongitude = self.attr.mapping.column
+                    data.columnLatitude = self.attr.allHeaders[otherColumnNumber];
+                    data.columnLongitude = self.attr.mapping.key
                     self.$node.find('.otherType').text('Latitude')
                 }
                 self.select('otherSectionSelector').toggle(contains !== 'both');

--- a/web/plugins/structured-ingest/core/src/main/resources/org/visallo/web/structuredingest/core/js/errorsPopover.js
+++ b/web/plugins/structured-ingest/core/src/main/resources/org/visallo/web/structuredingest/core/js/errorsPopover.js
@@ -23,7 +23,7 @@ define([
         })
 
         this.before('initialize', function(node, config) {
-            config.template = '/com/visallo/structuredFile/templates/error'
+            config.template = '/org/visallo/web/structuredingest/core/templates/error'
             config.hideStrategy = _.some(config.errors.list, function(e) {
                 return e.mappingError === true;
             });
@@ -45,7 +45,7 @@ define([
         this.onChange = function(event) {
             var type = $(event.target).val();
             this.trigger('errorHandlingUpdated', {
-                index: this.attr.index,
+                key: this.attr.key,
                 errorStrategy: type
             });
         }

--- a/web/plugins/structured-ingest/core/src/main/resources/org/visallo/web/structuredingest/core/js/util.js
+++ b/web/plugins/structured-ingest/core/src/main/resources/org/visallo/web/structuredingest/core/js/util.js
@@ -12,12 +12,12 @@ function(withDataRequest) {
 
         CONCEPT_TYPE: 'http://visallo.org#conceptType',
 
-        findPropertiesForColumnInObject: function(object, columnIndex) {
+        findPropertiesForColumnInObject: function(object, key) {
             return _.filter(object.properties, function(p) {
-                if (p.column === columnIndex) return true;
+                if (p.key === key) return true;
                 if (p.hints && (
-                    columnIndex === p.hints.columnLatitude ||
-                    columnIndex === p.hints.columnLongitude)) {
+                    key === p.hints.columnLatitude ||
+                    key === p.hints.columnLongitude)) {
                     return true;
                 }
             });


### PR DESCRIPTION
- [x] @joeferner
- [x] @diegogrz
- [x] @mwizeman @sfeng88
- [x] @joeybrk372 @rygim @jharwig @EvanOxfeld

Testing Instructions: Import csv with invalid geolocations to test the error handling and make sure skip rows works. (Create locations with geolocations)

```
title,longitude,latitude
a,55.583333,25.583333
invalid,41,-83
b,53.21,25.016667
c,54.333333,24.5
d,53.05,24.866667
```

NO CHANGELOG: between release
