### PR TITLE
Requery ontology to get parent properties

### DIFF
--- a/core/plugins/model-vertexium/src/main/java/org/visallo/vertexium/model/ontology/VertexiumOntologyRepository.java
+++ b/core/plugins/model-vertexium/src/main/java/org/visallo/vertexium/model/ontology/VertexiumOntologyRepository.java
@@ -468,7 +468,10 @@ public class VertexiumOntologyRepository extends OntologyRepositoryBase {
         if (parentConceptVertex == null) {
             return null;
         }
-        return createConcept(parentConceptVertex);
+
+        Concept parentConcept = createConcept(parentConceptVertex);
+
+        return getConceptByIRI(parentConcept.getIRI());
     }
 
     private List<Concept> toConcepts(Iterable<Vertex> vertices) {

--- a/tools/ontology-ingest/common/src/main/java/org/visallo/tools/ontology/ingest/common/IngestRepository.java
+++ b/tools/ontology-ingest/common/src/main/java/org/visallo/tools/ontology/ingest/common/IngestRepository.java
@@ -270,6 +270,7 @@ public class IngestRepository {
         if (entity.getProperties() == null || !entity.getProperties().contains(property)) {
             if (entity instanceof Concept) {
                 Concept parentConcept = ontologyRepository.getParentConcept((Concept) entity);
+                parentConcept = ontologyRepository.getConceptByIRI(parentConcept.getIRI());
                 if (parentConcept != null) {
                     return isPropertyValidForEntity(parentConcept, property);
                 }

--- a/tools/ontology-ingest/common/src/main/java/org/visallo/tools/ontology/ingest/common/IngestRepository.java
+++ b/tools/ontology-ingest/common/src/main/java/org/visallo/tools/ontology/ingest/common/IngestRepository.java
@@ -270,7 +270,6 @@ public class IngestRepository {
         if (entity.getProperties() == null || !entity.getProperties().contains(property)) {
             if (entity instanceof Concept) {
                 Concept parentConcept = ontologyRepository.getParentConcept((Concept) entity);
-                parentConcept = ontologyRepository.getConceptByIRI(parentConcept.getIRI());
                 if (parentConcept != null) {
                     return isPropertyValidForEntity(parentConcept, property);
                 }


### PR DESCRIPTION
Properties that were created from generated classes were unable to be imported due to errors that the ingest repository threw because it does not pull back parent concept properties. This behavior is different between the VertexiumOntologyRepository and the InMemoryOntologyRepository. This fix can be made in the VertexiumOntologyRepository by querying the getConceptsWithProperties() while trying to pull back the parent concept, but I was split on where I wanted to make the fix.

- [ ] @joeferner
- [ ] @diegogrz
- [ ] @mwizeman @sfeng88
- [ ] @joeybrk372 @rygim @jharwig @EvanOxfeld

Testing Instructions:
(These instructions may not be reasonable to actually test)
 - Generate code for entities of ontology that has two concepts, one parent and one child, with a property on the parent.
 - Ensure that you are using the VertexiumOntologyRepository 
 - Try and ingest the entities using the generated code by setting a property on the child-concept that is in on the parent concept. Use the IngestRepository to save the created data. There will be no validation errors.

Points of Regression:
N/A

CHANGELOG
Fixed: IngestRepository now correctly traverses the concept heirarchy and pulls back the parent concept properties when deciding if an entity should be ingested.
