### PR TITLE
Web: Snap to grid graph position fixes

### DIFF
--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/__mocks__/data/web-worker/store/actions.js
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/__mocks__/data/web-worker/store/actions.js
@@ -1,0 +1,2 @@
+export default {
+}

--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/__mocks__/data/web-worker/store/element/actions-impl.js
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/__mocks__/data/web-worker/store/element/actions-impl.js
@@ -1,0 +1,2 @@
+export default {
+}

--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/__mocks__/data/web-worker/store/product/actions-impl.js
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/__mocks__/data/web-worker/store/product/actions-impl.js
@@ -1,0 +1,2 @@
+export default {
+}

--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/__mocks__/data/web-worker/store/product/selectors.js
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/__mocks__/data/web-worker/store/product/selectors.js
@@ -1,0 +1,2 @@
+export default {
+}

--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/__mocks__/data/web-worker/store/selection/actions-impl.js
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/__mocks__/data/web-worker/store/selection/actions-impl.js
@@ -1,0 +1,2 @@
+export default {
+}

--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/__mocks__/data/web-worker/store/user/actions-impl.js
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/__mocks__/data/web-worker/store/user/actions-impl.js
@@ -1,0 +1,2 @@
+export default {
+}

--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/__mocks__/data/web-worker/util/ajax.js
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/__mocks__/data/web-worker/util/ajax.js
@@ -1,0 +1,2 @@
+export default {
+}

--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/__tests__/worker/actionsImplTest.js
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/__tests__/worker/actionsImplTest.js
@@ -1,0 +1,309 @@
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import actions from '../../worker/actions-impl';
+
+jest.mock('data/web-worker/store/actions', () => ({
+    protectFromMain: jest.fn()
+}));
+jest.mock('data/web-worker/util/ajax', () => () =>
+    Promise.resolve({
+        extendedData: {
+            edges: []
+        }
+    }));
+jest.mock('data/web-worker/store/product/actions-impl', () => ({
+    update: jest.fn(() => ({ type: 'MOCK_PRODUCT_UPDATE' }))
+}));
+jest.mock('data/web-worker/store/element/actions-impl', () => ({
+    get: jest.fn(() => ({ type: 'MOCK_ELEMENT_GET' }))
+}));
+
+const middlewares = [ thunk ];
+const mockStore = configureMockStore(middlewares);
+
+describe('graph plugin actions', () => {
+    describe('PRODUCT_GRAPH_SET_POSITIONS', () => {
+        it('should not dispatch if the workspace is read only', () => {
+            const store = mockStore({
+                workspace: {
+                    currentId: 'WORKSPACE1',
+                    byId: {
+                        WORKSPACE1: {
+                            editable: false
+                        }
+                    }
+                },
+                product: {
+                    workspaces: {
+                        WORKSPACE1: {
+                            products: {
+                                PRODUCT1: {}
+                            }
+                        }
+                    }
+                }
+            });
+            expect(
+               store.dispatch(
+                actions.setPositions({
+                    productId: 'PRODUCT1'
+                })
+               )
+            ).toBeUndefined();
+        });
+
+        it('should dispatch PRODUCT_GRAPH_SET_POSITIONS on an existing vertex', () => {
+            const expectedActions = [
+                {
+                    type: 'PRODUCT_GRAPH_SET_POSITIONS',
+                    payload: {
+                        productId: 'PRODUCT1',
+                        workspaceId: 'WORKSPACE1',
+                        updateVertices: {
+                            VERTEX1: { x: 5, y: 10 }
+                        }
+                    }
+                }
+            ];
+            const store = mockStore({
+                workspace: {
+                    currentId: 'WORKSPACE1',
+                    byId: {
+                        WORKSPACE1: {
+                            editable: true
+                        }
+                    }
+                },
+                product: {
+                    workspaces: {
+                        WORKSPACE1: {
+                            products: {
+                                PRODUCT1: {
+                                    extendedData: {
+                                        vertices: {
+                                            0: {
+                                                id: 'VERTEX1',
+                                                pos: {
+                                                    x: 0,
+                                                    y: 0
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            });
+
+            return store.dispatch(
+                actions.setPositions({
+                    productId: 'PRODUCT1',
+                    updateVertices: {
+                        VERTEX1: {
+                            x: 4.5,
+                            y: 10.1
+                        }
+                    }
+                })
+            ).then(() => {
+                expect(store.getActions()).toEqual(expectedActions);
+            });
+        });
+
+        it('should dispatch PRODUCT_GRAPH_SET_POSITIONS on a new vertex',  () => {
+            const expectedActions = [
+                {
+                    type: 'PRODUCT_GRAPH_SET_POSITIONS',
+                    payload: {
+                        productId: 'PRODUCT1',
+                        workspaceId: 'WORKSPACE1',
+                        updateVertices: {
+                            VERTEX1: { x: 5, y: 10 }
+                        }
+                    }
+                },
+                {
+                    type: 'MOCK_PRODUCT_UPDATE'
+                },
+                {
+                    type: 'MOCK_ELEMENT_GET'
+                }
+            ];
+            const store = mockStore({
+                workspace: {
+                    currentId: 'WORKSPACE1',
+                    byId: {
+                        WORKSPACE1: {
+                            editable: true
+                        }
+                    }
+                },
+                product: {
+                    workspaces: {
+                        WORKSPACE1: {
+                            products: {
+                                PRODUCT1: {
+                                    extendedData: { }
+                                }
+                            }
+                        }
+                    }
+                }
+            });
+
+            return store.dispatch(
+                actions.setPositions({
+                    productId: 'PRODUCT1',
+                    updateVertices: {
+                        VERTEX1: {
+                            x: 4.5,
+                            y: 10.1
+                        }
+                    }
+                })
+            ).then(() => {
+                expect(store.getActions()).toEqual(expectedActions);
+            });
+        });
+
+        it('should dispatch PRODUCT_GRAPH_SET_POSITIONS twice when snap to grid is enabled', () => {
+            const expectedActions = [
+                {
+                    type: 'PRODUCT_GRAPH_SET_POSITIONS',
+                    payload: {
+                        productId: 'PRODUCT1',
+                        workspaceId: 'WORKSPACE1',
+                        updateVertices: {
+                            VERTEX1: { x: 5, y: 10 }
+                        }
+                    }
+                },
+                {
+                    type: 'PRODUCT_GRAPH_SET_POSITIONS',
+                    payload: {
+                        productId: 'PRODUCT1',
+                        workspaceId: 'WORKSPACE1',
+                        updateVertices: {
+                            VERTEX1: { x: 0, y: -12.5 }
+                        }
+                    }
+                }
+            ];
+            const store = mockStore({
+                workspace: {
+                    currentId: 'WORKSPACE1',
+                    byId: {
+                        WORKSPACE1: {
+                            editable: true
+                        }
+                    }
+                },
+                product: {
+                    workspaces: {
+                        WORKSPACE1: {
+                            products: {
+                                PRODUCT1: {
+                                    extendedData: {
+                                        vertices: {
+                                            0: {
+                                                id: 'VERTEX1',
+                                                pos: {
+                                                    x: 0,
+                                                    y: 0
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            });
+
+            return store.dispatch(
+                actions.setPositions({
+                    productId: 'PRODUCT1',
+                    updateVertices: {
+                        VERTEX1: {
+                            x: 4.5,
+                            y: 10.1
+                        }
+                    },
+                    snapToGrid: true
+                })
+            ).then(() => {
+                expect(store.getActions()).toEqual(expectedActions);
+            });
+        });
+
+        it('should dispatch PRODUCT_GRAPH_SET_POSITIONS twice on a new vertex when snap to grid is enabled',  () => {
+            const expectedActions = [
+                {
+                    type: 'PRODUCT_GRAPH_SET_POSITIONS',
+                    payload: {
+                        productId: 'PRODUCT1',
+                        workspaceId: 'WORKSPACE1',
+                        updateVertices: {
+                            VERTEX1: { x: 5, y: 10 }
+                        }
+                    }
+                },
+                {
+                    type: 'PRODUCT_GRAPH_SET_POSITIONS',
+                    payload: {
+                        productId: 'PRODUCT1',
+                        workspaceId: 'WORKSPACE1',
+                        updateVertices: {
+                            VERTEX1: { x: 0, y: -12.5 }
+                        }
+                    }
+                },
+                {
+                    type: 'MOCK_PRODUCT_UPDATE'
+                },
+                {
+                    type: 'MOCK_ELEMENT_GET'
+                }
+            ];
+            const store = mockStore({
+                workspace: {
+                    currentId: 'WORKSPACE1',
+                    byId: {
+                        WORKSPACE1: {
+                            editable: true
+                        }
+                    }
+                },
+                product: {
+                    workspaces: {
+                        WORKSPACE1: {
+                            products: {
+                                PRODUCT1: {
+                                    extendedData: { }
+                                }
+                            }
+                        }
+                    }
+                }
+            });
+
+            return store.dispatch(
+                actions.setPositions({
+                    productId: 'PRODUCT1',
+                    updateVertices: {
+                        VERTEX1: {
+                            x: 4.5,
+                            y: 10.1
+                        }
+                    },
+                    snapToGrid: true
+                })
+            ).then(() => {
+                expect(store.getActions()).toEqual(expectedActions);
+            });
+        });
+    });
+});

--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/package.json
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/package.json
@@ -31,6 +31,9 @@
     "react-addons-test-utils": "15.4.2",
     "react-dom": "15.4.2",
     "react-test-renderer": "15.4.2",
+    "redux": "^3.6.0",
+    "redux-mock-store": "^1.2.2",
+    "redux-thunk": "^2.2.0",
     "underscore": "1.8.3",
     "webpack": "^1.14.0"
   },
@@ -38,6 +41,13 @@
     "moduleNameMapper": {
       "components/NavigationControls": "<rootDir>/__mocks__/components/NavigationControls.jsx",
       "components/RegistryInjectorHOC": "<rootDir>/__mocks__/components/RegistryInjectorHOC.jsx",
+      "data/web-worker/store/actions": "<rootDir>/__mocks__/data/web-worker/store/actions.js",
+      "data/web-worker/store/element/actions-impl": "<rootDir>/__mocks__/data/web-worker/store/element/actions-impl.js",
+      "data/web-worker/store/product/actions-impl": "<rootDir>/__mocks__/data/web-worker/store/product/actions-impl.js",
+      "data/web-worker/store/product/selectors": "<rootDir>/__mocks__/data/web-worker/store/product/selectors.js",
+      "data/web-worker/store/selection/actions-impl": "<rootDir>/__mocks__/data/web-worker/store/selection/actions-impl.js",
+      "data/web-worker/store/user/actions-impl": "<rootDir>/__mocks__/data/web-worker/store/user/actions-impl.js",
+      "data/web-worker/util/ajax": "<rootDir>/__mocks__/data/web-worker/util/ajax.js",
       "util/retina": "<rootDir>/__mocks__/util/retina.js",
       "util/vertex/formatters": "<rootDir>/__mocks__/util/vertexFormatters.js",
       "util/withContextMenu": "<rootDir>/__mocks__/util/withContextMenu.js",

--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/worker/plugin.js
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/worker/plugin.js
@@ -1,8 +1,7 @@
 define([
     'configuration/plugins/registry',
-    'updeep',
-    './snap',
-], function(registry, u, snapPosition) {
+    'updeep'
+], function(registry, u) {
 
     registry.registerExtension('org.visallo.store', {
         key: 'product',
@@ -53,7 +52,7 @@ define([
         return state;
     }
 
-    function updatePositions(state, { workspaceId, productId, updateVertices, snapToGrid }) {
+    function updatePositions(state, { workspaceId, productId, updateVertices }) {
         const product = state.workspaces[workspaceId].products[productId];
 
         if (product && product.extendedData && product.extendedData.vertices) {
@@ -66,7 +65,7 @@ define([
                         updatedIds.push([vertexPosition.id]);
                         return {
                             id: vertexPosition.id,
-                            pos: snapToGrid ? snapPosition(pos) : pos
+                            pos
                         }
                     }
                     return vertexPosition;

--- a/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/yarn.lock
+++ b/web/plugins/graph-product/src/main/resources/org/visallo/web/product/graph/yarn.lock
@@ -1939,6 +1939,10 @@ loader-utils@^0.2.11:
     json5 "^0.5.0"
     object-assign "^4.0.1"
 
+lodash-es@^4.2.1:
+  version "4.17.4"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.4.tgz#dcc1d7552e150a0640073ba9cb31d70f032950e7"
+
 lodash._arraycopy@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz#76e7b7c1f1fb92547374878a562ed06a3e50f6e1"
@@ -2008,7 +2012,7 @@ lodash.keys@^3.0.0:
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
 
-lodash@^4.14.0, lodash@^4.2.0:
+lodash@^4.14.0, lodash@^4.2.0, lodash@^4.2.1:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -2524,6 +2528,23 @@ redeyed@~1.0.0:
   dependencies:
     esprima "~3.0.0"
 
+redux-mock-store@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/redux-mock-store/-/redux-mock-store-1.2.2.tgz#38007dc38f12ca8d965c7521afee5ccacc234d03"
+
+redux-thunk@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.2.0.tgz#e615a16e16b47a19a515766133d1e3e99b7852e5"
+
+redux@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-3.6.0.tgz#887c2b3d0b9bd86eca2be70571c27654c19e188d"
+  dependencies:
+    lodash "^4.2.1"
+    lodash-es "^4.2.1"
+    loose-envify "^1.1.0"
+    symbol-observable "^1.0.2"
+
 regenerate@^1.2.1:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.3.2.tgz#d1941c67bad437e1be76433add5b385f95b19260"
@@ -2802,6 +2823,10 @@ supports-color@^3.1.0, supports-color@^3.1.2:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
   dependencies:
     has-flag "^1.0.0"
+
+symbol-observable@^1.0.2:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
 
 "symbol-tree@>= 3.1.0 < 4.0.0":
   version "3.2.1"


### PR DESCRIPTION
- [x] @joeferner
- [x] @diegogrz
- [x] @mwizeman @sfeng88
- [x] @joeybrk372 @rygim @jharwig @EvanOxfeld

Fixes issues dropping an element onto the graph when snap to grid is enabled and elements snapping back to the current position if not moved to a new position on the grid.

Moves position change logic when snap to grid is on out of the reducer and into the action creator function to prevent side effects.

Will cherry-pick to master when approved.

Testing Instructions: Verify moving entities on the graph with and without snap to grid enabled. Verify that when snap to grid is enabled, small entities movements cause the entity to snap back to its original position. Verify that elements can be added to the graph with and without snap to grid enabled.

Points of Regression: None known

CHANGELOG
Fixed: Entities can be added and moved when snap to grid is enabled.
