### PR TITLE
Web: Fix saving user UI preferences (3.1)

### DIFF
--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/popovers/FindPathPopoverContainer.jsx
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/popovers/FindPathPopoverContainer.jsx
@@ -19,7 +19,12 @@ define([
         },
         (dispatch, props) => {
             return {
-                setUserPreferences: (value) => dispatch(userActions.setUserPreference(PREFERENCE_NAME, JSON.stringify(value)))
+                setUserPreferences: (value) => dispatch(
+                    userActions.setUserPreference({
+                      name: PREFERENCE_NAME,
+                      value: JSON.stringify(value)
+                    })
+                )
             }
         }
     )(FindPathPopover);

--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/worker/actions-impl.js
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/worker/actions-impl.js
@@ -38,7 +38,12 @@ define([
                     dispatch(api.setPositions({ productId, updateVertices, snapToGrid: snap }));
                 }
 
-                dispatch(userActions.setUserPreference('snapToGrid', String(snap)));
+                dispatch(
+                  userActions.setUserPreference({
+                      name: 'snapToGrid',
+                      value: String(snap)
+                  })
+                );
             }
         },
 

--- a/web/war/src/main/webapp/js/data/web-worker/services/user.js
+++ b/web/war/src/main/webapp/js/data/web-worker/services/user.js
@@ -19,7 +19,7 @@ define(['../util/ajax', '../store', '../store/user/actions-impl'], function(ajax
         },
 
         preference: function(name, value) {
-            store.getStore().dispatch(userActions.putUserPreference(name, value))
+            store.getStore().dispatch(userActions.putUserPreference({ name, value }))
             return ajax('POST', '/user/ui-preferences', {
                 name: name,
                 value: value

--- a/web/war/src/main/webapp/js/data/web-worker/store/user/actions-impl.js
+++ b/web/war/src/main/webapp/js/data/web-worker/store/user/actions-impl.js
@@ -1,4 +1,4 @@
-define(['../actions', '../../util/ajax'], function(actions, ajax) {
+define(['../actions', 'data/web-worker/util/ajax'], function(actions, ajax) {
     actions.protectFromMain();
 
     const api = {
@@ -12,13 +12,13 @@ define(['../actions', '../../util/ajax'], function(actions, ajax) {
             payload: { preferences }
         }),
 
-        putUserPreference: (name, value) => ({
+        putUserPreference: ({ name, value }) => ({
             type: 'USER_PUT_PREF',
             payload: { name, value }
         }),
 
         setUserPreference: ({ name, value }) => (dispatch, getState) => {
-            dispatch(api.putUserPreference(name, value));
+            dispatch(api.putUserPreference({ name, value }));
             return ajax('POST', '/user/ui-preferences', { name, value });
         }
 

--- a/web/war/src/main/webapp/js/data/web-worker/store/user/actions.js
+++ b/web/war/src/main/webapp/js/data/web-worker/store/user/actions.js
@@ -4,9 +4,9 @@ define(['../actions'], function(actions) {
     return actions.createActions({
         workerImpl: 'data/web-worker/store/user/actions-impl',
         actions: {
-            putUser: (user) => ({ user }),
-            putUserPreferences: (preferences) => ({ preferences }),
-            setUserPreference: (name, value) => ({ name, value })
+            putUser: ({ user }) => ({ user }),
+            putUserPreferences: ({ preferences }) => ({ preferences }),
+            setUserPreference: ({ name, value }) => ({ name, value })
         }
     })
 })

--- a/web/war/src/main/webapp/js/data/withCurrentUser.js
+++ b/web/war/src/main/webapp/js/data/withCurrentUser.js
@@ -33,15 +33,16 @@ define(['data/web-worker/store/user/actions'], function(userActions) {
                 var user = request.result;
 
                 this.setPublicApi('currentUser', user, { onlyIfNull: true });
-                visalloData.storePromise.then(store => store.dispatch(userActions.putUser(user)));
+                visalloData.storePromise.then(store => store.dispatch(userActions.putUser({ user })));
 
                 if (user.currentWorkspaceId) {
                     this.setPublicApi('currentWorkspaceId', user.currentWorkspaceId, { onlyIfNull: true });
                 }
             } else if (isUserPreferencesUpdate(request)) {
-                visalloData.currentUser.uiPreferences = request.result.uiPreferences;
+                const { uiPreferences: preferences } = request.result;
+                visalloData.currentUser.uiPreferences = preferences;
                 this.setPublicApi('currentUser', visalloData.currentUser);
-                visalloData.storePromise.then(store => store.dispatch(userActions.putUserPreferences(request.result.uiPreferences)));
+                visalloData.storePromise.then(store => store.dispatch(userActions.putUserPreferences({ preferences })));
             }
 
             return dataRequestCompleted.call(this, request);

--- a/web/war/src/main/webapp/test/unit/spec/data/web-worker/store/user/actionsImplTest.js
+++ b/web/war/src/main/webapp/test/unit/spec/data/web-worker/store/user/actionsImplTest.js
@@ -1,0 +1,97 @@
+define([
+    '/base/jsc/data/web-worker/store/user/actions-impl.js',
+    'data/web-worker/util/ajax'
+], function(userActions, ajax) {
+
+    describe('userActions', () => {
+        it('should create an action to put a user', () => {
+            const user = {
+                id: '1',
+                userName: 'Test User'
+            };
+            const expectedAction = {
+                type: 'USER_PUT',
+                payload: {
+                    user
+                }
+            };
+
+            userActions.putUser({ user }).should.deep.equal(expectedAction);
+        });
+
+        it('should create an action to put user preferences', () => {
+            const preferences = {
+                TestPref: 'test value'
+            };
+            const expectedAction = {
+                type: 'USER_PUT_PREFS',
+                payload: {
+                    preferences
+                }
+            };
+
+            userActions.putUserPreferences({ preferences })
+                    .should.deep.equal(expectedAction);
+        });
+
+        it('should create an action to put a single user preference', () => {
+            const name = 'TestPref';
+            const value = 'test value';
+            const expectedAction = {
+                type: 'USER_PUT_PREF',
+                payload: {
+                    name,
+                    value
+                }
+            };
+
+            userActions.putUserPreference({ name, value })
+                    .should.deep.equal(expectedAction);
+        });
+
+
+        it('should create USER_PUT_PREF and POST to /user/ui-preferences', () => {
+            const dispatch = sinon.spy();
+            const createFakeStore = (fakeData) => ({
+                dispatch,
+                getState() {
+                    return fakeData;
+                }
+            });
+            const dispatchWithStoreOf = (storeData, action) => {
+                let dispatched;
+                const dispatch = createFakeStore(storeData)(actionAttempt => {
+                    dispatched = actionAttempt;
+                });
+                dispatch(action);
+                return dispatched;
+            };
+
+            const name = 'TestPref';
+            const value = 'test value';
+            const expectedAction = {
+                type: 'USER_PUT_PREF',
+                payload: {
+                    name,
+                    value
+                }
+            };
+
+            userActions.setUserPreference(
+                {
+                    name,
+                    value
+                }
+            )(dispatch);
+            expect(dispatch).to.have.been.calledWith(expectedAction);
+            expect(ajax).to.have.been.calledWith(
+                'POST',
+                '/user/ui-preferences',
+                {
+                    name,
+                    value
+                }
+            );
+        });
+    });
+});


### PR DESCRIPTION
Resolves issues saving snap to grid and find path settings. Will cherry-pick to master when approved.

- [x] @joeferner
- [x] @diegogrz
- [x] @mwizeman @sfeng88
- [x] @joeybrk372 @rygim @jharwig @EvanOxfeld

Testing Instructions: Confirm snap to grid and most recent find path settings are stored and reused in the current user session and across user sessions.

Points of Regression:

CHANGELOG
Fixed: Saving snap to grid and find path settings
