### PR TITLE
Fix Select All in element list(3.1)

### DIFF
--- a/web/war/src/main/webapp/js/util/element/list.js
+++ b/web/war/src/main/webapp/js/util/element/list.js
@@ -127,6 +127,7 @@ define([
         this.onClick = function(event) {
             event.preventDefault();
             event.stopPropagation();
+            this.trigger('focusComponent');
 
             const {vertexIds, edgeIds} = visalloData.selectedObjects;
             const $target = $(event.target).parents('li');


### PR DESCRIPTION
- [x] @joeferner
- [x] @diegogrz
- [x] @mwizeman @sfeng88
- [x] @joeybrk372 @rygim @jharwig @EvanOxfeld

Click event has propagation stopped so dashboard doesn't swallow selection, but still trigger `focusComponent` so keyboard.js can trigger `selectAll` on the list

Points of Regression: Selection/dragging anywhere there is an element list (multi-detail, search popover, search results, saved search cards)

CHANGELOG
Fixed: Select All keyboard shortcut was not working when trying to select lists.
