### PR TITLE
Restore previous graph fit behavior when all nodes won't fit in minZoom (3.1)

### DIFF
--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/Cytoscape.jsx
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/Cytoscape.jsx
@@ -287,6 +287,8 @@ define([
                             this.setState({ showGraphMenu: event })
                         }
                     })
+                    cy._private.originalMinZoom = cy._private.minZoom;
+                    cy._private.originalMaxZoom = cy._private.maxZoom;
                     this.props.onReady(event)
                 }
             }
@@ -521,8 +523,17 @@ define([
                         (h - (top + bottom)) / bb.h
                     ));
 
-                    if (zoom < cy._private.minZoom) zoom = cy._private.minZoom;
+                    // Set min and max zoom to fit all items
+                    if (zoom < cy._private.minZoom) {
+                        cy._private.minZoom = zoom;
+                        cy._private.maxZoom = 1 / zoom;
+                    } else {
+                        cy._private.minZoom = cy._private.originalMinZoom;
+                        cy._private.maxZoom = cy._private.originalMaxZoom;
+                    }
+
                     if (zoom > cy._private.maxZoom) zoom = cy._private.maxZoom;
+                    
 
                     var position = {
                             x: (w + left - right - zoom * (bb.x1 + bb.x2)) / 2,


### PR DESCRIPTION
- [x] @joeferner
- [x] @diegogrz
- [x] @mwizeman @sfeng88
- [x] @joeybrk372 @rygim @jharwig @EvanOxfeld

Will zoom out as far as needed past minZoom, but will restore the min zoom if the nodes should layout to fit in zoom levels.

Testing Instructions: Zoom out all the way, Place nodes in graph outside of viewport on 4 edges, then fit. All nodes should be visible

CHANGELOG
Fixed: Graph fit will show all nodes even if the zoom is past preset minZoom
