### PR TITLE
Fix searchByProperty from edge properties (3.1)

### DIFF
--- a/web/war/src/main/webapp/js/util/popovers/propertyInfo/propertyInfo.js
+++ b/web/war/src/main/webapp/js/util/popovers/propertyInfo/propertyInfo.js
@@ -361,11 +361,18 @@ define([
         };
 
         this.onSearch = function() {
-            var concept = F.vertex.concept(this.attr.data),
-                data = {
-                    conceptId: concept && concept.id
-                },
-                trim = function(p) {
+            var element = this.attr.data,
+                data = {};
+            if (element.type === 'vertex') {
+                var concept = F.vertex.concept(element);
+                data.conceptId = concept && concept.id;
+            } else if (element.type === 'edge') {
+                data.edgeLabel = element.label
+            } else {
+                throw new Error('Unknown type', this.attr.data)
+            }
+
+            var trim = function(p) {
                     return _.pick(p, 'name', 'value', 'values');
                 };
 


### PR DESCRIPTION
- [x] @joeferner
- [x] @diegogrz
- [x] @mwizeman @sfeng88
- [x] @joeybrk372 @rygim @jharwig @EvanOxfeld

Allow searchByProperty to pass edgeLabel to search edges instead ofvertices

Testing Instructions: Use ontology that has edge properties. Create an edge property and use "i" button to search based on the value. Make sure the search flips to relation searches based on the type of edge. Also ensure that vertex properties flip back to entity search.

Points of Regression: None

CHANGELOG
Fixed: Search by property value works correctly for edge properties

