### PR TITLE
Support unauthorized edge ends on the UI(3.1)

### DIFF
--- a/core/core/src/main/java/org/visallo/core/model/termMention/TermMentionRepository.java
+++ b/core/core/src/main/java/org/visallo/core/model/termMention/TermMentionRepository.java
@@ -650,6 +650,9 @@ public class TermMentionRepository {
     ) {
         Authorizations authorizationsWithTermMentions = getAuthorizations(authorizations);
         Vertex vertex = graph.getVertex(vertexId, authorizationsWithTermMentions);
+
+        if (vertex == null) { return null; }
+
         Iterable<Vertex> termMentions = vertex.getVertices(
                 Direction.IN,
                 VisalloProperties.TERM_MENTION_LABEL_RESOLVED_TO,

--- a/core/core/src/main/resources/MessageBundle.properties
+++ b/core/core/src/main/resources/MessageBundle.properties
@@ -38,6 +38,8 @@ visallo.title=Visallo
 visallo.description=open source big data integration, analytics, and visualization
 visallo.loading-logo.path=/img/visallo-small.png
 
+element.unauthorized=Unauthorized
+
 login.powered_by_visallo=Powered By Visallo
 
 concept.field.placeholder=Choose a Concept...

--- a/web/war/src/main/webapp/js/data/web-worker/store/element/actions-impl.js
+++ b/web/war/src/main/webapp/js/data/web-worker/store/element/actions-impl.js
@@ -60,9 +60,11 @@ define(['../actions', '../../util/ajax'], function(actions, ajax) {
             const addToUpdates = (vertexId, label) => {
                 if (vertices[vertexId]) {
                     const vertex = vertices[vertexId];
-                    const labels = vertex.edgeLabels || [];
-                    if (!labels.includes(label)) {
-                        updates[vertexId] = [...labels, label];
+                    if (vertex) {
+                        const labels = vertex.edgeLabels || [];
+                        if (!labels.includes(label)) {
+                            updates[vertexId] = [...labels, label];
+                        }
                     }
                 }
             };

--- a/web/war/src/main/webapp/js/detail/item/layoutComponents/edge.js
+++ b/web/war/src/main/webapp/js/detail/item/layoutComponents/edge.js
@@ -18,10 +18,10 @@ define([
         outVertexDisplay = _.compose(vertexDisplayId, _.property('outVertexId')),
         inVertexDisplay = _.compose(vertexDisplayId, _.property('inVertexId')),
         outVertexConceptDisplay = function(edge) {
-            return vertexStore(edge.outVertexId).then(conceptDisplay)
+            return vertexStore(edge.outVertexId).then((vertex) => vertex && !_.isArray(vertex) ? conceptDisplay(vertex) : '');
         },
         inVertexConceptDisplay = function(edge) {
-            return vertexStore(edge.inVertexId).then(conceptDisplay)
+            return vertexStore(edge.inVertexId).then((vertex) => vertex && !_.isArray(vertex) ? conceptDisplay(vertex) : '');
         };
 
     return [

--- a/web/war/src/main/webapp/js/util/element/detail-relationship-item.js
+++ b/web/war/src/main/webapp/js/util/element/detail-relationship-item.js
@@ -15,22 +15,23 @@ define([
     function DetailRelationshipItem() {
 
         this.after('initialize', function() {
-            this.vertex = this.attr.item.vertex;
+            const { vertex, relationship } = this.attr.item;
+            const vertexId = vertex && vertex.id;
+            const title = F.vertex.title(vertex);
+            const timeSubtitle = F.vertex.time(vertex);
+            const subtitle = F.vertex.subtitle(vertex);
 
-            var timeSubtitle = F.vertex.time(this.vertex),
-                subtitle = F.vertex.subtitle(this.vertex);
+            this.vertex = vertex;
 
             this.$node
                 .addClass(timeSubtitle ? 'has-timeSubtitle' : '')
                 .addClass(subtitle ? 'has-subtitle' : '')
-                .addClass(this.attr.item.relationship.inVertexId === this.vertex.id ? 'relation-to' : 'relation-from')
-                .html(template({
-                    title: F.vertex.title(this.vertex),
-                    timeSubtitle: timeSubtitle,
-                    subtitle: subtitle
-                }));
+                .addClass(relationship.inVertexId === vertexId ? 'relation-to' : 'relation-from')
+                .html(template({ title, timeSubtitle, subtitle }));
 
-            this.$node.data('vertexId', this.vertex.id);
+            if (vertexId) {
+                this.$node.data('vertexId', vertexId);
+            }
         });
 
         this.before('teardown', function() {

--- a/web/war/src/main/webapp/js/util/element/list.js
+++ b/web/war/src/main/webapp/js/util/element/list.js
@@ -60,9 +60,8 @@ define([
             this.renderers = registry.extensionsForPoint(EXTENSION_POINT_NAME).concat([
                 { canHandle: function(item, usageContext) {
                         return usageContext === 'detail/relationships' &&
-                                item && item.relationship && item.vertex &&
-                                F.vertex.isEdge(item.relationship) &&
-                                F.vertex.isVertex(item.vertex);
+                                item && item.relationship &&
+                                F.vertex.isEdge(item.relationship);
                     }, component: DetailRelationshipItem },
                 { canHandle: function(item) { return F.vertex.isEdge(item); }, component: EdgeItem },
                 { canHandle: function(item) { return F.vertex.isVertex(item); }, component: VertexItem }

--- a/web/war/src/main/webapp/js/util/element/withPreview.js
+++ b/web/war/src/main/webapp/js/util/element/withPreview.js
@@ -30,8 +30,8 @@ define([
                     preview = this.preview = this.$node.find('.preview'),
                     activePreview = this.activePreview = this.$node.find('.active-preview'),
                     vertex = this.vertex,
-                    image = F.vertex.image(vertex, null, 80, 80),
-                    videoPreview = F.vertex.imageFrames(vertex),
+                    image = vertex && F.vertex.image(vertex, null, 80, 80),
+                    videoPreview = vertex && F.vertex.imageFrames(vertex),
                     nonConceptClsName = 'non_concept_preview';
 
                 if (videoPreview) {
@@ -67,15 +67,16 @@ define([
                         activePreview.css('background-image', 'url(' + activeConceptImage + ')')
                     })
                     .done(function() {
-                        if (conceptImage === image) {
-                            self.$node.toggleClass(nonConceptClsName, !F.vertex.imageIsFromConcept(vertex))
+                        let imageIsFromConcept = !vertex || F.vertex.imageIsFromConcept(vertex);
+                        if (!image || conceptImage === image) {
+                            self.$node.toggleClass(nonConceptClsName, !imageIsFromConcept)
                             .removeClass('loading');
                         } else {
                             _.delay(function() {
                                 deferredImage(image).always(function() {
                                     preview.css('background-image', 'url(' + image + ')');
                                     activePreview.css('background-image', 'url(' + image + ')');
-                                    self.$node.toggleClass(nonConceptClsName, !F.vertex.imageIsFromConcept(vertex))
+                                    self.$node.toggleClass(nonConceptClsName, !imageIsFromConcept)
                                     .removeClass('loading');
                                 })
                             }, 500);

--- a/web/war/src/main/webapp/js/util/popovers/propertyInfo/propertyInfo.js
+++ b/web/war/src/main/webapp/js/util/popovers/propertyInfo/propertyInfo.js
@@ -252,9 +252,9 @@ define([
                 }
             } else {
                 this.renderJustification(justification);
-                if (!justificationMetadata || !('justificationText' in justificationMetadata)) {
+                if ((!justificationMetadata || !('justificationText' in justificationMetadata))) {
                     this.dataRequest(
-                        'vertex',
+                        F.vertex.isVertex(element) ? 'vertex' : 'edge',
                         'propertyDetails',
                         this.attr.data.id,
                         property.name,

--- a/web/war/src/main/webapp/test/unit/spec/util/vertex/vertexFormattersTest.js
+++ b/web/war/src/main/webapp/test/unit/spec/util/vertex/vertexFormattersTest.js
@@ -70,7 +70,8 @@ define([
             }
             return {
                 id: id || ('testVertex' + vertexIdent++),
-                properties: properties || []
+                properties: properties || [],
+                type: 'vertex'
             }
         }
 
@@ -883,10 +884,8 @@ define([
                 expect(V.displayType(vertex)).to.equal('entity');
             })
             it('should return \'edge\' if the passed in entity is an edge', function() {
-                var vertex = vertexFactory('v1', [
-                    propertyFactory(PROPERTY_NAME_CONCEPT, 'relationship')
-                ]);
-                expect(V.displayType(vertex)).to.equal('edge');
+                var edge = { id: 'e1', type: 'edge'};
+                expect(V.displayType(edge)).to.equal('edge');
             })
             it('should return \'video\' if the vertex has transcoded mp4 video', function() {
                 var vertex = vertexFactory('v1', [


### PR DESCRIPTION
- [x] @joeferner
- [x] @diegogrz
- [ ] @mwizeman @sfeng88
- [x] @joeybrk372 @rygim @jharwig @EvanOxfeld

Testing Instructions: Everywhere you can interact with edges when one or both vertices are not visible to the user.

CHANGELOG
Fixed: When one or more of a relationship's vertices were not visible to the user, the element inspector would appear blank when trying to inspect that edge.
Changed: When the other end of a relationship is not visible to the user, inspecting the relationships of a vertex will not include that vertex in the list.
