### PR TITLE
Remove Jetty from root POM

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -14,3 +14,5 @@ Run the web application.
 
       mvn -am -pl dev/tomcat-server -P dev-tomcat-run compile
 
+Once the log output stops, your server will be available at [http://localhost:8888](http://localhost:8888).
+

--- a/docs/getting-started/running.md
+++ b/docs/getting-started/running.md
@@ -7,3 +7,5 @@ The steps below describe the quickest method for getting Visallo up and running 
 The following Maven command will run the web application. You may prefer to [run the web server using IntelliJ](../ide-setup/intellij.md) if you're doing active development. This command will also initialize the out-of-box embedded database.
 
     mvn -am -pl dev/tomcat-server -P dev-tomcat-run compile
+
+Once the log output stops, your server will be available at [http://localhost:8888](http://localhost:8888).

--- a/root/pom.xml
+++ b/root/pom.xml
@@ -72,8 +72,6 @@
         <inflector.version>0.7.0</inflector.version>
         <jackson.version>2.6.6</jackson.version>
         <jackson-mapper-asl.version>1.9.13</jackson-mapper-asl.version>
-        <jetty.version>9.2.9.v20150224</jetty.version>
-        <jetty.javaee.version>3.0.0.v201112011016</jetty.javaee.version>
         <javax.servlet.api.version>3.1.0</javax.servlet.api.version>
         <json.version>20131018</json.version>
         <lesscss.version>1.3.3</lesscss.version>
@@ -127,7 +125,6 @@
         <plugin.doxia.markdown.version>1.5</plugin.doxia.markdown.version>
         <plugin.findbugs.version>2.5.3</plugin.findbugs.version>
         <plugin.findbugs.findsecbugs.version>1.1.0</plugin.findbugs.findsecbugs.version>
-        <plugin.jetty.version>${jetty.version}</plugin.jetty.version>
         <plugin.maven.assembly.version>2.5.3</plugin.maven.assembly.version>
         <plugin.maven.clean.version>2.5</plugin.maven.clean.version>
         <plugin.maven.compiler.version>3.1</plugin.maven.compiler.version>
@@ -540,11 +537,6 @@
                 <version>${simple-orm.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.v5analytics.simpleorm</groupId>
-                <artifactId>simple-orm-jetty-session-manager</artifactId>
-                <version>${simple-orm.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>com.h2database</groupId>
                 <artifactId>h2</artifactId>
                 <version>${h2.version}</version>
@@ -660,51 +652,6 @@
 
 
             <!-- Provided Dependencies -->
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-server</artifactId>
-                <version>${jetty.version}</version>
-                <scope>compile</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-servlet</artifactId>
-                <version>${jetty.version}</version>
-                <scope>compile</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-servlets</artifactId>
-                <version>${jetty.version}</version>
-                <scope>compile</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-webapp</artifactId>
-                <version>${jetty.version}</version>
-                <scope>compile</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-nosql</artifactId>
-                <version>${jetty.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.eclipse.jetty</groupId>
-                        <artifactId>jetty-server</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.mongodb</groupId>
-                        <artifactId>mongo-java-driver</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty.websocket</groupId>
-                <artifactId>websocket-server</artifactId>
-                <version>${jetty.version}</version>
-                <scope>compile</scope>
-            </dependency>
             <dependency>
                 <groupId>javax.servlet</groupId>
                 <artifactId>javax.servlet-api</artifactId>
@@ -978,21 +925,10 @@
                                 <exclude>log4j:log4j</exclude>
                                 <exclude>org.apache.httpcomponents:httpclient</exclude>
                                 <exclude>org.apache.httpcomponents:httpcore</exclude>
-                                <exclude>org.eclipse.jetty:jetty-server</exclude>
-                                <exclude>org.eclipse.jetty:jetty-http</exclude>
-                                <exclude>org.eclipse.jetty:jetty-io</exclude>
-                                <exclude>org.eclipse.jetty:jetty-servlet</exclude>
-                                <exclude>org.eclipse.jetty:jetty-security</exclude>
-                                <exclude>org.eclipse.jetty:jetty-servlets</exclude>
-                                <exclude>org.eclipse.jetty:jetty-continuation</exclude>
-                                <exclude>org.eclipse.jetty:jetty-util</exclude>
-                                <exclude>org.eclipse.jetty:jetty-webapp</exclude>
-                                <exclude>org.eclipse.jetty:jetty-xml</exclude>
-                                <exclude>org.eclipse.jetty.websocket:websocket-server</exclude>
-                                <exclude>org.eclipse.jetty.websocket:websocket-common</exclude>
-                                <exclude>org.eclipse.jetty.websocket:websocket-api</exclude>
-                                <exclude>org.eclipse.jetty.websocket:websocket-client</exclude>
-                                <exclude>org.eclipse.jetty.websocket:websocket-servlet</exclude>
+                                <exclude>org.apache.tomcat.embed:tomcat-embed-core</exclude>
+                                <exclude>org.apache.tomcat.embed:tomcat-embed-jasper</exclude>
+                                <exclude>org.apache.tomcat.embed:tomcat-embed-el</exclude>
+                                <exclude>org.apache.tomcat.embed:tomcat-embed-websocket</exclude>
                             </excludes>
                         </artifactSet>
                     </configuration>


### PR DESCRIPTION
The properties and dependency management stuff related to Jetty wasn't being used anywhere. I missed removing it earlier in the transition from Jetty to Tomcat.

- [x] @joeferner
- [x] @diegogrz
- [x] @mwizeman @sfeng88
- [x] @joeybrk372 @rygim @jharwig @EvanOxfeld

Testing Instructions:
None. The properties and dependency management stuff related to Jetty wasn't being used anywhere.